### PR TITLE
docs: clarify worker_cpu_affinity_pinning description

### DIFF
--- a/pg_doorman.toml
+++ b/pg_doorman.toml
@@ -180,7 +180,7 @@ log_client_disconnections = true
 # Default: 4
 worker_threads = 4
 
-# Automatically pin workers to different CPUs.
+# Bind each worker thread to a separate CPU core. By default, worker threads are not bound to any specific CPU.
 # Default: false
 worker_cpu_affinity_pinning = false
 

--- a/pg_doorman.yaml
+++ b/pg_doorman.yaml
@@ -218,7 +218,7 @@ general:
   # Default: 4
   worker_threads: 4
 
-  # Automatically pin workers to different CPUs.
+  # Bind each worker thread to a separate CPU core. By default, worker threads are not bound to any specific CPU.
   # Default: false
   worker_cpu_affinity_pinning: false
 

--- a/src/app/generate/fields.yaml
+++ b/src/app/generate/fields.yaml
@@ -622,9 +622,9 @@ fields:
 
     worker_cpu_affinity_pinning:
       config:
-        en: "Automatically pin workers to different CPUs."
-        ru: "Автоматически привязывать воркеры к разным CPU."
-      doc: "Automatically assign workers to different CPUs (man 3 cpu_set)."
+        en: "Bind each worker thread to a separate CPU core. By default, worker threads are not bound to any specific CPU."
+        ru: "Привязать каждый worker thread к отдельному ядру CPU. По умолчанию потоки не привязаны к конкретным ядрам."
+      doc: "Bind each worker thread to a separate CPU core (sched_setaffinity). Disabled when fewer than 3 cores are available."
       default: "false"
 
     tokio_settings_note:


### PR DESCRIPTION
## Summary

- Clarify `worker_cpu_affinity_pinning` config description

The old wording "Automatically pin workers to different CPUs" was ambiguous — it could be read as workers being auto-pinned by default.

New wording matches nginx convention: "Bind each worker thread to a separate CPU core. By default, worker threads are not bound to any specific CPU."

Updated in: `fields.yaml` (doc generator source), `pg_doorman.toml`, `pg_doorman.yaml`.