### PR TITLE
fix 'double' response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "pg_doorman"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "1.8.2"
+version = "1.8.3"
 edition = "2021"
 rust-version = "1.86.0"
 license = "MIT"

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -6,6 +6,10 @@ title: Changelog
 
 ## PgDoorman
 
+### 1.8.3 <small>Jun 11, 2025</small> { id="1.8.3" }
+
+- Fixed critical bug: if a free connection was not available on the Server in pool (query_wait_timeout), the Client's buffer was not cleared, leading to an incorrect response error #38.
+
 ### 1.8.2 <small>May 24, 2025</small> { id="1.8.2" }
 
 - Added `application_name` parameter in pool #30.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -56,7 +56,8 @@ where
                     stream,
                     "Unsupported query against the admin database",
                     "58000",
-                ).await
+                )
+                .await
             } else {
                 match query_parts[1].to_ascii_uppercase().as_str() {
                     "HELP" => show_help(stream).await,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1087,7 +1087,7 @@ where
                         }}",
                                 self.pool_name, self.username, err
                             );
-                            return Err(Error::ProtocolSyncError(err.to_string()));
+                            return Err(Error::AllServersDown);
                         }
                     };
                 };

--- a/src/client.rs
+++ b/src/client.rs
@@ -782,10 +782,23 @@ where
 
         // Update the parameters to merge what the application sent and what's originally on the server
         server_parameters.set_from_hashmap(parameters.clone(), false);
-        auth_ok(&mut write).await?;
-        write_all(&mut write, (&server_parameters).into()).await?;
-        backend_key_data(&mut write, process_id, secret_key).await?;
-        send_ready_for_query(&mut write).await?;
+        let mut buf = BytesMut::new();
+        {
+            let mut auth_ok = BytesMut::with_capacity(9);
+            auth_ok.put_u8(b'R');
+            auth_ok.put_i32(8);
+            auth_ok.put_i32(0);
+            buf.put(auth_ok);
+            let server_params_buf: BytesMut = (&server_parameters).into();
+            buf.put(server_params_buf);
+            let mut key_data = BytesMut::from(&b"K"[..]);
+            key_data.put_i32(12);
+            key_data.put_i32(process_id);
+            key_data.put_i32(secret_key);
+            buf.put(key_data);
+            buf.put(ready_for_query(false));
+        }
+        write_all_flush(&mut write, &buf).await?;
 
         let stats = Arc::new(ClientStats::new(
             process_id,
@@ -1074,7 +1087,7 @@ where
                         }}",
                                 self.pool_name, self.username, err
                             );
-                            continue;
+                            return Err(Error::ProtocolSyncError(err.to_string()));
                         }
                     };
                 };

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -60,17 +60,14 @@ impl From<&DataType> for i32 {
 }
 
 /// Tell the client that authentication handshake completed successfully.
-pub async fn auth_ok<S>(stream: &mut S) -> Result<(), Error>
-where
-    S: tokio::io::AsyncWrite + std::marker::Unpin,
-{
+pub fn auth_ok() -> BytesMut {
     let mut auth_ok = BytesMut::with_capacity(9);
 
     auth_ok.put_u8(b'R');
     auth_ok.put_i32(8);
     auth_ok.put_i32(0);
 
-    write_all(stream, auth_ok).await
+    auth_ok
 }
 
 /// Generate md5 password challenge.
@@ -169,20 +166,13 @@ where
 
 /// Give the client the process_id and secret we generated
 /// used in query cancellation.
-pub async fn backend_key_data<S>(
-    stream: &mut S,
-    backend_id: i32,
-    secret_key: i32,
-) -> Result<(), Error>
-where
-    S: tokio::io::AsyncWrite + std::marker::Unpin,
-{
+pub fn backend_key_data<S>(backend_id: i32, secret_key: i32) -> BytesMut {
     let mut key_data = BytesMut::from(&b"K"[..]);
     key_data.put_i32(12);
     key_data.put_i32(backend_id);
     key_data.put_i32(secret_key);
 
-    write_all(stream, key_data).await
+    key_data
 }
 
 /// Construct a `Q`: Query message.
@@ -194,14 +184,6 @@ pub fn simple_query(query: &str) -> BytesMut {
     res.put_slice(query.as_bytes());
 
     res
-}
-
-/// Tell the client we're ready for another query.
-pub async fn send_ready_for_query<S>(stream: &mut S) -> Result<(), Error>
-where
-    S: tokio::io::AsyncWrite + std::marker::Unpin,
-{
-    write_all(stream, ready_for_query(false)).await
 }
 
 /// Send the startup packet the server. We're pretending we're a Pg client.
@@ -383,32 +365,13 @@ where
     write_all(stream, message).await
 }
 
-/// Implements a response to our custom `SET ...`
-/// This tells the client we're ready for the next query.
-pub async fn custom_protocol_response_ok<S>(stream: &mut S, message: &str) -> Result<(), Error>
-where
-    S: tokio::io::AsyncWrite + std::marker::Unpin,
-{
-    let mut res = BytesMut::with_capacity(25);
-
-    let set_complete = BytesMut::from(&format!("{}\0", message)[..]);
-    let len = (set_complete.len() + 4) as i32;
-
-    // CommandComplete
-    res.put_u8(b'C');
-    res.put_i32(len);
-    res.put_slice(&set_complete[..]);
-
-    write_all_half(stream, &res).await?;
-    send_ready_for_query(stream).await
-}
-
 pub async fn error_response<S>(stream: &mut S, message: &str, code: &str) -> Result<(), Error>
 where
     S: tokio::io::AsyncWrite + std::marker::Unpin,
 {
-    error_response_terminal(stream, message, code).await?;
-    send_ready_for_query(stream).await
+    let mut buf = error_message(message, code);
+    buf.put(ready_for_query(false));
+    write_all_flush(stream, &buf).await
 }
 
 pub fn error_message(message: &str, code: &str) -> BytesMut {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -59,17 +59,6 @@ impl From<&DataType> for i32 {
     }
 }
 
-/// Tell the client that authentication handshake completed successfully.
-pub fn auth_ok() -> BytesMut {
-    let mut auth_ok = BytesMut::with_capacity(9);
-
-    auth_ok.put_u8(b'R');
-    auth_ok.put_i32(8);
-    auth_ok.put_i32(0);
-
-    auth_ok
-}
-
 /// Generate md5 password challenge.
 pub async fn md5_challenge<S>(stream: &mut S) -> Result<[u8; 4], Error>
 where
@@ -164,16 +153,6 @@ where
     Ok(password_response)
 }
 
-/// Give the client the process_id and secret we generated
-/// used in query cancellation.
-pub fn backend_key_data<S>(backend_id: i32, secret_key: i32) -> BytesMut {
-    let mut key_data = BytesMut::from(&b"K"[..]);
-    key_data.put_i32(12);
-    key_data.put_i32(backend_id);
-    key_data.put_i32(secret_key);
-
-    key_data
-}
 
 /// Construct a `Q`: Query message.
 pub fn simple_query(query: &str) -> BytesMut {

--- a/src/server.rs
+++ b/src/server.rs
@@ -848,6 +848,7 @@ impl Server {
             }
             self.cleanup_state.reset();
         }
+        self.small_simple_query(";").await?;
         Ok(())
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -848,7 +848,6 @@ impl Server {
             }
             self.cleanup_state.reset();
         }
-        self.small_simple_query(";").await?;
         Ok(())
     }
 


### PR DESCRIPTION
Critical. If a free connection was not available on the server in pool, the Client's buffer was not cleared, leading to an incorrect response error.

Thank @lasteris for discovering the error and providing an environment for reproducing it.