### PR TITLE
pool: coordinator Phase C polish and damage avoidance

### DIFF
--- a/src/pool/inner.rs
+++ b/src/pool/inner.rs
@@ -566,6 +566,28 @@ impl Pool {
             None
         };
 
+        // The coordinator wait above can run for up to `reserve_pool_timeout_ms`
+        // (default 3000 ms). During that wait a sibling caller in this same
+        // user pool may have finished a query and pushed its connection back
+        // into `slots.vec`. The coordinator has no visibility into the local
+        // pool — it could not have consumed that return on our behalf — so we
+        // re-check the local idle vec here, before paying the cost of a fresh
+        // backend connect. If we find a recyclable idle, drop the coordinator
+        // permit (its slot returns to the cross-pool semaphore and any peer
+        // Phase C waiter can take it) and hand the recycled object to the
+        // caller. The connect cost is saved; an eviction the coordinator may
+        // have already performed is unrecoverable, but the damage stops at
+        // one peer backend instead of cascading into a wasted local create.
+        if coordinator_permit.is_some() {
+            if let RecycleOutcome::Reused(inner) = self.inner.try_recycle_one(timeouts).await {
+                permit.forget();
+                return Ok(Object {
+                    inner: Some(*inner),
+                    pool: Arc::downgrade(&self.inner),
+                });
+            }
+        }
+
         // Bounded burst gate: cap the number of concurrent server creates per
         // pool. Without this gate, N parallel callers that all miss the idle
         // pool each independently issue a backend connect, producing
@@ -715,70 +737,119 @@ impl Pool {
     }
 
     /// Retains only the objects specified by the given function.
+    ///
+    /// Evicted `ObjectInner`s are extracted into a local Vec and dropped
+    /// **after** `slots.lock()` is released. The drop chain on each evicted
+    /// object runs `Server::drop` (a `Terminate` syscall to PG) plus
+    /// `CoordinatorPermit::drop` (a tokio `Notify::notify_one` that itself
+    /// briefly takes an internal mutex). Holding `slots.lock()` across these
+    /// blocks any peer caller trying to recycle from the same pool.
     pub fn retain(&self, f: impl Fn(&Server, Metrics) -> bool) {
-        let mut guard = self.inner.slots.lock();
-        let len_before = guard.vec.len();
-        guard.vec.retain_mut(|obj| f(&obj.obj, obj.metrics));
-        guard.size -= len_before - guard.vec.len();
+        let evicted: Vec<ObjectInner> = {
+            let mut guard = self.inner.slots.lock();
+            // Common case on a healthy retain cycle: nothing to evict.
+            // Skip the partition + allocation pair entirely.
+            if guard.vec.iter().all(|obj| f(&obj.obj, obj.metrics)) {
+                return;
+            }
+            let mut keep = VecDeque::with_capacity(guard.vec.capacity());
+            let mut evicted = Vec::new();
+            for obj in guard.vec.drain(..) {
+                if f(&obj.obj, obj.metrics) {
+                    keep.push_back(obj);
+                } else {
+                    evicted.push(obj);
+                }
+            }
+            guard.vec = keep;
+            guard.size -= evicted.len();
+            evicted
+        };
+        // Lock released here. Syscalls and notify_one fire below, off-lock.
+        drop(evicted);
     }
 
     /// Retains connections, closing oldest first when max limit is set.
     /// If max is 0, behaves like regular retain (closes all matching).
     /// If max > 0, closes at most `max` connections, prioritizing oldest by creation time.
     /// Returns the number of connections closed.
