### PR TITLE
Nix-based Docker image generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ With Docker image:
 1. docker build -t pg_doorman -f Dockerfile .
 2. docker run -p 6432:6432 -v /path/to/pg_doorman.toml:/etc/pg_doorman/pg_doorman.toml --rm -t -i pg_doorman
 
+With nix-generated Docker image:
+
+1. nix build .#dockerImage
+2. docker load -i result
+3. docker run -p 6432:6432 -v /path/to/pg_doorman.toml:/etc/pg_doorman/pg_doorman.toml --rm -t -i pg_doorman
+
 With docker compose:
 
 1. cd example && docker compose up

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,17 @@
                 rust-jemalloc-sys
               ];
             };
+          dockerImage =
+            let
+              rev = inputs.self.sourceInfo.shortRev or "dirty";
+              tag = "${(pg_doorman rust).version}-${rev}";
+            in
+            pkgs.dockerTools.buildLayeredImage {
+              inherit tag;
+              name = "pg_doorman";
+              contents = [ (pg_doorman rust) ];
+              created = "now";
+            };
           mkShell =
             rust: extra-packages:
             pkgs.mkShell {
@@ -62,7 +73,7 @@
           };
           formatter = pkgs.nixfmt-rfc-style;
           packages = {
-            inherit pg_doorman rust;
+            inherit pg_doorman dockerImage rust;
             default = pg_doorman rust;
           };
           devShells = {


### PR DESCRIPTION
## Description

I added docker image generation using nix, this allows you to get really lightweight images with an isolated environment.

```
$ docker images
pg_doorman          1.8.2-f30b54e   dea6e5b73292   28 seconds ago   62MB
```

## Questions

I can extend the CI/CD so that the generated image is uploaded as a GitHub artifacts. Is this required?