### PR TITLE
pool: suppress redundant RESET ALL after client session reset batch

### DIFF
--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -32,6 +32,10 @@
 
 - **Removed password hash from logs.** The "unsupported password type" warning no longer includes the password hash value.
 
+**Bug Fixes:**
+
+- **Client-side session reset batch no longer triggers a second `RESET ALL` on checkin.** When a client (e.g. `jackc/pgx` on an internal context deadline) kept the server connection alive by running its own cleanup batch (`SET SESSION AUTHORIZATION DEFAULT; RESET ALL; CLOSE ALL; UNLISTEN *; DISCARD PLANS; DISCARD SEQUENCES; DISCARD TEMP`), pg_doorman saw only the `SET` tag from `SET SESSION AUTHORIZATION DEFAULT`, marked the connection dirty, and sent its own `RESET ROLE; RESET ALL;` when the connection returned to the pool. Every dangling client query tripled the traffic to PostgreSQL: the original query, the client's cleanup batch, and pg_doorman's redundant reset. Fixed by recognising the CommandComplete tags that restore session state (`RESET`, `CLOSE CURSOR ALL`, `DEALLOCATE ALL`, `DISCARD ALL`) and clearing the matching `needs_cleanup_*` flags. Baseline behaviour is unchanged: a `SET statement_timeout = 1000` without a follow-up reset still provokes `RESET ROLE; RESET ALL;` on checkin.
+
 ### 3.3.5 <small>Mar 31, 2026</small>
 
 **Bug Fixes:**

--- a/src/server/protocol_io.rs
+++ b/src/server/protocol_io.rs
@@ -35,14 +35,35 @@ use crate::messages::{
 use super::parameters::ServerParameters;
 use super::server_backend::Server;
 
-// PostgreSQL CommandComplete message payloads for tracking session state changes
-/// CommandComplete payload for SET statements (requires RESET ALL cleanup)
+// PostgreSQL CommandComplete message payloads for tracking session state changes.
+//
+// A checkin-time `RESET ALL` / `DEALLOCATE ALL` / `CLOSE ALL` is a heuristic
+// upper bound: we arm the `needs_cleanup_*` flags when we see a statement that
+// *might* have mutated the session, and we disarm them when we see a statement
+// that has since restored it. Disarming matters because otherwise a client that
+// performs its own reset batch (e.g. pgx on internal context deadline sends
+// `SET SESSION AUTHORIZATION DEFAULT; RESET ALL; CLOSE ALL; UNLISTEN *;
+// DISCARD PLANS; ...`) leaves pg_doorman thinking the connection is still dirty
+// and triggers a second, redundant `RESET ALL` round-trip on checkin.
+
+/// `SET` statement CommandComplete tag — arms the `needs_cleanup_set` flag.
+/// Returned for any `SET foo = ...`, including `SET SESSION AUTHORIZATION ...`.
 const COMMAND_COMPLETE_BY_SET: &[u8; 4] = b"SET\0";
-/// CommandComplete payload for DECLARE CURSOR statements (requires CLOSE ALL cleanup)
+/// `RESET` statement CommandComplete tag — disarms `needs_cleanup_set`.
+/// PostgreSQL returns this tag both for `RESET ALL` and for `RESET foo.bar`;
+/// the per-GUC form is still safe to treat as a reset because the only state
+/// pg_doorman tracked is the `SET` flag — the next `SET` will re-arm it.
+const COMMAND_COMPLETE_BY_RESET: &[u8; 6] = b"RESET\0";
+/// `DECLARE CURSOR` CommandComplete tag — arms the `needs_cleanup_declare` flag.
 const COMMAND_COMPLETE_BY_DECLARE: &[u8; 15] = b"DECLARE CURSOR\0";
-/// CommandComplete payload for DEALLOCATE ALL (clears prepared statement cache)
+/// `CLOSE ALL` CommandComplete tag — disarms `needs_cleanup_declare`.
+/// Note the server emits `CLOSE CURSOR ALL`, not `CLOSE ALL`.
+const COMMAND_COMPLETE_BY_CLOSE_CURSOR_ALL: &[u8; 17] = b"CLOSE CURSOR ALL\0";
+/// `DEALLOCATE ALL` CommandComplete tag — clears prepared statement cache
+/// and disarms `needs_cleanup_prepare`.
 const COMMAND_COMPLETE_BY_DEALLOCATE_ALL: &[u8; 15] = b"DEALLOCATE ALL\0";
-/// CommandComplete payload for DISCARD ALL (clears prepared statement cache)
+/// `DISCARD ALL` CommandComplete tag — equivalent to `RESET ALL; DEALLOCATE ALL;
+/// CLOSE ALL; UNLISTEN *; ...`, so disarms every `needs_cleanup_*` flag.
 const COMMAND_COMPLETE_BY_DISCARD_ALL: &[u8; 12] = b"DISCARD ALL\0";
 
 /// Buffer flush threshold in bytes (8 KiB).
@@ -301,47 +322,111 @@ fn handle_error_response(server: &mut Server, message: &mut BytesMut) {
     }
 }
 