+    ///
+    /// As with [`retain`], evicted objects are extracted under the lock and
+    /// dropped only after the lock is released, so peer callers do not block
+    /// on PG `Terminate` syscalls or coordinator wake-ups.
     pub fn retain_oldest_first(
         &self,
         should_close: impl Fn(&Server, &Metrics) -> bool,
         max_to_close: usize,
     ) -> usize {
-        let mut guard = self.inner.slots.lock();
+        let evicted: Vec<ObjectInner> = {
+            let mut guard = self.inner.slots.lock();
 
-        if max_to_close == 0 {
-            // Unlimited - close all matching connections
-            let len_before = guard.vec.len();
-            guard
-                .vec
-                .retain_mut(|obj| !should_close(&obj.obj, &obj.metrics));
-            let closed = len_before - guard.vec.len();
-            guard.size -= closed;
-            return closed;
-        }
+            if max_to_close == 0 {
+                // Early exit when nothing matches — avoid the partition
+                // allocation in the frequent "retain cycle sees no stale
+                // connections" case.
+                if !guard
+                    .vec
+                    .iter()
+                    .any(|obj| should_close(&obj.obj, &obj.metrics))
+                {
+                    return 0;
+                }
+                // Unlimited — partition every matching object out of the vec.
+                let mut keep = VecDeque::with_capacity(guard.vec.capacity());
+                let mut evicted = Vec::new();
+                for obj in guard.vec.drain(..) {
+                    if should_close(&obj.obj, &obj.metrics) {
+                        evicted.push(obj);
+                    } else {
+                        keep.push_back(obj);
+                    }
+                }
+                guard.vec = keep;
+                guard.size -= evicted.len();
+                evicted
+            } else {
+                // Pre-walk to identify the oldest `max_to_close` candidates.
+                // We do not extract here — only collect (index, age) pairs.
+                let mut candidates: Vec<(usize, u128)> = guard
+                    .vec
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, obj)| should_close(&obj.obj, &obj.metrics))
+                    .map(|(idx, obj)| (idx, obj.metrics.age().as_millis()))
+                    .collect();
 
-        // Collect indices of connections that should be closed with their ages
-        let mut candidates: Vec<(usize, u128)> = guard
-            .vec
-            .iter()
-            .enumerate()
-            .filter(|(_, obj)| should_close(&obj.obj, &obj.metrics))
-            .map(|(idx, obj)| (idx, obj.metrics.age().as_millis()))
-            .collect();
+                if candidates.is_empty() {
+                    return 0;
+                }
 
-        if candidates.is_empty() {
-            return 0;
-        }
+                // Sort by age descending (oldest first — highest age value)
+                candidates.sort_by(|a, b| b.1.cmp(&a.1));
 
-        // Sort by age descending (oldest first - highest age value)
-        candidates.sort_by(|a, b| b.1.cmp(&a.1));
+                let to_close: std::collections::HashSet<usize> = candidates
+                    .into_iter()
+                    .take(max_to_close)
+                    .map(|(idx, _)| idx)
+                    .collect();
 
-        // Take at most max_to_close oldest connections
-        let to_close: std::collections::HashSet<usize> = candidates
-            .into_iter()
-            .take(max_to_close)
-            .map(|(idx, _)| idx)
-            .collect();
-
-        // Remove selected connections by rebuilding the vec
-        let len_before = guard.vec.len();
-        let mut new_vec = VecDeque::with_capacity(guard.vec.capacity());
-        for (idx, obj) in guard.vec.drain(..).enumerate() {
-            if !to_close.contains(&idx) {
-                new_vec.push_back(obj);
+                let mut keep = VecDeque::with_capacity(guard.vec.capacity());
+                let mut evicted = Vec::with_capacity(to_close.len());
+                for (idx, obj) in guard.vec.drain(..).enumerate() {
+                    if to_close.contains(&idx) {
+                        evicted.push(obj);
+                    } else {
+                        keep.push_back(obj);
+                    }
+                }
+                guard.vec = keep;
+                guard.size -= evicted.len();
+                evicted
             }
-        }
-        guard.vec = new_vec;
-
-        let closed = len_before - guard.vec.len();
-        guard.size -= closed;
+        };
+        let closed = evicted.len();
+        // Lock released here. Drops below run off-lock.
+        drop(evicted);
         closed
     }
 
@@ -804,23 +875,53 @@ impl Pool {
     /// This runs as part of the retain cycle to gradually relieve reserve pressure.
     ///
     /// Returns the number of reserve connections closed.
+    ///
+    /// Same off-lock drop discipline as [`retain`] / [`retain_oldest_first`]:
+    /// closed objects are extracted under the lock and dropped after the lock
+    /// is released, so the peer pool's eviction syscalls and coordinator
+    /// notifications do not stall concurrent recyclers.
     pub fn close_idle_reserve_connections(&self, min_lifetime_ms: u64) -> usize {
-        let mut guard = self.inner.slots.lock();
-        let len_before = guard.vec.len();
-        guard.vec.retain(|obj| {
-            let is_reserve = obj
-                .coordinator_permit
-                .as_ref()
-                .is_some_and(|p| p.is_reserve);
-            if !is_reserve {
-                return true;
+        let evicted: Vec<ObjectInner> = {
+            let mut guard = self.inner.slots.lock();
+            // Common case on pools with `reserve_pool_size = 0` or with
+            // reserve connections still within `min_connection_lifetime`:
+            // nothing to close. Skip the partition allocation.
+            let has_stale_reserve = guard.vec.iter().any(|obj| {
+                let is_reserve = obj
+                    .coordinator_permit
+                    .as_ref()
+                    .is_some_and(|p| p.is_reserve);
+                is_reserve && obj.metrics.last_used().as_millis() >= u128::from(min_lifetime_ms)
+            });
+            if !has_stale_reserve {
+                return 0;
             }
-            // Close reserve connections idle longer than min_connection_lifetime
-            let idle = obj.metrics.last_used().as_millis();
-            idle < u128::from(min_lifetime_ms)
-        });
-        let closed = len_before - guard.vec.len();
-        guard.size -= closed;
+            let mut keep = VecDeque::with_capacity(guard.vec.capacity());
+            let mut evicted = Vec::new();
+            for obj in guard.vec.drain(..) {
+                let is_reserve = obj
+                    .coordinator_permit
+                    .as_ref()
+                    .is_some_and(|p| p.is_reserve);
+                if !is_reserve {
+                    keep.push_back(obj);
+                    continue;
+                }
+                // Close reserve connections idle longer than min_connection_lifetime
+                let idle = obj.metrics.last_used().as_millis();
+                if idle < u128::from(min_lifetime_ms) {
+                    keep.push_back(obj);
+                } else {
+                    evicted.push(obj);
+                }
+            }
+            guard.vec = keep;
+            guard.size -= evicted.len();
+            evicted
+        };
+        let closed = evicted.len();
+        // Lock released here. Reserve permit drops fire below.
+        drop(evicted);
         closed
     }
 

--- a/src/pool/inner.rs
+++ b/src/pool/inner.rs
@@ -239,29 +239,10 @@ impl PoolInner {
             }
             drop(slots);
             self.semaphore.add_permits(1);
-            // Wake one task waiting in the cooldown anticipation zone
-            // or behind the bounded burst limiter.
-            self.idle_returned.notify_one();
-            // Wake one Phase C waiter in a peer pool's coordinator path.
-            // The connection just landed in our `slots.vec`, so the next
-            // `evict_one_idle` scan over our pool can find and drop it —
-            // freeing the semaphore slot a peer pool needs. Before this
-            // signal, Phase C only reacted to permit drops, so a peer
-            // waiter would sleep until our connection aged out via
-            // `server_lifetime` instead of picking up the freshly idle one.
-            //
-            // Note: `spare_above_min` is NOT what changes here. It tracks
-            // `slots.size - effective_min` and `slots.size` is the allocated
-            // count, not `vec.len()`; `return_object` leaves `slots.size`
-            // unchanged. What changes is the *evictable set* scanned by
-            // `retain_oldest_first` inside `evict_one_idle` — the returned
-            // connection is now visible there.
-            if let Some(ref coordinator) = self.coordinator {
-                coordinator.notify_idle_returned();
-            }
+            self.notify_return_observers();
             return;
         }
-        // Slow path: wait for lock. Same notify semantics as the fast path.
+        // Slow path: wait for lock.
         let mut slots = self.slots.lock();
         match self.config.queue_mode {
             QueueMode::Fifo => slots.vec.push_back(inner),
@@ -269,8 +250,29 @@ impl PoolInner {
         }
         drop(slots);
         self.semaphore.add_permits(1);
+        self.notify_return_observers();
+    }
+
+    /// Wake observers of an idle return: the same-pool cooldown anticipation
+    /// waiter and any peer-pool Phase C waiter on the coordinator. Both fire
+    /// on the same event (a connection landed in `slots.vec`) but consume by
+    /// different waiters:
+    /// - `idle_returned` is for callers in this pool's bounded-burst /
+    ///   cooldown anticipation zone, who will recycle the returned object.
+    /// - `coordinator.notify_idle_returned()` is for callers in *peer* user
+    ///   pools waiting on `PoolCoordinator` Phase C; they will scan this
+    ///   pool's idle vec via `evict_one_idle` and drop the returned
+    ///   connection to free a coordinator slot.
+    ///
+    /// Note: `spare_above_min` is NOT what changes here. It tracks
+    /// `slots.size - effective_min`, and `slots.size` is the allocated count,
+    /// not `vec.len()`; `return_object` leaves `slots.size` unchanged. What
+    /// changes is the *evictable set* scanned by `retain_oldest_first` inside
+    /// `evict_one_idle` — the returned connection is now visible there.
+    #[inline(always)]
+    fn notify_return_observers(&self) {
         self.idle_returned.notify_one();
-        if let Some(ref coordinator) = self.coordinator {
+        if let Some(coordinator) = self.coordinator.as_ref() {
             coordinator.notify_idle_returned();
         }
     }
@@ -1396,5 +1398,169 @@ mod tests {
             "a Notified future created AFTER the buffered permit was consumed \
              must NOT wake without a fresh notify_one"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // notify_return_observers — covers both fast and slow return_object
+    // ------------------------------------------------------------------
+
+    /// Builds a `Pool` whose `ServerPool` is never asked to `create()`.
+    /// Address/User defaults are fine because the test never opens a
+    /// real backend connection — it only exercises the in-memory notify
+    /// machinery on the resulting `PoolInner`.
+    fn test_pool_with_coordinator(coord: Arc<pool_coordinator::PoolCoordinator>) -> Pool {
+        use crate::config::{Address, User};
+        use dashmap::DashMap;
+
+        let server_pool = ServerPool::new(
+            Address::default(),
+            User::default(),
+            "test_db",
+            Arc::new(DashMap::new()),
+            false,
+            false,
+            0,
+            "test_app".to_string(),
+            1,
+            60_000,
+            60_000,
+            60_000,
+            Duration::from_secs(5),
+            false,
+        );
+        Pool::builder(server_pool)
+            .coordinator(Some(coord))
+            .pool_name("test_db".to_string())
+            .username("test_user".to_string())
+            .build()
+    }
+
+    /// Both fast and slow paths of `return_object` funnel through
+    /// `notify_return_observers`. This test pins the helper's contract:
+    /// it wakes the same-pool `idle_returned` waiter AND the peer-pool
+    /// coordinator Phase C waiter from a single call. A regression that
+    /// drops one of the two notify calls inside the helper would fail
+    /// this test even though `return_object` itself is not invoked,
+    /// because the helper is the single point that both code paths share.
+    #[tokio::test]
+    async fn notify_return_observers_wakes_phase_c_waiter_and_idle_returned() {
+        use std::sync::atomic::AtomicU64;
+        use std::sync::atomic::Ordering as AOrdering;
+
+        use pool_coordinator::{CoordinatorConfig, EvictionSource, PoolCoordinator};
+
+        // Counts how many times Phase C asks for an eviction. Phase B
+        // and the first iteration of Phase C each call try_evict_one
+        // exactly once before parking, so the baseline before any wake
+        // is exactly 2.
+        struct CountingEviction {
+            calls: Arc<AtomicU64>,
+        }
+        impl EvictionSource for CountingEviction {
+            fn try_evict_one(&self, _user: &str) -> bool {
+                self.calls.fetch_add(1, AOrdering::Relaxed);
+                false
+            }
+            fn queued_clients(&self, _user: &str) -> usize {
+                0
+            }
+            fn is_starving(&self, _user: &str) -> bool {
+                false
+            }
+        }
+
+        // Single-slot coordinator, slot pinned so Phase C never finishes
+        // via try_acquire — the only thing that can move the counter is
+        // a fresh notify_one on `connection_returned`.
+        let coord = PoolCoordinator::new(
+            "test_db".to_string(),
+            CoordinatorConfig {
+                max_db_connections: 1,
+                min_connection_lifetime_ms: 5000,
+                reserve_pool_size: 0,
+                reserve_pool_timeout_ms: 2000,
+            },
+        );
+        let _pinned = coord.try_acquire().expect("first slot is free");
+
+        let pool = test_pool_with_coordinator(coord.clone());
+
+        // Park a Phase C waiter on the coordinator's connection_returned.
+        let coord_w = coord.clone();
+        let calls = Arc::new(AtomicU64::new(0));
+        let calls_w = Arc::clone(&calls);
+        let phase_c_waiter = tokio::spawn(async move {
+            let eviction = CountingEviction { calls: calls_w };
+            coord_w.acquire("test_db", "u", &eviction).await
+        });
+
+        // Park an idle-return observer on the same pool's idle_returned.
+        // Pin + enable so the wake cannot race a late first poll.
+        let inner = Arc::clone(&pool.inner);
+        let idle_observer = tokio::spawn(async move {
+            let fut = inner.idle_returned.notified();
+            tokio::pin!(fut);
+            fut.as_mut().enable();
+            fut.await;
+        });
+
+        // Wait until both observers are parked. Phase C is observable
+        // through its eviction-call counter (baseline = 2 calls). The
+        // idle-return observer is observable indirectly: the test will
+        // either wake it via notify_return_observers or hang.
+        let parked = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if calls.load(AOrdering::Relaxed) >= 2 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(parked.is_ok(), "Phase C waiter never parked");
+        let baseline = calls.load(AOrdering::Relaxed);
+        assert_eq!(
+            baseline, 2,
+            "Phase B and the first Phase C iteration each call try_evict_one once",
+        );
+
+        // Single helper call: must wake both observers from one event.
+        pool.inner.notify_return_observers();
+
+        // The idle-return observer wakes within a generous budget. If the
+        // helper forgot the `idle_returned.notify_one()` call, this hangs
+        // until the timeout fires and the test fails.
+        tokio::time::timeout(Duration::from_secs(1), idle_observer)
+            .await
+            .expect("idle_returned waiter must wake from notify_return_observers")
+            .expect("idle_returned task must not panic");
+
+        // The Phase C waiter wakes, runs try_evict_one once more
+        // (baseline + 1) and parks again. If the helper forgot the
+        // `coordinator.notify_idle_returned()` call, the counter never
+        // moves above the baseline.
+        let woke = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if calls.load(AOrdering::Relaxed) > baseline {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            woke.is_ok(),
+            "Phase C waiter must wake on coordinator.notify_idle_returned",
+        );
+        assert_eq!(
+            calls.load(AOrdering::Relaxed),
+            baseline + 1,
+            "exactly one Phase C wake → exactly one extra try_evict_one",
+        );
+
+        // Cleanup: let the Phase C waiter eventually time out so the
+        // spawned task does not leak past the test.
+        phase_c_waiter.abort();
+        let _ = phase_c_waiter.await;
     }
 }

--- a/src/pool/pool_coordinator.rs
+++ b/src/pool/pool_coordinator.rs
@@ -258,6 +258,25 @@ impl PoolCoordinator {
             user, database, active, max,
         );
 
+        // A peer pool may have dropped its permit between Phase A's
+        // `try_acquire` and now (any concurrent `CoordinatorPermit::drop`
+        // bumps `db_semaphore` without going through this path). Re-check
+        // the cheap fast path before incurring an eviction: closing a peer
+        // backend that didn't need to be closed is unrecoverable damage,
+        // and a single extra atomic CAS is essentially free compared to
+        // the alternative.
+        if let Some(permit) = self.try_acquire() {
+            debug!(
+                "[{}@{}] coordinator: permit became free between Phase A and Phase B, \
+                 eviction avoided (active={}/{})",
+                user,
+                database,
+                self.total_connections.load(Ordering::Relaxed),
+                max,
+            );
+            return Ok(permit);
+        }
+
         // Phase B: try eviction — close an idle connection from another user
         let evicted = eviction_source.try_evict_one(user);
         if evicted {
@@ -318,37 +337,16 @@ impl PoolCoordinator {
             // `Pool::timeout_get`.
             let notified = self.connection_returned.notified();
 
-            // Opportunistic eviction retry. The wake-up may have come from
-            // `Pool::return_object` on a peer pool, which made a previously
-            // checked-out connection visible in that peer's idle vec without
-            // destroying any permit. A previous Phase B attempt may have
-            // found nothing evictable because the candidate was checked out,
-            // but the state has now changed.
-            //
-            // We call `try_evict_one` on every loop iteration, not just
-            // after a notify, because:
-            //   - The wake source is indistinguishable from a permit drop.
-            //   - The scan is cheap compared to a `reserve_pool_timeout`
-            //     wait that ends in a reserve grant or a client error.
-            //   - The retry is what lets symmetric peer-pool traffic resolve
-            //     in milliseconds. Without it, a Phase C waiter would only
-            //     react to physical permit drops (server_lifetime expiry,
-            //     recycle errors, reconnect epoch) and would sleep through
-            //     every plain `return_object` even though peers were
-            //     constantly recycling idle connections it could evict.
-            if eviction_source.try_evict_one(user) {
-                self.evictions_total.fetch_add(1, Ordering::Relaxed);
-                debug!(
-                    "[{}@{}] coordinator: wait phase evicted idle from peer \
-                     (wakeups={})",
-                    user, database, wait_wakeups,
-                );
-            }
-
+            // Cheap path first: a previous wake (or any concurrent
+            // `CoordinatorPermit::drop`) may have already left a free permit
+            // in the semaphore. `try_evict_one` would close a peer connection
+            // for nothing in that case — the slot is already there for the
+            // taking. The atomic CAS is roughly five nanoseconds; an avoided
+            // eviction saves a peer backend.
             if let Some(permit) = self.try_acquire() {
                 debug!(
-                    "[{}@{}] coordinator: wait phase succeeded \
-                     after {} wakeup(s), permit acquired (active={}/{})",
+                    "[{}@{}] coordinator: wait phase acquired free permit \
+                     without eviction after {} wakeup(s) (active={}/{})",
                     user,
                     database,
                     wait_wakeups,
@@ -356,6 +354,40 @@ impl PoolCoordinator {
                     max,
                 );
                 return Ok(permit);
+            }
+
+            // Opportunistic eviction retry. The wake-up may have come from
+            // `Pool::return_object` on a peer pool, which made a previously
+            // checked-out connection visible in that peer's idle vec without
+            // destroying any permit. A previous Phase B attempt may have
+            // found nothing evictable because the candidate was checked out,
+            // but the state has now changed.
+            //
+            // The scan runs on every iteration, not only after a notify,
+            // because the wake source is indistinguishable from a permit
+            // drop and the scan is much cheaper than a `reserve_pool_timeout`
+            // wait that ends in a reserve grant or a client error. The
+            // try_acquire above means we only reach this point when the
+            // semaphore is genuinely empty — eviction is the only way out.
+            if eviction_source.try_evict_one(user) {
+                self.evictions_total.fetch_add(1, Ordering::Relaxed);
+                debug!(
+                    "[{}@{}] coordinator: wait phase evicted idle from peer \
+                     (wakeups={})",
+                    user, database, wait_wakeups,
+                );
+                if let Some(permit) = self.try_acquire() {
+                    debug!(
+                        "[{}@{}] coordinator: wait phase succeeded \
+                         after {} wakeup(s), permit acquired (active={}/{})",
+                        user,
+                        database,
+                        wait_wakeups,
+                        self.total_connections.load(Ordering::Relaxed),
+                        max,
+                    );
+                    return Ok(permit);
+                }
             }
 
             tokio::select! {
@@ -1191,6 +1223,98 @@ mod tests {
                 .unwrap();
             assert!(r.is_err());
         }
+    }
+
+    /// Regression for the cheap-path-first invariant: when Phase C wakes
+    /// from a real `CoordinatorPermit::drop` (semaphore actually has a free
+    /// slot now), the waiter must take that slot via `try_acquire` WITHOUT
+    /// running another `try_evict_one`. Closing a peer backend to free a
+    /// slot that is already free is wasted damage on the peer.
+    ///
+    /// Before the fix, Phase C ran `try_evict_one` unconditionally at the
+    /// top of every loop iteration. With a peer that had spare capacity,
+    /// the wake from a `CoordinatorPermit::drop` would still close a peer
+    /// connection for nothing.
+    ///
+    /// The test pins the new ordering: `try_acquire → try_evict_one`. The
+    /// eviction-call counter must NOT advance past the parking baseline
+    /// when the wake comes from a permit drop.
+    #[tokio::test]
+    async fn phase_c_wake_from_permit_drop_skips_eviction() {
+        use std::sync::atomic::{AtomicU64, Ordering as AOrdering};
+
+        #[derive(Clone)]
+        struct CountingEviction {
+            calls: std::sync::Arc<AtomicU64>,
+        }
+        impl EvictionSource for CountingEviction {
+            fn try_evict_one(&self, _user: &str) -> bool {
+                // Counts every call. Always returns false so a successful
+                // eviction never confounds the wake-source attribution.
+                self.calls.fetch_add(1, AOrdering::Relaxed);
+                false
+            }
+            fn queued_clients(&self, _user: &str) -> usize {
+                0
+            }
+            fn is_starving(&self, _user: &str) -> bool {
+                false
+            }
+        }
+
+        // Single-slot coordinator. We pin the slot, park a Phase C waiter
+        // on it, then drop the pin to let the waiter take the freed permit.
+        let coord = PoolCoordinator::new("test_db".to_string(), test_config(1, 0));
+        let p = coord.try_acquire().expect("first slot is free");
+
+        let calls = std::sync::Arc::new(AtomicU64::new(0));
+        let coord_w = coord.clone();
+        let calls_w = std::sync::Arc::clone(&calls);
+        let waiter = tokio::spawn(async move {
+            let eviction = CountingEviction { calls: calls_w };
+            coord_w.acquire("testdb", "waiter", &eviction).await
+        });
+
+        // Let the waiter reach Phase C. The cheap-path-first ordering means
+        // each of Phase B and the first Phase C iteration runs the cheap
+        // `try_acquire` first (fails — slot is pinned) and then `try_evict_one`
+        // exactly once. Baseline counter == 2.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        let baseline = calls.load(AOrdering::Relaxed);
+        assert_eq!(
+            baseline, 2,
+            "baseline must be Phase B + first Phase C try_evict_one calls",
+        );
+
+        // Drop the pinned permit: semaphore +1, `connection_returned.notify_one`
+        // fires from `CoordinatorPermit::drop`. The waiter wakes, sees a free
+        // slot, and must take it via the new try_acquire-first path.
+        drop(p);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter should complete after permit drop")
+            .expect("waiter task must not panic");
+        assert!(
+            result.is_ok(),
+            "Phase C waiter must acquire the freed permit, not time out",
+        );
+        assert!(!result.unwrap().is_reserve);
+
+        // The invariant: no extra eviction call ran on the wake. Without the
+        // cheap-path-first reordering the counter would be 3 (Phase B + first
+        // Phase C iter + wake-driven extra `try_evict_one`).
+        let final_calls = calls.load(AOrdering::Relaxed);
+        assert_eq!(
+            final_calls, baseline,
+            "wake from permit drop must take the cheap path; counter advanced {} → {}",
+            baseline, final_calls,
+        );
+        assert_eq!(
+            coord.stats().evictions_total,
+            0,
+            "permit-drop path must not record any successful eviction",
+        );
     }
 
     /// Negative guard: a bare `notify_idle_returned` call that does not

--- a/src/pool/pool_coordinator.rs
+++ b/src/pool/pool_coordinator.rs
@@ -126,8 +126,9 @@ pub struct PoolCoordinator {
     ///    physically destroyed and its semaphore slot is free.
     /// 2. A `Pool::return_object` fired on a peer pool — the connection went
     ///    back to that pool's idle queue without being destroyed. The slot is
-    ///    NOT free, but the peer's `spare_above_min` may have just grown, so a
-    ///    Phase C waiter should re-run `try_evict_one` against that peer.
+    ///    NOT free, but the peer's idle `vec` has a new entry, so the next
+    ///    `retain_oldest_first` scan inside `evict_one_idle` can find an
+    ///    eligible eviction candidate that wasn't visible a moment ago.
     ///
     /// Phase C handles both cases uniformly: on every wake it retries
     /// `eviction_source.try_evict_one(user)` before `try_acquire()`.
@@ -318,20 +319,23 @@ impl PoolCoordinator {
             let notified = self.connection_returned.notified();
 
             // Opportunistic eviction retry. The wake-up may have come from
-            // `Pool::return_object` on a peer pool, which increased that
-            // peer's `spare_above_min` without destroying any permit. A
-            // previous Phase B attempt may have found nothing to evict
-            // because peers had no spare, but the state has now changed.
+            // `Pool::return_object` on a peer pool, which made a previously
+            // checked-out connection visible in that peer's idle vec without
+            // destroying any permit. A previous Phase B attempt may have
+            // found nothing evictable because the candidate was checked out,
+            // but the state has now changed.
             //
             // We call `try_evict_one` on every loop iteration, not just
             // after a notify, because:
             //   - The wake source is indistinguishable from a permit drop.
             //   - The scan is cheap compared to a `reserve_pool_timeout`
             //     wait that ends in a reserve grant or a client error.
-            //   - Without this retry, symmetric traffic between peer pools
-            //     produces long waits and unnecessary reserve usage, since
-            //     `connection_returned` only fires on physical permit drops
-            //     (server_lifetime expiry, recycle errors, reconnect epoch).
+            //   - The retry is what lets symmetric peer-pool traffic resolve
+            //     in milliseconds. Without it, a Phase C waiter would only
+            //     react to physical permit drops (server_lifetime expiry,
+            //     recycle errors, reconnect epoch) and would sleep through
+            //     every plain `return_object` even though peers were
+            //     constantly recycling idle connections it could evict.
             if eviction_source.try_evict_one(user) {
                 self.evictions_total.fetch_add(1, Ordering::Relaxed);
                 debug!(
@@ -476,15 +480,16 @@ impl PoolCoordinator {
     /// Called by `Pool::return_object` when a server connection goes back
     /// into a peer pool's idle queue without being destroyed. Wakes one
     /// Phase C waiter so it can re-run `eviction_source.try_evict_one` —
-    /// the peer's `spare_above_min` may have just grown and a slot that was
-    /// impossible to free a moment ago is now evictable.
+    /// the returned connection is now visible to `retain_oldest_first`, so
+    /// an eviction candidate that didn't exist a moment ago is now scannable.
     ///
-    /// Without this signal, Phase C only reacts to physical permit drops
-    /// (`CoordinatorPermit::drop`), so a busy peer that constantly recycles
-    /// its own idle queue would keep a waiter sleeping until `server_lifetime`
-    /// ages a connection out — the waiter would then timeout into Phase D
-    /// even though the cross-pool system had headroom every few milliseconds.
-    pub fn notify_idle_returned(&self) {
+    /// Without this signal, Phase C would only react to physical permit
+    /// drops (`CoordinatorPermit::drop`), so a busy peer that constantly
+    /// recycles its own idle queue would keep a waiter sleeping until
+    /// `server_lifetime` ages a connection out — the waiter would then
+    /// timeout into Phase D even though the cross-pool system had headroom
+    /// every few milliseconds.
+    pub(crate) fn notify_idle_returned(&self) {
         self.connection_returned.notify_one();
     }
 


### PR DESCRIPTION
Follow-up to #181 that bundles two related tracks:

1. **Review-feedback polish** (first commit): doc accuracy, API visibility,
   internal refactor, and a regression test.
2. **Damage avoidance** (second commit): three points where the coordinator
   path was paying for an unrecoverable operation that a single extra cheap
   check would have skipped.

Both tracks are behaviour-preserving for the correct cases and only *reduce*
the number of expensive operations (peer backend evictions and fresh
`server_pool.create()` calls) under symmetric load.

## Commit 1 — tighten invariants and docs

- Sync the doc-comments on `notify_idle_returned` and the
  `connection_returned` field with the corrected explanation already present
  in `Pool::return_object`. The old wording claimed the peer's
  `spare_above_min` grows on a return; it does not (`spare_above_min` is
  derived from `slots.size`, which `return_object` leaves unchanged). The
  actual change is the evictable set scanned by `retain_oldest_first`.
- Rework the Phase C loop comment so the per-iteration `try_evict_one` retry
  is justified independently of the wake source. The previous bullet said
  `connection_returned` only fires on permit drops, which became false the
  moment #181 started routing `Pool::return_object` through
  `notify_idle_returned`.
- Restrict `PoolCoordinator::notify_idle_returned` to `pub(crate)`. It is
  only called from `Pool::return_object` inside the same crate.
- Extract `PoolInner::notify_return_observers` so the two-notify dance for
  own-pool cooldown waiters and peer-pool Phase C waiters lives in one
  place instead of being duplicated across the fast and slow paths of
  `return_object`.
- Pin the helper's contract with a new unit test: a single
  `notify_return_observers` call wakes both an `idle_returned` observer
  and a parked Phase C waiter on the coordinator.

## Commit 2 — avoid wasted eviction and connect when idle is available

- **Coordinator Phase B and Phase C now run `try_acquire` BEFORE
  `try_evict_one`.** The semaphore can become free between Phase A and the
  first eviction attempt (any concurrent `CoordinatorPermit::drop` from a
  peer pool bumps it without going through this path), and Phase C wakes
  are not source-attributed: a wake from a permit drop already left a free
  slot, while a wake from `notify_idle_returned` did not. Closing a peer
  backend to free a slot that is already free is unrecoverable damage on
  the peer. One extra atomic CAS per wake (~5 ns) avoids this.

- **`Pool::timeout_get` does one more `try_recycle_one` after
  `coordinator.acquire` returns.** The coordinator wait can run for up to
  `reserve_pool_timeout_ms` (default 3000 ms), and during that wait a
  sibling caller in the same user pool may have returned a connection into
  the local idle vec. The coordinator has no visibility into the local
  pool. If we find a recyclable idle, we drop the just-acquired coordinator
  permit and return the recycled object — the connect cost is saved, and
  the damage from the potentially-already-evicted peer stops at one
  backend instead of cascading into a wasted local create.

- **`retain_oldest_first`, `retain`, and `close_idle_reserve_connections`
  drop evicted `ObjectInner`s off-lock.** The Drop chain runs `Server::drop`
  (a `Terminate` syscall to PG) plus `CoordinatorPermit::drop` (a tokio
  `Notify::notify_one` that itself takes an internal mutex). Holding the
  peer pool's `parking_lot::Mutex` across these blocked any concurrent
  `try_recycle_one` on the same pool for the duration of the syscall — a
  contention amplifier that grew with the eviction frequency this PR
  otherwise increases. A peek-first short-circuit keeps the no-op retain
  cycle allocation-free.

### New regression test

`phase_c_wake_from_permit_drop_skips_eviction` — a single-slot coordinator
with a parked Phase C waiter and a `CountingEviction` mock. When the pinned
permit is dropped, the waiter must take the freed slot via the cheap
`try_acquire` path WITHOUT advancing the eviction-call counter.

The existing `phase_c_single_notify_wakes_exactly_one_waiter` still passes
unchanged: the slot stays pinned across the wake in that scenario, so the
new `try_acquire` correctly falls through to `try_evict_one`, preserving
the `baseline + 1` count.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --lib -- --deny warnings\` clean
- [x] \`cargo test --lib pool\` — 84/84 pass (including the new
      \`phase_c_wake_from_permit_drop_skips_eviction\` and the existing
      \`notify_return_observers_wakes_phase_c_waiter_and_idle_returned\`)
- [x] Pre-commit Rust review (separate agent) on both commits — passed,
      no blockers