+/// Effect a single CommandComplete tag has on the server's cleanup tracking.
+///
+/// Extracted from [`handle_command_complete`] so the tag-matching logic can be
+/// unit-tested without constructing a full `Server`. See the tests at the bottom
+/// of this file for the exhaustive tag coverage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandCompleteEffect {
+    /// Tag does not influence cleanup tracking (e.g. SELECT, INSERT).
+    None,
+    /// `SET ...` — session GUC potentially mutated; arm set-cleanup.
+    ArmSet,
+    /// `DECLARE CURSOR` — a server-side cursor may now be open; arm declare-cleanup.
+    ArmDeclare,
+    /// `RESET` / `RESET ALL` — session GUCs are back to the server defaults;
+    /// disarm set-cleanup because the subsequent checkin RESET would be a no-op.
+    DisarmSet,
+    /// `CLOSE CURSOR ALL` — no server-side cursors remain; disarm declare-cleanup.
+    DisarmDeclare,
+    /// `DEALLOCATE ALL` — every prepared statement is gone server-side; disarm
+    /// prepare-cleanup and drop the LRU so the next checkout starts from scratch.
+    DisarmPrepare,
+    /// `DISCARD ALL` — equivalent to `RESET ALL; DEALLOCATE ALL; CLOSE ALL;
+    /// UNLISTEN *; ...` executed atomically; disarm every `needs_cleanup_*` flag
+    /// and drop the LRU.
+    DisarmAll,
+}
+
+/// Pure classifier for CommandComplete tags relevant to session cleanup tracking.
+///
+/// The tags are compared byte-for-byte; `PartialEq for [u8]` already short-circuits
+/// on length, so non-matching messages (the common case on the hot path) cost a
+/// single length comparison per arm.
+fn classify_command_complete(tag: &[u8]) -> CommandCompleteEffect {
+    if tag == COMMAND_COMPLETE_BY_SET {
+        CommandCompleteEffect::ArmSet
+    } else if tag == COMMAND_COMPLETE_BY_RESET {
+        CommandCompleteEffect::DisarmSet
+    } else if tag == COMMAND_COMPLETE_BY_DECLARE {
+        CommandCompleteEffect::ArmDeclare
+    } else if tag == COMMAND_COMPLETE_BY_CLOSE_CURSOR_ALL {
+        CommandCompleteEffect::DisarmDeclare
+    } else if tag == COMMAND_COMPLETE_BY_DEALLOCATE_ALL {
+        CommandCompleteEffect::DisarmPrepare
+    } else if tag == COMMAND_COMPLETE_BY_DISCARD_ALL {
+        CommandCompleteEffect::DisarmAll
+    } else {
+        CommandCompleteEffect::None
+    }
+}
+
+/// Drop the pg_doorman-side prepared statement LRU after the server confirms it
+/// just executed an equivalent of `DEALLOCATE ALL` or `DISCARD ALL`.
+fn drop_prepared_statement_cache_on_reset(server: &mut Server, reason: &'static str) {
+    server.registering_prepared_statement.clear();
+    let Some(cache_size) = server
+        .prepared_statement_cache
+        .as_ref()
+        .map(|cache| cache.len())
+    else {
+        return;
+    };
+    warn!(
+        "[{}@{}] clearing prepared statement cache pid={}: {reason} ({cache_size} entries)",
+        server.address.username,
+        server.address.pool_name,
+        server.get_process_id(),
+    );
+    if let Some(cache) = server.prepared_statement_cache.as_mut() {
+        cache.clear();
+    }
+}
+
 /// Handles CommandComplete ('C') message - indicates successful completion of a command.
-/// Tracks commands that require cleanup (SET, DECLARE, etc.) and updates server state.
+/// Tracks commands that may require cleanup (SET, DECLARE, ...) and disarms the
+/// cleanup flags when the session has since been restored by a RESET / DISCARD /
+/// DEALLOCATE / CLOSE ALL statement in the same or a later batch — so that the
+/// next checkin does not issue a redundant `RESET ALL` round-trip on a connection
+/// the client has already cleaned up.
 fn handle_command_complete(server: &mut Server, message: &BytesMut) {
     // Exit COPY mode if we were in it
     if server.in_copy_mode {
         server.in_copy_mode = false;
     }
 
-    // Check for commands that require cleanup at connection checkin
-    if message.len() == 4 && &message[..] == COMMAND_COMPLETE_BY_SET {
-        server.cleanup_state.needs_cleanup_set = true;
-    }
-    if message.len() == 15 && &message[..] == COMMAND_COMPLETE_BY_DECLARE {
-        server.cleanup_state.needs_cleanup_declare = true;
-    }
-    if message.len() == 12 && &message[..] == COMMAND_COMPLETE_BY_DISCARD_ALL {
-        server.registering_prepared_statement.clear();
-        if server.prepared_statement_cache.is_some() {
-            let cache_size = server.prepared_statement_cache.as_ref().unwrap().len();
-            warn!(
-                "[{}@{}] clearing prepared statement cache pid={}: DISCARD ALL ({} entries)",
-                server.address.username,
-                server.address.pool_name,
-                server.get_process_id(),
-                cache_size
-            );
-            server.prepared_statement_cache.as_mut().unwrap().clear();
+    match classify_command_complete(&message[..]) {
+        CommandCompleteEffect::None => {}
+        CommandCompleteEffect::ArmSet => {
+            server.cleanup_state.needs_cleanup_set = true;
         }
-    }
-    if message.len() == 15 && &message[..] == COMMAND_COMPLETE_BY_DEALLOCATE_ALL {
-        server.registering_prepared_statement.clear();
-        if server.prepared_statement_cache.is_some() {
-            let cache_size = server.prepared_statement_cache.as_ref().unwrap().len();
-            warn!(
-                "[{}@{}] clearing prepared statement cache pid={}: DEALLOCATE ALL ({} entries)",
-                server.address.username,
-                server.address.pool_name,
-                server.get_process_id(),
-                cache_size
-            );
-            server.prepared_statement_cache.as_mut().unwrap().clear();
+        CommandCompleteEffect::ArmDeclare => {
+            server.cleanup_state.needs_cleanup_declare = true;
+        }
+        CommandCompleteEffect::DisarmSet => {
+            server.cleanup_state.needs_cleanup_set = false;
+        }
+        CommandCompleteEffect::DisarmDeclare => {
+            server.cleanup_state.needs_cleanup_declare = false;
+        }
+        CommandCompleteEffect::DisarmPrepare => {
+            server.cleanup_state.needs_cleanup_prepare = false;
+            drop_prepared_statement_cache_on_reset(server, "DEALLOCATE ALL");
+        }
+        CommandCompleteEffect::DisarmAll => {
+            server.cleanup_state.reset();
+            drop_prepared_statement_cache_on_reset(server, "DISCARD ALL");
         }
     }
 }
@@ -652,4 +737,158 @@ where
 
     // Pass the data back to the client.
     Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-function tests for CommandComplete tag classification.
+    //!
+    //! The tag strings were captured empirically against PostgreSQL 16 by
+    //! connecting with `psql` and inspecting the CommandComplete payload —
+    //! PostgreSQL does not expose the tag list as a public contract, so these
+    //! tests pin the bytes pg_doorman relies on.
+    //!
+    //! Note the two non-obvious cases:
+    //! * `RESET ALL` is reported as `RESET\0`, not `RESET ALL\0`.
+    //! * `CLOSE ALL` is reported as `CLOSE CURSOR ALL\0`, not `CLOSE ALL\0`.
+
+    use super::{classify_command_complete, CommandCompleteEffect};
+
+    #[test]
+    fn set_tag_arms_set_cleanup() {
+        assert_eq!(
+            classify_command_complete(b"SET\0"),
+            CommandCompleteEffect::ArmSet,
+        );
+    }
+
+    #[test]
+    fn reset_tag_disarms_set_cleanup() {
+        // PostgreSQL emits the same `RESET\0` tag for `RESET ALL` and
+        // `RESET foo.bar`; both restore GUCs to their default so either one
+        // legitimately disarms pg_doorman's heuristic flag.
+        assert_eq!(
+            classify_command_complete(b"RESET\0"),
+            CommandCompleteEffect::DisarmSet,
+        );
+    }
+
+    #[test]
+    fn declare_cursor_tag_arms_declare_cleanup() {
+        assert_eq!(
+            classify_command_complete(b"DECLARE CURSOR\0"),
+            CommandCompleteEffect::ArmDeclare,
+        );
+    }
+
+    #[test]
+    fn close_cursor_all_tag_disarms_declare_cleanup() {
+        assert_eq!(
+            classify_command_complete(b"CLOSE CURSOR ALL\0"),
+            CommandCompleteEffect::DisarmDeclare,
+        );
+    }
+
+    #[test]
+    fn close_single_cursor_tag_is_inert() {
+        // Closing one named cursor is not the same as `CLOSE ALL` — other
+        // cursors may still be open, so this tag must NOT disarm declare-cleanup.
+        assert_eq!(
+            classify_command_complete(b"CLOSE CURSOR\0"),
+            CommandCompleteEffect::None,
+        );
+    }
+
+    #[test]
+    fn deallocate_all_tag_disarms_prepare_cleanup() {
+        assert_eq!(
+            classify_command_complete(b"DEALLOCATE ALL\0"),
+            CommandCompleteEffect::DisarmPrepare,
+        );
+    }
+
+    #[test]
+    fn discard_all_tag_disarms_every_cleanup_flag() {
+        assert_eq!(
+            classify_command_complete(b"DISCARD ALL\0"),
+            CommandCompleteEffect::DisarmAll,
+        );
+    }
+
+    #[test]
+    fn partial_discard_tags_are_inert() {
+        // DISCARD PLANS drops the plan cache, DISCARD TEMP drops temp tables,
+        // DISCARD SEQUENCES resets sequence caches. None of them revert SET
+        // state or drop prepared statements, so none should influence the
+        // cleanup flags on their own.
+        assert_eq!(
+            classify_command_complete(b"DISCARD PLANS\0"),
+            CommandCompleteEffect::None,
+        );
+        assert_eq!(
+            classify_command_complete(b"DISCARD TEMP\0"),
+            CommandCompleteEffect::None,
+        );
+        assert_eq!(
+            classify_command_complete(b"DISCARD SEQUENCES\0"),
+            CommandCompleteEffect::None,
+        );
+    }
+
+    #[test]
+    fn regular_command_tags_are_inert() {
+        // A representative sample of data-plane tags. If any of these ever
+        // start influencing cleanup tracking it will be a correctness bug.
+        for tag in [
+            &b"SELECT 1\0"[..],
+            b"INSERT 0 1\0",
+            b"UPDATE 5\0",
+            b"DELETE 10\0",
+            b"BEGIN\0",
+            b"COMMIT\0",
+            b"ROLLBACK\0",
+            b"UNLISTEN\0",
+            b"SAVEPOINT\0",
+        ] {
+            assert_eq!(
+                classify_command_complete(tag),
+                CommandCompleteEffect::None,
+                "tag {:?} should not influence cleanup",
+                std::str::from_utf8(tag).unwrap_or("<non-utf8>"),
+            );
+        }
+    }
+
+    #[test]
+    fn length_only_matches_do_not_confuse_classifier() {
+        // Both DECLARE CURSOR and DEALLOCATE ALL are 15 bytes long with the
+        // trailing NUL; the classifier must dispatch on content, not length.
+        assert_eq!(
+            classify_command_complete(b"DECLARE CURSOR\0"),
+            CommandCompleteEffect::ArmDeclare,
+        );
+        assert_eq!(
+            classify_command_complete(b"DEALLOCATE ALL\0"),
+            CommandCompleteEffect::DisarmPrepare,
+        );
+        // Same length as DEALLOCATE ALL but unrelated content — must be inert.
+        assert_eq!(
+            classify_command_complete(b"MADE UP TAG 01\0"),
+            CommandCompleteEffect::None,
+        );
+    }
+
+    #[test]
+    fn empty_or_missing_nul_is_inert() {
+        assert_eq!(classify_command_complete(b""), CommandCompleteEffect::None,);
+        // Without the trailing NUL the length never matches the expected one.
+        assert_eq!(
+            classify_command_complete(b"SET"),
+            CommandCompleteEffect::None,
+        );
+        assert_eq!(
+            classify_command_complete(b"RESET"),
+            CommandCompleteEffect::None,
+        );
+    }
 }

--- a/tests/bdd/extended/advanced_testing.rs
+++ b/tests/bdd/extended/advanced_testing.rs
@@ -1,5 +1,6 @@
 use crate::world::DoormanWorld;
 use cucumber::{then, when};
+use std::path::PathBuf;
 
 #[when(regex = r#"^we read (\d+) bytes from session "([^"]+)"$"#)]
 pub async fn read_bytes_from_session(world: &mut DoormanWorld, bytes: usize, session_name: String) {
@@ -406,4 +407,91 @@ pub async fn verify_error_response_on_flush_timeout(
         "Session '{}': correctly received ErrorResponse on flush timeout",
         session_name
     );
+}
+
+// =============================================================================
+// PostgreSQL server log inspection steps
+// =============================================================================
+
+/// Locate `pg.log` inside the temporary PostgreSQL data directory. The path is
+/// the one `start_postgres_internal` hands to `pg_ctl -l`, so it always exists
+/// for scenarios that start PostgreSQL via one of the `PostgreSQL started ...`
+/// Given steps.
+fn pg_log_path(world: &DoormanWorld) -> PathBuf {
+    world
+        .pg_tmp_dir
+        .as_ref()
+        .expect("PostgreSQL not started (no pg_tmp_dir)")
+        .path()
+        .join("pg.log")
+}
+
+/// Count non-overlapping occurrences of `needle` in the PostgreSQL server log.
+/// Falls back to `0` if the log file has not been created yet — this is safe
+/// because the steps using this helper assert after traffic has flowed.
+fn pg_log_count(world: &DoormanWorld, needle: &str) -> usize {
+    let path = pg_log_path(world);
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    content.matches(needle).count()
+}
+
+/// Truncate `pg.log` so subsequent assertions only see log lines emitted from
+/// this point onward. PostgreSQL keeps its `stderr` file descriptor open past
+/// the truncation, which is exactly the behaviour we want (new lines are
+/// appended from offset zero again).
+#[when(regex = r#"^we truncate PostgreSQL log$"#)]
+pub async fn truncate_postgres_log(world: &mut DoormanWorld) {
+    let path = pg_log_path(world);
+    // Ignore NotFound: if the log does not exist yet there is nothing to truncate.
+    match std::fs::File::create(&path) {
+        Ok(_) => eprintln!("Truncated PostgreSQL log at {:?}", path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("PostgreSQL log at {:?} does not exist yet, skipping", path)
+        }
+        Err(err) => panic!("Failed to truncate PostgreSQL log at {:?}: {}", path, err),
+    }
+}
+
+/// Assert an exact occurrence count of a literal substring in `pg.log`.
+///
+/// Requires the scenario to start PostgreSQL with `log_statement = 'all'`
+/// (via `PostgreSQL started with options "-c log_statement=all"`), otherwise
+/// DDL/utility statements like `RESET ALL` are never written to the log and
+/// every count is zero.
+#[then(regex = r#"^PostgreSQL log should contain exactly (\d+) occurrences of "([^"]+)"$"#)]
+pub async fn pg_log_should_contain_exactly(
+    world: &mut DoormanWorld,
+    expected: String,
+    needle: String,
+) {
+    let expected: usize = expected.parse().expect("Invalid count");
+    let actual = pg_log_count(world, &needle);
+    if actual != expected {
+        let path = pg_log_path(world);
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        panic!(
+            "PostgreSQL log expected {expected} occurrences of {needle:?}, \
+             got {actual}. Full log:\n{content}"
+        );
+    }
+}
+
+/// Assert that a literal substring is absent from `pg.log`.
+#[then(regex = r#"^PostgreSQL log should not contain "([^"]+)"$"#)]
+pub async fn pg_log_should_not_contain(world: &mut DoormanWorld, needle: String) {
+    pg_log_should_contain_exactly(world, "0".to_string(), needle).await;
+}
+
+/// Assert that a literal substring is present at least once.
+#[then(regex = r#"^PostgreSQL log should contain "([^"]+)"$"#)]
+pub async fn pg_log_should_contain(world: &mut DoormanWorld, needle: String) {
+    let actual = pg_log_count(world, &needle);
+    if actual == 0 {
+        let path = pg_log_path(world);
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        panic!(
+            "PostgreSQL log expected to contain {needle:?}, but it was missing. \
+             Full log:\n{content}"
+        );
+    }
 }

--- a/tests/bdd/features/client-session-reset-cleanup.feature
+++ b/tests/bdd/features/client-session-reset-cleanup.feature
@@ -1,0 +1,137 @@
+@rust @rust-3 @client-session-reset-cleanup
+Feature: Client session reset batch suppresses doorman-side cleanup
+  When a client (e.g. jackc/pgx on an internal context deadline) keeps the
+  server connection alive by running a self-cleanup batch such as
+
+      SET SESSION AUTHORIZATION DEFAULT;
+      RESET ALL;
+      CLOSE ALL;
+      UNLISTEN *;
+      SELECT pg_advisory_unlock_all();
+      DISCARD PLANS;
+      DISCARD SEQUENCES;
+      DISCARD TEMP;
+
+  pg_doorman must recognise that the session is already clean and skip the
+  checkin-time `RESET ROLE; RESET ALL; ...` round-trip it would otherwise send.
+  Without this recognition every dangling client query triples the traffic to
+  PostgreSQL: the original (stuck) query, the client's self-reset batch, and a
+  redundant pg_doorman reset.
+
+  Each scenario starts PostgreSQL with `log_statement = 'all'` and asserts the
+  absence or presence of pg_doorman's cleanup statements in the server log.
+  The `RESET ROLE` prefix is used as a marker because pg_doorman always prefixes
+  its cleanup batch with `RESET ROLE;` and clients from the real world do not
+  issue it.
+
+  Background:
+    Given PostgreSQL started with options "-c log_statement=all -c logging_collector=off" and pg_hba.conf:
+      """
+      local all all trust
+      host all all 127.0.0.1/32 trust
+      """
+    And fixtures from "tests/fixture.sql" applied
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 2
+
+      [pools.example_db_session]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      server_database = "example_db"
+      pool_mode = "session"
+
+      [[pools.example_db_session.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 2
+      """
+
+  @client-session-reset-cleanup-pgx-batch
+  Scenario: pgx-style session reset batch does not trigger a second server cleanup
+    When we create session "one" to pg_doorman as "example_user_1" with password "" and database "example_db"
+    # Warm the pool with a trivial query so that server auth and any startup
+    # chatter is already in the log before we start asserting on it.
+    And we send SimpleQuery "SELECT 1" to session "one"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    # Exactly the batch jackc/pgx emits on an internal context deadline.
+    And we send SimpleQuery "SET SESSION AUTHORIZATION DEFAULT; RESET ALL; CLOSE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD SEQUENCES; DISCARD TEMP" to session "one"
+    And we sleep 300ms
+    # Client batch itself still shows up once — that is the one we expect.
+    Then PostgreSQL log should contain exactly 1 occurrences of "RESET ALL"
+    # pg_doorman's checkin cleanup would have prefixed its batch with RESET ROLE.
+    # Its absence proves the second cleanup was suppressed.
+    And PostgreSQL log should not contain "RESET ROLE"
+
+  @client-session-reset-cleanup-real-set-still-cleans
+  Scenario: a genuine SET still arms the checkin cleanup
+    # Baseline: if the client actually mutates session state and does not
+    # follow up with RESET/DISCARD, pg_doorman must still clean up on checkin.
+    # This guards against the fix over-correcting and swallowing real cleanups.
+    When we create session "two" to pg_doorman as "example_user_1" with password "" and database "example_db"
+    And we send SimpleQuery "SELECT 1" to session "two"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    And we send SimpleQuery "SET statement_timeout = 1000" to session "two"
+    And we sleep 300ms
+    # Client sent `RESET ALL` zero times — the one we expect is pg_doorman's.
+    Then PostgreSQL log should contain exactly 1 occurrences of "RESET ALL"
+    And PostgreSQL log should contain "RESET ROLE"
+
+  @client-session-reset-cleanup-discard-all
+  Scenario: DISCARD ALL after SET suppresses doorman-side cleanup (session mode)
+    # DISCARD ALL cannot run inside an implicit transaction block, so it has to
+    # be sent as a standalone SimpleQuery. That only works with session mode,
+    # where pg_doorman keeps the same server connection across multiple client
+    # queries and defers checkin_cleanup until the client disconnects.
+    When we create session "three" to pg_doorman as "example_user_1" with password "" and database "example_db_session"
+    And we send SimpleQuery "SELECT 1" to session "three"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    # SET arms set-cleanup; a subsequent DISCARD ALL in the same session must
+    # disarm every cleanup flag because DISCARD ALL is semantically
+    # `RESET ALL; DEALLOCATE ALL; CLOSE ALL; UNLISTEN *; ...`.
+    And we send SimpleQuery "SET statement_timeout = 1000" to session "three"
+    And we send SimpleQuery "DISCARD ALL" to session "three"
+    # Close the session so pg_doorman returns the server connection and runs
+    # checkin_cleanup — which must be a no-op thanks to the DISCARD ALL disarm.
+    And we close session "three"
+    And we sleep 300ms
+    Then PostgreSQL log should contain "DISCARD ALL"
+    # No `RESET ALL` from either side: client did not issue one, and pg_doorman
+    # learned from the DISCARD ALL tag that the session is already clean.
+    And PostgreSQL log should not contain "RESET ROLE"
+    And PostgreSQL log should contain exactly 0 occurrences of "RESET ALL"
+
+  @client-session-reset-cleanup-close-all-disarms-declare
+  Scenario: CLOSE ALL in the same batch as DECLARE suppresses declare cleanup
+    When we create session "four" to pg_doorman as "example_user_1" with password "" and database "example_db"
+    And we send SimpleQuery "SELECT 1" to session "four"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    # DECLARE CURSOR arms declare cleanup (CLOSE ALL on checkin); the same batch
+    # explicitly closes every cursor, so pg_doorman must recognise the server
+    # state is already clean and skip its own CLOSE ALL.
+    And we send SimpleQuery "BEGIN; DECLARE doorman_cur CURSOR FOR SELECT 1; CLOSE ALL; COMMIT" to session "four"
+    And we sleep 300ms
+    # Sanity-check the client batch is actually in the log (PostgreSQL logs the
+    # whole simple-query string on one line when log_statement = 'all').
+    Then PostgreSQL log should contain "DECLARE doorman_cur"
+    # And the marker for pg_doorman's own checkin cleanup is absent.
+    And PostgreSQL log should not contain "RESET ROLE"

--- a/tests/bdd/features/client-session-reset-cleanup.feature
+++ b/tests/bdd/features/client-session-reset-cleanup.feature
@@ -39,6 +39,8 @@ Feature: Client session reset batch suppresses doorman-side cleanup
       admin_username = "admin"
       admin_password = "admin"
       pg_hba.content = "host all all 127.0.0.1/32 trust"
+      prepared_statements = true
+      prepared_statements_cache_size = 100
 
       [pools.example_db]
       server_host = "127.0.0.1"
@@ -134,4 +136,72 @@ Feature: Client session reset batch suppresses doorman-side cleanup
     # whole simple-query string on one line when log_statement = 'all').
     Then PostgreSQL log should contain "DECLARE doorman_cur"
     # And the marker for pg_doorman's own checkin cleanup is absent.
+    And PostgreSQL log should not contain "RESET ROLE"
+
+  @client-session-reset-cleanup-per-guc-reset
+  Scenario: Per-GUC RESET disarms set-cleanup
+    # PostgreSQL returns the same `RESET` tag for `RESET ALL` and `RESET foo`,
+    # so a per-GUC RESET after a SET on the same GUC leaves the session clean
+    # as far as pg_doorman is concerned. Documents the intentional trade-off:
+    # `SET a=1; SET b=2; RESET a;` would also be treated as clean, because
+    # pg_doorman only tracks a single cleanup bit and cannot distinguish which
+    # GUCs are still modified.
+    When we create session "five" to pg_doorman as "example_user_1" with password "" and database "example_db_session"
+    And we send SimpleQuery "SELECT 1" to session "five"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    And we send SimpleQuery "SET statement_timeout = 1000" to session "five"
+    And we send SimpleQuery "RESET statement_timeout" to session "five"
+    And we close session "five"
+    And we sleep 300ms
+    Then PostgreSQL log should contain "RESET statement_timeout"
+    And PostgreSQL log should not contain "RESET ROLE"
+
+  @client-session-reset-cleanup-single-close-keeps-armed
+  Scenario: Closing one named cursor does not disarm declare-cleanup
+    # Only `CLOSE CURSOR ALL` carries the disarm semantics. Closing a single
+    # named cursor emits `CLOSE CURSOR` (no ALL), which leaves other cursors
+    # open and must not clear the cleanup flag. pg_doorman has to follow up
+    # with its own `CLOSE ALL` on checkin.
+    When we create session "six" to pg_doorman as "example_user_1" with password "" and database "example_db"
+    And we send SimpleQuery "SELECT 1" to session "six"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    And we send SimpleQuery "BEGIN; DECLARE doorman_c1 CURSOR FOR SELECT 1; DECLARE doorman_c2 CURSOR FOR SELECT 2; CLOSE doorman_c1; COMMIT" to session "six"
+    And we sleep 300ms
+    # The client closed only c1 — c2 is still defined on the server until the
+    # implicit transaction ended via COMMIT, so pg_doorman stayed armed and
+    # issued its own cleanup batch.
+    Then PostgreSQL log should contain "RESET ROLE"
+    And PostgreSQL log should contain "CLOSE ALL"
+
+  @client-session-reset-cleanup-error-arms-prepare
+  Scenario: PostgreSQL error arms prepare-cleanup, forcing DEALLOCATE ALL on checkin
+    # Baseline for the prepare-cleanup path: an ErrorResponse while the
+    # prepared-statement cache is enabled sets `needs_cleanup_prepare`, and
+    # pg_doorman must still issue `DEALLOCATE ALL` on checkin.
+    When we create session "seven" to pg_doorman as "example_user_1" with password "" and database "example_db_session"
+    And we send SimpleQuery "SELECT 1" to session "seven"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    And we send SimpleQuery "SELECT 1/0" to session "seven" expecting error
+    And we close session "seven"
+    And we sleep 300ms
+    Then PostgreSQL log should contain "DEALLOCATE ALL"
+
+  @client-session-reset-cleanup-discard-after-error
+  Scenario: DISCARD ALL after a PostgreSQL error disarms prepare-cleanup
+    # After the error arms `needs_cleanup_prepare`, a subsequent DISCARD ALL
+    # clears every cleanup flag. No redundant `DEALLOCATE ALL` on checkin.
+    When we create session "eight" to pg_doorman as "example_user_1" with password "" and database "example_db_session"
+    And we send SimpleQuery "SELECT 1" to session "eight"
+    And we sleep 100ms
+    When we truncate PostgreSQL log
+    And we send SimpleQuery "SELECT 1/0" to session "eight" expecting error
+    And we send SimpleQuery "DISCARD ALL" to session "eight"
+    And we close session "eight"
+    And we sleep 300ms
+    Then PostgreSQL log should contain "DISCARD ALL"
+    # Neither the client nor pg_doorman issued DEALLOCATE ALL.
+    And PostgreSQL log should contain exactly 0 occurrences of "DEALLOCATE ALL"
     And PostgreSQL log should not contain "RESET ROLE"


### PR DESCRIPTION
## Problem

When a client (for example, `jackc/pgx` on an internal context deadline)
keeps the server connection alive by running its own cleanup batch instead
of closing the connection:

```sql
SET SESSION AUTHORIZATION DEFAULT;
RESET ALL;
CLOSE ALL;
UNLISTEN *;
SELECT pg_advisory_unlock_all();
DISCARD PLANS;
DISCARD SEQUENCES;
DISCARD TEMP;
```

pg_doorman saw only the `SET` tag (from `SET SESSION AUTHORIZATION DEFAULT`),
marked the connection as dirty, and sent its own `RESET ROLE; RESET ALL;`
when the connection returned to the pool. Every dangling client query sent
**three** statements to PostgreSQL: the original query, the client's cleanup
batch, and pg_doorman's redundant reset. On hot pools this added noticeable
CPU and lock contention on `RESET ALL`.

## Fix

The `CommandComplete` handler now recognises tags that restore the session
to a clean state and clears the matching `needs_cleanup_*` flags:

- `RESET` (covers both `RESET ALL` and per-GUC `RESET foo.bar`) clears
  `needs_cleanup_set`.
- `CLOSE CURSOR ALL` clears `needs_cleanup_declare`.
- `DEALLOCATE ALL` clears `needs_cleanup_prepare` and drops the LRU of
  prepared statements.
- `DISCARD ALL` clears every flag and drops the LRU.

When the client has already cleaned up the session, `checkin_cleanup`
becomes a no-op. Baseline behaviour is preserved: a `SET` without a
follow-up reset still provokes `RESET ROLE; RESET ALL;` on checkin.

Tags were verified empirically against PostgreSQL 16 — in particular,
`RESET ALL` emits the `RESET\0` tag, `CLOSE ALL` emits `CLOSE CURSOR ALL\0`,
and `DISCARD ALL` emits `DISCARD ALL\0`.
