### PR TITLE
Add Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Scrape `http://host:9127/` to collect metrics. Key metrics:
 | `pg_doorman_total_memory` | — | Process memory usage (bytes)                |
 | `pg_doorman_connection_count` | type | Connections by type (plain / tls / total)   |
 
+A ready-to-import [Grafana dashboard](grafana/) is included — pool utilization, latency percentiles, coordinator state, prepared statement cache, and auth query metrics.
+
 ## Signals & Zero-Downtime Upgrade
 
 | Signal | Effect |

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,42 @@
+# pg_doorman Grafana dashboard
+
+## Import
+
+Import `pg_doorman.json` into Grafana. Select your Prometheus datasource when prompted.
+
+pg_doorman must have the Prometheus exporter enabled:
+
+```toml
+[prometheus]
+enabled = true
+port = 9127
+```
+
+## Regenerate
+
+```bash
+pip install grafana-foundation-sdk
+python3 generate_dashboard.py > pg_doorman.json
+```
+
+For portable dashboards (grafana.com import):
+
+```bash
+GRAFANA_DS_UID='${DS_PROMETHEUS}' python3 generate_dashboard.py > pg_doorman.json
+```
+
+## Demo
+
+Local demo with PostgreSQL, pg_doorman, Prometheus, Grafana, and pgbench load:
+
+```bash
+cd demo/
+docker compose up -d
+```
+
+- Grafana: http://localhost:3000
+- Prometheus: http://localhost:19090
+
+```bash
+docker compose down -v
+```

--- a/grafana/demo/docker-compose.yml
+++ b/grafana/demo/docker-compose.yml
@@ -1,0 +1,81 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres_secret
+      PGDATA: /var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./pg_hba.conf:/etc/postgresql/pg_hba.conf
+    command: postgres -c hba_file=/etc/postgresql/pg_hba.conf
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  pg_doorman:
+    image: pg_doorman:ubuntu2204-tls
+    ports:
+      - "6432:6432"
+      - "9127:9127"
+    command: ["pg_doorman", "/etc/pg_doorman/pg_doorman.toml"]
+    volumes:
+      - ./pg_doorman.toml:/etc/pg_doorman/pg_doorman.toml
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    stop_signal: SIGINT
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "19090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - pg_doorman
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ../pg_doorman.json:/var/lib/grafana/dashboards/pg_doorman.json
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  pgbench:
+    image: postgres:16
+    volumes:
+      - ./pgbench.sh:/pgbench.sh
+    entrypoint: ["bash", "/pgbench.sh"]
+    environment:
+      PGPASSWORD: app_pass
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: always
+
+  pgbench2:
+    image: postgres:16
+    volumes:
+      - ./pgbench2.sh:/pgbench.sh
+    entrypoint: ["bash", "/pgbench.sh"]
+    environment:
+      PGPASSWORD: app_pass_2
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: always

--- a/grafana/demo/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/demo/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: pg_doorman
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/demo/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/demo/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/grafana/demo/init.sql
+++ b/grafana/demo/init.sql
@@ -1,0 +1,15 @@
+SET password_encryption = 'md5';
+CREATE USER app_user WITH PASSWORD 'app_pass' SUPERUSER;
+CREATE USER app_user_2 WITH PASSWORD 'app_pass_2' SUPERUSER;
+CREATE USER doorman_auth WITH PASSWORD 'auth_secret';
+CREATE DATABASE app_db OWNER app_user;
+
+-- Auth query function
+\c app_db
+CREATE OR REPLACE FUNCTION pg_doorman_auth(p_username TEXT)
+RETURNS TABLE(username TEXT, password TEXT) AS $$
+BEGIN
+    RETURN QUERY SELECT usename::TEXT, passwd::TEXT FROM pg_shadow WHERE usename = p_username;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+GRANT EXECUTE ON FUNCTION pg_doorman_auth(TEXT) TO doorman_auth;

--- a/grafana/demo/pg_doorman.toml
+++ b/grafana/demo/pg_doorman.toml
@@ -1,0 +1,36 @@
+[general]
+host = "0.0.0.0"
+port = 6432
+admin_username = "admin"
+admin_password = "admin"
+pool_mode = "transaction"
+shutdown_timeout = 10000
+pg_hba = { content = "host all all 0.0.0.0/0 trust" }
+
+[prometheus]
+enabled = true
+host = "0.0.0.0"
+port = 9127
+
+[pools.app_db]
+server_host = "postgres"
+server_port = 5432
+max_db_connections = 15
+
+[[pools.app_db.users]]
+username = "app_user"
+password = "md51eb270aee6c83fc6a7a27519d5fa0c9e"
+pool_size = 10
+
+[[pools.app_db.users]]
+username = "app_user_2"
+password = "md5a05c39aae7f2198b1f06c4291434ee85"
+pool_size = 10
+
+[pools.app_db.auth_query]
+query = "SELECT username, password FROM pg_doorman_auth($1)"
+user = "doorman_auth"
+password = "auth_secret"
+database = "app_db"
+workers = 2
+cache_ttl = 60000

--- a/grafana/demo/pg_hba.conf
+++ b/grafana/demo/pg_hba.conf
@@ -1,0 +1,5 @@
+# TYPE  DATABASE  USER  ADDRESS       METHOD
+local   all       all                 trust
+host    all       all   127.0.0.1/32  trust
+host    all       all   ::1/128       trust
+host    all       all   0.0.0.0/0     md5

--- a/grafana/demo/pgbench.sh
+++ b/grafana/demo/pgbench.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Wait for pg_doorman to be ready
+until pg_isready -h pg_doorman -p 6432 -U app_user -d app_db 2>/dev/null; do
+  sleep 1
+done
+
+# Initialize pgbench tables directly on postgres (not through the pooler)
+PGPASSWORD=app_pass pgbench -i -h postgres -p 5432 -U app_user app_db 2>/dev/null || true
+
+# Run continuous load through pg_doorman with prepared statements
+exec pgbench -h pg_doorman -p 6432 -U app_user -c 20 -j 4 -T 999999 -P 10 \
+  -M prepared app_db

--- a/grafana/demo/pgbench2.sh
+++ b/grafana/demo/pgbench2.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Wait for pg_doorman to be ready
+until pg_isready -h pg_doorman -p 6432 -U app_user_2 -d app_db 2>/dev/null; do
+  sleep 1
+done
+
+# Run continuous load as second user with prepared statements
+exec pgbench -h pg_doorman -p 6432 -U app_user_2 -c 10 -j 2 -T 999999 -P 10 \
+  -M prepared app_db

--- a/grafana/demo/prometheus.yml
+++ b/grafana/demo/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: pg_doorman
+    static_configs:
+      - targets: ['pg_doorman:9127']

--- a/grafana/generate_dashboard.py
+++ b/grafana/generate_dashboard.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Generate pg_doorman Grafana dashboard JSON from code.
+
+Usage:
+    python3 generate_dashboard.py > dashboards/pg_doorman.json
+"""
+
+import json
+from grafana_foundation_sdk.builders import (
+    dashboard as dash_builder,
+    timeseries,
+    stat,
+    gauge,
+    prometheus,
+    table,
+    common as common_builder,
+)
+from grafana_foundation_sdk.builders.dashboard import ThresholdsConfig as ThresholdsBuilder
+from grafana_foundation_sdk.models import dashboard as dash_models
+from grafana_foundation_sdk.models.common import (
+    BigValueColorMode,
+    LegendDisplayMode,
+    LegendPlacement,
+)
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+
+
+# For portable dashboards (grafana.com): "${DS_PROMETHEUS}"
+# For provisioned dashboards (docker compose demo): "prometheus"
+import os
+DS = os.environ.get("GRAFANA_DS_UID", "prometheus")
+
+
+def prom(expr: str, legend: str = "") -> prometheus.Dataquery:
+    q = prometheus.Dataquery().expr(expr)
+    if legend:
+        q = q.legend_format(legend)
+    return q
+
+
+def stat_panel(title: str, expr: str, unit: str = "", w: int = 4,
+               thresholds=None, color_mode="background", desc: str = ""):
+    p = (
+        stat.Panel()
+        .title(title)
+        .datasource(dash_models.DataSourceRef(uid=DS))
+        .with_target(prom(expr))
+        .height(4)
+        .span(w)
+    )
+    if desc:
+        p = p.description(desc)
+    if unit:
+        p = p.unit(unit)
+    if thresholds:
+        tb = ThresholdsBuilder().mode(dash_models.ThresholdsMode.ABSOLUTE).steps(
+            [dash_models.Threshold(color=c, value=v) for v, c in thresholds]
+        )
+        p = p.thresholds(tb)
+    if color_mode:
+        p = p.color_mode(BigValueColorMode(color_mode))
+    return p
+
+
+def ts_panel(title: str, targets: list, unit: str = "", w: int = 12,
+             desc: str = "", legend_calcs=None):
+    if legend_calcs is None:
+        legend_calcs = ["min", "max", "lastNotNull"]
+    p = (
+        timeseries.Panel()
+        .title(title)
+        .datasource(dash_models.DataSourceRef(uid=DS))
+        .height(8)
+        .span(w)
+        .legend(
+            common_builder.VizLegendOptions()
+            .show_legend(True)
+            .display_mode(LegendDisplayMode.TABLE)
+            .placement(LegendPlacement.BOTTOM)
+            .calcs(legend_calcs)
+        )
+    )
+    if desc:
+        p = p.description(desc)
+    for t in targets:
+        p = p.with_target(t)
+    if unit:
+        p = p.unit(unit)
+    return p
+
+
+def collapsed_row(title: str):
+    return dash_builder.Row(title).collapsed(True)
+
+
+def expanded_row(title: str):
+    return dash_builder.Row(title).collapsed(False)
+
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+var_datasource = (
+    dash_builder.DatasourceVariable("DS_PROMETHEUS")
+    .label("Prometheus")
+    .type("prometheus")
+    .hide(dash_models.VariableHide.HIDE_VARIABLE)
+)
+
+var_instance = (
+    dash_builder.QueryVariable("instance")
+    .label("Instance")
+    .query("label_values(pg_doorman_total_memory, instance)")
+    .datasource(dash_models.DataSourceRef(uid=DS))
+    .include_all(True)
+    .multi(True)
+    .refresh(dash_models.VariableRefresh.ON_TIME_RANGE_CHANGED)
+)
+
+var_database = (
+    dash_builder.QueryVariable("database")
+    .label("Database")
+    .query('label_values(pg_doorman_pools_clients{instance=~"$instance"}, database)')
+    .datasource(dash_models.DataSourceRef(uid=DS))
+    .include_all(True)
+    .multi(True)
+    .refresh(dash_models.VariableRefresh.ON_TIME_RANGE_CHANGED)
+)
+
+var_user = (
+    dash_builder.QueryVariable("user")
+    .label("User")
+    .query('label_values(pg_doorman_pools_clients{instance=~"$instance", database=~"$database"}, user)')
+    .datasource(dash_models.DataSourceRef(uid=DS))
+    .include_all(True)
+    .multi(True)
+    .refresh(dash_models.VariableRefresh.ON_TIME_RANGE_CHANGED)
+)
+
+# Selector shorthand
+S = 'instance=~"$instance", user=~"$user", database=~"$database"'
+SD = 'instance=~"$instance", database=~"$database"'
+
+# ---------------------------------------------------------------------------
+# Row 1: Overview
+# ---------------------------------------------------------------------------
+row1 = expanded_row("Overview")
+
+p_waiting = stat_panel(
+    "Waiting Clients",
+    f'sum(pg_doorman_pools_clients{{status="waiting", {S}}})',
+    thresholds=[(None, "green"), (1, "yellow"), (10, "red")],
+    desc="Clients queued for a server connection. Sustained >0 means pool_size is insufficient — increase pool_size or reduce query duration.",
+)
+p_wait_time = stat_panel(
+    "Avg Wait Time",
+    f'max(pg_doorman_pools_avg_wait_time{{{S}}})',
+    unit="ms",
+    thresholds=[(None, "green"), (5, "yellow"), (50, "red")],
+    desc="Max across pools of average queue wait — adds directly to application latency. Above 50ms: check Pool Utilization and raise pool_size.",
+)
+p_query_p99 = stat_panel(
+    "Query p99",
+    f'max(pg_doorman_pools_queries_percentile{{percentile="99", {S}}})',
+    unit="ms",
+    thresholds=[(None, "green"), (50, "yellow"), (200, "red")],
+    desc="99th percentile server-side query time (excludes queue wait). Spike without QPS increase — check pg_stat_activity for locks or vacuum.",
+)
+p_utilization = stat_panel(
+    "Pool Utilization",
+    f'sum(pg_doorman_pools_servers{{status="active", {S}}}) / sum(pg_doorman_pool_size{{{S}}}) * 100',
+    unit="percent",
+    thresholds=[(None, "green"), (70, "yellow"), (90, "red")],
+    desc="Active server connections / pool_size. Above 70%: anticipate saturation. Above 90%: clients are queuing.",
+)
+p_memory = stat_panel(
+    "Memory",
+    'pg_doorman_total_memory{instance=~"$instance"}',
+    unit="bytes",
+    thresholds=[(None, "green"), (536870912, "yellow"), (1073741824, "red")],
+    desc="Process RSS. Sudden growth without new connections usually means unbounded prepared statement cache — check Pool Cache Entries.",
+)
+p_connections = stat_panel(
+    "Total Connections",
+    'pg_doorman_connection_count{type="total", instance=~"$instance"}',
+    thresholds=[(None, "blue")],
+    color_mode="none",
+    desc="Current client connections (all pools). Compare with pool_size for multiplexing ratio — 100:1+ is normal in transaction mode.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 2: Client Load
+# ---------------------------------------------------------------------------
+row2 = expanded_row("Client Load")
+
+p_clients_state = ts_panel(
+    "Clients by State", [
+        prom(f'sum by (status) (pg_doorman_pools_clients{{{S}}})', "{{status}}"),
+    ], w=8,
+    desc="Active (has server), idle (between transactions), waiting (queued). Growing 'waiting' area means pool_size is the bottleneck.",
+)
+p_waiting_ts = ts_panel(
+    "Waiting Clients", [
+        prom(f'pg_doorman_pools_clients{{status="waiting", {S}}}', "{{user}}@{{database}}"),
+    ], w=8,
+    desc="Waiting clients by user@database. Pinpoints which pool needs pool_size increase or query optimization.",
+)
+p_wait_time_ts = ts_panel(
+    "Avg Wait Time", [
+        prom(f'pg_doorman_pools_avg_wait_time{{{S}}}', "{{user}}@{{database}}"),
+    ], unit="ms", w=8,
+    desc="Average queue time per pool. Pool with low wait count but high wait time has slow query turnover.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 3: Server Pool
+# ---------------------------------------------------------------------------
+row3 = expanded_row("Server Pool")
+
+p_servers_state = ts_panel(
+    "Servers by State", [
+        prom(f'sum by (status) (pg_doorman_pools_servers{{{S}}})', "{{status}}"),
+    ], w=8,
+    desc="Backend connections: active (executing query), idle (available for checkout). Idle approaching zero means no headroom for bursts.",
+)
+p_pool_vs_active = ts_panel(
+    "Pool Size vs Active Servers", [
+        prom(f'pg_doorman_pool_size{{{S}}}', "pool_size {{user}}@{{database}}"),
+        prom(f'pg_doorman_pools_servers{{status="active", {S}}}', "active {{user}}@{{database}}"),
+    ], w=8,
+    desc="Active servers overlaid with pool_size ceiling. Gap between lines is spare capacity. When they converge, clients start queuing.",
+)
+p_pool_util_ts = ts_panel(
+    "Pool Utilization %", [
+        prom(f'pg_doorman_pools_servers{{status="active", {S}}} / pg_doorman_pool_size{{{S}}} * 100', "{{user}}@{{database}}"),
+    ], unit="percent", w=8,
+    desc="Active/pool_size ratio over time. Sustained above 70% warrants pool_size increase; above 90% clients are already waiting.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 4: Query Latency
+# ---------------------------------------------------------------------------
+row4 = expanded_row("Query Latency")
+
+p_query_lat = ts_panel(
+    "Query Latency Percentiles", [
+        prom(f'max by (database) (pg_doorman_pools_queries_percentile{{percentile="50", {S}}})', "p50"),
+        prom(f'max by (database) (pg_doorman_pools_queries_percentile{{percentile="90", {S}}})', "p90"),
+        prom(f'max by (database) (pg_doorman_pools_queries_percentile{{percentile="95", {S}}})', "p95"),
+        prom(f'max by (database) (pg_doorman_pools_queries_percentile{{percentile="99", {S}}})', "p99"),
+    ], unit="ms",
+    desc="Server-side query time at p50/p90/p95/p99. p99 diverging from p50 — check pg_stat_activity for lock waits or long-running queries.",
+)
+p_qps = ts_panel(
+    "Queries per Second", [
+        prom(f'rate(pg_doorman_pools_queries_count{{{S}}}[$__rate_interval])', "{{user}}@{{database}}"),
+    ], unit="ops",
+    desc="Query throughput per pool. Flat QPS with rising latency signals PostgreSQL saturation. Rising QPS with stable latency is healthy growth.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 5: Transaction Latency
+# ---------------------------------------------------------------------------
+row5 = expanded_row("Transaction Latency")
+
+p_xact_lat = ts_panel(
+    "Transaction Latency Percentiles", [
+        prom(f'max by (database) (pg_doorman_pools_transactions_percentile{{percentile="50", {S}}})', "p50"),
+        prom(f'max by (database) (pg_doorman_pools_transactions_percentile{{percentile="90", {S}}})', "p90"),
+        prom(f'max by (database) (pg_doorman_pools_transactions_percentile{{percentile="95", {S}}})', "p95"),
+        prom(f'max by (database) (pg_doorman_pools_transactions_percentile{{percentile="99", {S}}})', "p99"),
+    ], unit="ms",
+    desc="End-to-end transaction time including all queries and inter-query gaps. High values with low query latency indicate application-side delays between queries.",
+)
+p_tps = ts_panel(
+    "Transactions per Second", [
+        prom(f'rate(pg_doorman_pools_transactions_count{{{S}}}[$__rate_interval])', "{{user}}@{{database}}"),
+    ], unit="ops",
+    desc="Transaction throughput per pool. Drop with rising latency indicates lock contention or long transactions holding server connections.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 6: Traffic (collapsed)
+# ---------------------------------------------------------------------------
+row6 = collapsed_row("Traffic")
+
+p_bytes_recv = ts_panel(
+    "Bytes Received", [
+        prom(f'rate(pg_doorman_pools_bytes{{direction="received", {S}}}[$__rate_interval])', "{{user}}@{{database}}"),
+    ], unit="Bps",
+    desc="Data rate from clients. Spikes correlate with bulk INSERTs/COPYs.",
+)
+p_bytes_sent = ts_panel(
+    "Bytes Sent", [
+        prom(f'rate(pg_doorman_pools_bytes{{direction="sent", {S}}}[$__rate_interval])', "{{user}}@{{database}}"),
+    ], unit="Bps",
+    desc="Data rate to clients. Large spikes indicate fat result sets — consider LIMIT if unexpected.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 7: Pool Coordinator (collapsed)
+# ---------------------------------------------------------------------------
+row7 = collapsed_row("Pool Coordinator")
+
+p_coord_conns = ts_panel(
+    "Connections vs Max", [
+        prom(f'pg_doorman_pool_coordinator{{type="connections", {SD}}}', "current"),
+        prom(f'pg_doorman_pool_coordinator{{type="max_connections", {SD}}}', "max"),
+    ], w=8,
+    desc="Total backend connections across all user pools vs max_db_connections. When current approaches max, coordinator evicts idle connections from lower-priority pools.",
+)
+p_coord_reserve = ts_panel(
+    "Reserve Pool", [
+        prom(f'pg_doorman_pool_coordinator{{type="reserve_in_use", {SD}}}', "in_use"),
+        prom(f'pg_doorman_pool_coordinator{{type="reserve_pool_size", {SD}}}', "size"),
+    ], w=8,
+    desc="Reserve connections activated when all max_db_connections slots are full. Any usage means primary capacity exhausted — raise max_db_connections.",
+)
+p_coord_events = ts_panel(
+    "Coordinator Events", [
+        prom(f'rate(pg_doorman_pool_coordinator_total{{type="evictions", {SD}}}[$__rate_interval])', "evictions/s"),
+        prom(f'rate(pg_doorman_pool_coordinator_total{{type="reserve_acquisitions", {SD}}}[$__rate_interval])', "reserve_acq/s"),
+        prom(f'rate(pg_doorman_pool_coordinator_total{{type="exhaustions", {SD}}}[$__rate_interval])', "exhaustions/s"),
+    ], w=8,
+    desc="Evictions: idle connections reclaimed across pools (normal). Exhaustions: client errors, no connection available (critical — increase capacity).",
+)
+
+# ---------------------------------------------------------------------------
+# Row 8: Pool Scaling (collapsed)
+# ---------------------------------------------------------------------------
+row8 = collapsed_row("Pool Scaling")
+
+p_inflight = ts_panel(
+    "Inflight Creates", [
+        prom(f'pg_doorman_pool_scaling{{type="inflight_creates", {S}}}', "{{user}}@{{database}}"),
+    ], w=8,
+    desc="Connections mid-handshake (TCP + auth + startup). Sustained high count — PostgreSQL slow to accept, check auth method or backend CPU.",
+)
+p_scaling_events = ts_panel(
+    "Scaling Events", [
+        prom(f'sum by (database) (rate(pg_doorman_pool_scaling_total{{type="creates_started", {S}}}[$__rate_interval]))', "creates/s"),
+        prom(f'sum by (database) (rate(pg_doorman_pool_scaling_total{{type="burst_gate_waits", {S}}}[$__rate_interval]))', "gate_waits/s"),
+        prom(f'sum by (database) (rate(pg_doorman_pool_scaling_total{{type="create_fallback", {S}}}[$__rate_interval]))', "fallback/s"),
+    ], w=8,
+    desc="creates/s: new connections. gate_waits/s: throttled by burst limiter. fallback/s: anticipation missed, created on-demand.",
+)
+p_conn_types = ts_panel(
+    "Connections by Type", [
+        prom('pg_doorman_connection_count{type="plain", instance=~"$instance"}', "plain"),
+        prom('pg_doorman_connection_count{type="tls", instance=~"$instance"}', "tls"),
+        prom('pg_doorman_connection_count{type="cancel", instance=~"$instance"}', "cancel"),
+    ], w=8,
+    desc="Connections by protocol. Track TLS adoption. Elevated cancel count indicates application timeouts.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 9: Prepared Statements (collapsed)
+# ---------------------------------------------------------------------------
+row9 = collapsed_row("Prepared Statements")
+
+p_cache_entries = ts_panel(
+    "Pool Cache Entries", [
+        prom(f'pg_doorman_pool_prepared_cache_entries{{{S}}}', "{{user}}@{{database}}"),
+    ], w=8,
+    desc="Unique prepared statements per pool. Unbounded growth means dynamic statement names — fix the app or cap with prepared_statements_cache_size.",
+)
+p_cache_bytes = ts_panel(
+    "Cache Memory (Pool + Client)", [
+        prom(f'pg_doorman_pool_prepared_cache_bytes{{{S}}}', "pool {{user}}@{{database}}"),
+        prom(f'pg_doorman_clients_prepared_cache_bytes{{{S}}}', "client {{user}}@{{database}}"),
+    ], unit="bytes", w=8,
+    desc="Memory in prepared caches (pool + client). When this dominates total memory, reduce cache size or fix dynamic statement names.",
+)
+p_hit_ratio = ts_panel(
+    "Prepared Statement Hit Ratio", [
+        prom(
+            f'clamp_max('
+            f'sum by (user, database) (pg_doorman_servers_prepared_hits{{{S}}}) / '
+            f'clamp_min(sum by (user, database) (pg_doorman_servers_prepared_hits{{{S}}}) + '
+            f'sum by (user, database) (pg_doorman_servers_prepared_misses{{{S}}}), 1)'
+            f', 1)',
+            "{{user}}@{{database}}",
+        ),
+    ], unit="percentunit", w=8,
+    desc="Cache hits / total lookups. Below 90%: servers frequently re-parse after multiplexing. Ensure consistent statement names.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 10: Auth Query (collapsed)
+# ---------------------------------------------------------------------------
+row10 = collapsed_row("Auth Query")
+
+p_auth_cache = ts_panel(
+    "Auth Cache Hit Rate", [
+        prom(
+            f'clamp_max('
+            f'rate(pg_doorman_auth_query_cache{{type="hits", {SD}}}[$__rate_interval]) / '
+            f'clamp_min(rate(pg_doorman_auth_query_cache{{type="hits", {SD}}}[$__rate_interval]) + '
+            f'rate(pg_doorman_auth_query_cache{{type="misses", {SD}}}[$__rate_interval]), 0.001)'
+            f', 1)',
+            "{{database}}",
+        ),
+    ], unit="percentunit", w=8,
+    desc="Auth lookups served from cache vs PostgreSQL query. Low rate adds latency to every new connection — increase cache_ttl.",
+)
+p_auth_outcomes = ts_panel(
+    "Auth Outcomes", [
+        prom(f'rate(pg_doorman_auth_query_auth{{result="success", {SD}}}[$__rate_interval])', "success/s"),
+        prom(f'rate(pg_doorman_auth_query_auth{{result="failure", {SD}}}[$__rate_interval])', "failure/s"),
+    ], w=8,
+    desc="Auth success vs failure rate. Failure spike after deploy = credential mismatch. Sustained failures = check source IPs in logs.",
+)
+p_dynamic_pools = ts_panel(
+    "Dynamic Pools", [
+        prom(f'pg_doorman_auth_query_dynamic_pools{{type="current", {SD}}}', "current"),
+    ], w=8,
+    desc="Auto-created pools for auth_query users. Unexpected growth indicates wrong database names or unplanned user sprawl.",
+)
+
+# ---------------------------------------------------------------------------
+# Row 11: System (collapsed)
+# ---------------------------------------------------------------------------
+row11 = collapsed_row("System")
+
+p_memory_ts = ts_panel(
+    "Process Memory", [
+        prom('pg_doorman_total_memory{instance=~"$instance"}', "{{instance}}"),
+    ], unit="bytes",
+    desc="Process RSS over time. Correlate with Total Connections and Cache Memory to isolate growth driver.",
+)
+p_sockets = ts_panel(
+    "Sockets by Type", [
+        prom('pg_doorman_sockets{type="tcp", instance=~"$instance"}', "tcp"),
+        prom('pg_doorman_sockets{type="tcp6", instance=~"$instance"}', "tcp6"),
+        prom('pg_doorman_sockets{type="unix", instance=~"$instance"}', "unix"),
+    ],
+    desc="Open sockets by protocol. Count growing faster than connections indicates FD leak — check CLOSE_WAIT via SHOW SOCKETS.",
+)
+
+# ---------------------------------------------------------------------------
+# Build dashboard
+# ---------------------------------------------------------------------------
+d = (
+    dash_builder.Dashboard("pg_doorman")
+    .uid("pg-doorman-overview")
+    .tags(["pg_doorman", "postgresql", "connection-pooler"])
+    .refresh("10s")
+    .time("now-30m", "now")
+    .timezone("browser")
+    .editable()
+    .with_variable(var_datasource)
+    .with_variable(var_instance)
+    .with_variable(var_database)
+    .with_variable(var_user)
+    # Row 1: Overview
+    .with_row(row1)
+    .with_panel(p_waiting)
+    .with_panel(p_wait_time)
+    .with_panel(p_query_p99)
+    .with_panel(p_utilization)
+    .with_panel(p_memory)
+    .with_panel(p_connections)
+    # Row 2: Client Load
+    .with_row(row2)
+    .with_panel(p_clients_state)
+    .with_panel(p_waiting_ts)
+    .with_panel(p_wait_time_ts)
+    # Row 3: Server Pool
+    .with_row(row3)
+    .with_panel(p_servers_state)
+    .with_panel(p_pool_vs_active)
+    .with_panel(p_pool_util_ts)
+    # Row 4: Query Latency
+    .with_row(row4)
+    .with_panel(p_query_lat)
+    .with_panel(p_qps)
+    # Row 5: Transaction Latency
+    .with_row(row5)
+    .with_panel(p_xact_lat)
+    .with_panel(p_tps)
+    # Row 6: Traffic (collapsed)
+    .with_row(row6)
+    .with_panel(p_bytes_recv)
+    .with_panel(p_bytes_sent)
+    # Row 7: Pool Coordinator (collapsed)
+    .with_row(row7)
+    .with_panel(p_coord_conns)
+    .with_panel(p_coord_reserve)
+    .with_panel(p_coord_events)
+    # Row 8: Pool Scaling (collapsed)
+    .with_row(row8)
+    .with_panel(p_inflight)
+    .with_panel(p_scaling_events)
+    .with_panel(p_conn_types)
+    # Row 9: Prepared Statements (collapsed)
+    .with_row(row9)
+    .with_panel(p_cache_entries)
+    .with_panel(p_cache_bytes)
+    .with_panel(p_hit_ratio)
+    # Row 10: Auth Query (collapsed)
+    .with_row(row10)
+    .with_panel(p_auth_cache)
+    .with_panel(p_auth_outcomes)
+    .with_panel(p_dynamic_pools)
+    # Row 11: System (collapsed)
+    .with_row(row11)
+    .with_panel(p_memory_ts)
+    .with_panel(p_sockets)
+)
+
+dashboard_obj = d.build()
+print(json.dumps(dashboard_obj, cls=JSONEncoder, indent=2))

--- a/grafana/pg_doorman.json
+++ b/grafana/pg_doorman.json
@@ -1,0 +1,1827 @@
+{
+  "style": "dark",
+  "editable": true,
+  "graphTooltip": 0,
+  "schemaVersion": 36,
+  "templating": {
+    "list": [
+      {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "type": "datasource",
+        "name": "DS_PROMETHEUS",
+        "hide": 2,
+        "skipUrlSync": false,
+        "label": "Prometheus",
+        "query": "prometheus",
+        "multi": false,
+        "includeAll": false,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "type": "query",
+        "name": "instance",
+        "hide": 0,
+        "skipUrlSync": false,
+        "label": "Instance",
+        "query": "label_values(pg_doorman_total_memory, instance)",
+        "datasource": {
+          "uid": "prometheus"
+        },
+        "multi": true,
+        "refresh": 2,
+        "includeAll": true,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "type": "query",
+        "name": "database",
+        "hide": 0,
+        "skipUrlSync": false,
+        "label": "Database",
+        "query": "label_values(pg_doorman_pools_clients{instance=~\"$instance\"}, database)",
+        "datasource": {
+          "uid": "prometheus"
+        },
+        "multi": true,
+        "refresh": 2,
+        "includeAll": true,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "type": "query",
+        "name": "user",
+        "hide": 0,
+        "skipUrlSync": false,
+        "label": "User",
+        "query": "label_values(pg_doorman_pools_clients{instance=~\"$instance\", database=~\"$database\"}, user)",
+        "datasource": {
+          "uid": "prometheus"
+        },
+        "multi": true,
+        "refresh": 2,
+        "includeAll": true,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      }
+    ]
+  },
+  "annotations": {},
+  "uid": "pg-doorman-overview",
+  "title": "pg_doorman",
+  "tags": [
+    "pg_doorman",
+    "postgresql",
+    "connection-pooler"
+  ],
+  "timezone": "browser",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Overview",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "yellow"
+              },
+              {
+                "value": 10,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(pg_doorman_pools_clients{status=\"waiting\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": ""
+        }
+      ],
+      "title": "Waiting Clients",
+      "description": "Clients queued for a server connection. Sustained >0 means pool_size is insufficient \u2014 increase pool_size or reduce query duration.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 5,
+                "color": "yellow"
+              },
+              {
+                "value": 50,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max(pg_doorman_pools_avg_wait_time{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": ""
+        }
+      ],
+      "title": "Avg Wait Time",
+      "description": "Max across pools of average queue wait \u2014 adds directly to application latency. Above 50ms: check Pool Utilization and raise pool_size.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 50,
+                "color": "yellow"
+              },
+              {
+                "value": 200,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max(pg_doorman_pools_queries_percentile{percentile=\"99\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": ""
+        }
+      ],
+      "title": "Query p99",
+      "description": "99th percentile server-side query time (excludes queue wait). Spike without QPS increase \u2014 check pg_stat_activity for locks or vacuum.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 70,
+                "color": "yellow"
+              },
+              {
+                "value": 90,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(pg_doorman_pools_servers{status=\"active\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}) / sum(pg_doorman_pool_size{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}) * 100",
+          "refId": ""
+        }
+      ],
+      "title": "Pool Utilization",
+      "description": "Active server connections / pool_size. Above 70%: anticipate saturation. Above 90%: clients are queuing.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 536870912,
+                "color": "yellow"
+              },
+              {
+                "value": 1073741824,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_total_memory{instance=~\"$instance\"}",
+          "refId": ""
+        }
+      ],
+      "title": "Memory",
+      "description": "Process RSS. Sudden growth without new connections usually means unbounded prepared statement cache \u2014 check Pool Cache Entries.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "stat",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_connection_count{type=\"total\", instance=~\"$instance\"}",
+          "refId": ""
+        }
+      ],
+      "title": "Total Connections",
+      "description": "Current client connections (all pools). Compare with pool_size for multiplexing ratio \u2014 100:1+ is normal in transaction mode.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Client Load",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (pg_doorman_pools_clients{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "title": "Clients by State",
+      "description": "Active (has server), idle (between transactions), waiting (queued). Growing 'waiting' area means pool_size is the bottleneck.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pools_clients{status=\"waiting\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Waiting Clients",
+      "description": "Waiting clients by user@database. Pinpoints which pool needs pool_size increase or query optimization.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pools_avg_wait_time{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Avg Wait Time",
+      "description": "Average queue time per pool. Pool with low wait count but high wait time has slow query turnover.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Server Pool",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (pg_doorman_pools_servers{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "title": "Servers by State",
+      "description": "Backend connections: active (executing query), idle (available for checkout). Idle approaching zero means no headroom for bursts.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_size{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "pool_size {{user}}@{{database}}"
+        },
+        {
+          "expr": "pg_doorman_pools_servers{status=\"active\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "active {{user}}@{{database}}"
+        }
+      ],
+      "title": "Pool Size vs Active Servers",
+      "description": "Active servers overlaid with pool_size ceiling. Gap between lines is spare capacity. When they converge, clients start queuing.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pools_servers{status=\"active\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"} / pg_doorman_pool_size{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"} * 100",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Pool Utilization %",
+      "description": "Active/pool_size ratio over time. Sustained above 70% warrants pool_size increase; above 90% clients are already waiting.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Query Latency",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (database) (pg_doorman_pools_queries_percentile{percentile=\"50\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_queries_percentile{percentile=\"90\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p90"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_queries_percentile{percentile=\"95\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_queries_percentile{percentile=\"99\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Query Latency Percentiles",
+      "description": "Server-side query time at p50/p90/p95/p99. p99 diverging from p50 \u2014 check pg_stat_activity for lock waits or long-running queries.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_pools_queries_count{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Queries per Second",
+      "description": "Query throughput per pool. Flat QPS with rising latency signals PostgreSQL saturation. Rising QPS with stable latency is healthy growth.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Transaction Latency",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (database) (pg_doorman_pools_transactions_percentile{percentile=\"50\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_transactions_percentile{percentile=\"90\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p90"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_transactions_percentile{percentile=\"95\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "max by (database) (pg_doorman_pools_transactions_percentile{percentile=\"99\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"})",
+          "refId": "",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Transaction Latency Percentiles",
+      "description": "End-to-end transaction time including all queries and inter-query gaps. High values with low query latency indicate application-side delays between queries.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_pools_transactions_count{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Transactions per Second",
+      "description": "Transaction throughput per pool. Drop with rising latency indicates lock contention or long transactions holding server connections.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "Traffic",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_pools_bytes{direction=\"received\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Bytes Received",
+      "description": "Data rate from clients. Spikes correlate with bulk INSERTs/COPYs.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_pools_bytes{direction=\"sent\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Bytes Sent",
+      "description": "Data rate to clients. Large spikes indicate fat result sets \u2014 consider LIMIT if unexpected.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "Pool Coordinator",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_coordinator{type=\"connections\", instance=~\"$instance\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "current"
+        },
+        {
+          "expr": "pg_doorman_pool_coordinator{type=\"max_connections\", instance=~\"$instance\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "max"
+        }
+      ],
+      "title": "Connections vs Max",
+      "description": "Total backend connections across all user pools vs max_db_connections. When current approaches max, coordinator evicts idle connections from lower-priority pools.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 51
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_coordinator{type=\"reserve_in_use\", instance=~\"$instance\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "in_use"
+        },
+        {
+          "expr": "pg_doorman_pool_coordinator{type=\"reserve_pool_size\", instance=~\"$instance\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "size"
+        }
+      ],
+      "title": "Reserve Pool",
+      "description": "Reserve connections activated when all max_db_connections slots are full. Any usage means primary capacity exhausted \u2014 raise max_db_connections.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 51
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_pool_coordinator_total{type=\"evictions\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "evictions/s"
+        },
+        {
+          "expr": "rate(pg_doorman_pool_coordinator_total{type=\"reserve_acquisitions\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "reserve_acq/s"
+        },
+        {
+          "expr": "rate(pg_doorman_pool_coordinator_total{type=\"exhaustions\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "exhaustions/s"
+        }
+      ],
+      "title": "Coordinator Events",
+      "description": "Evictions: idle connections reclaimed across pools (normal). Exhaustions: client errors, no connection available (critical \u2014 increase capacity).",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 51
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "Pool Scaling",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_scaling{type=\"inflight_creates\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Inflight Creates",
+      "description": "Connections mid-handshake (TCP + auth + startup). Sustained high count \u2014 PostgreSQL slow to accept, check auth method or backend CPU.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (database) (rate(pg_doorman_pool_scaling_total{type=\"creates_started\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval]))",
+          "refId": "",
+          "legendFormat": "creates/s"
+        },
+        {
+          "expr": "sum by (database) (rate(pg_doorman_pool_scaling_total{type=\"burst_gate_waits\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval]))",
+          "refId": "",
+          "legendFormat": "gate_waits/s"
+        },
+        {
+          "expr": "sum by (database) (rate(pg_doorman_pool_scaling_total{type=\"create_fallback\", instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}[$__rate_interval]))",
+          "refId": "",
+          "legendFormat": "fallback/s"
+        }
+      ],
+      "title": "Scaling Events",
+      "description": "creates/s: new connections. gate_waits/s: throttled by burst limiter. fallback/s: anticipation missed, created on-demand.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_connection_count{type=\"plain\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "plain"
+        },
+        {
+          "expr": "pg_doorman_connection_count{type=\"tls\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "tls"
+        },
+        {
+          "expr": "pg_doorman_connection_count{type=\"cancel\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "cancel"
+        }
+      ],
+      "title": "Connections by Type",
+      "description": "Connections by protocol. Track TLS adoption. Elevated cancel count indicates application timeouts.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "Prepared Statements",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_prepared_cache_entries{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Pool Cache Entries",
+      "description": "Unique prepared statements per pool. Unbounded growth means dynamic statement names \u2014 fix the app or cap with prepared_statements_cache_size.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 69
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_pool_prepared_cache_bytes{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "pool {{user}}@{{database}}"
+        },
+        {
+          "expr": "pg_doorman_clients_prepared_cache_bytes{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "client {{user}}@{{database}}"
+        }
+      ],
+      "title": "Cache Memory (Pool + Client)",
+      "description": "Memory in prepared caches (pool + client). When this dominates total memory, reduce cache size or fix dynamic statement names.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 69
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "clamp_max(sum by (user, database) (pg_doorman_servers_prepared_hits{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}) / clamp_min(sum by (user, database) (pg_doorman_servers_prepared_hits{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}) + sum by (user, database) (pg_doorman_servers_prepared_misses{instance=~\"$instance\", user=~\"$user\", database=~\"$database\"}), 1), 1)",
+          "refId": "",
+          "legendFormat": "{{user}}@{{database}}"
+        }
+      ],
+      "title": "Prepared Statement Hit Ratio",
+      "description": "Cache hits / total lookups. Below 90%: servers frequently re-parse after multiplexing. Ensure consistent statement names.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 69
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "Auth Query",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "clamp_max(rate(pg_doorman_auth_query_cache{type=\"hits\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval]) / clamp_min(rate(pg_doorman_auth_query_cache{type=\"hits\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval]) + rate(pg_doorman_auth_query_cache{type=\"misses\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval]), 0.001), 1)",
+          "refId": "",
+          "legendFormat": "{{database}}"
+        }
+      ],
+      "title": "Auth Cache Hit Rate",
+      "description": "Auth lookups served from cache vs PostgreSQL query. Low rate adds latency to every new connection \u2014 increase cache_ttl.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 78
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_doorman_auth_query_auth{result=\"success\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "success/s"
+        },
+        {
+          "expr": "rate(pg_doorman_auth_query_auth{result=\"failure\", instance=~\"$instance\", database=~\"$database\"}[$__rate_interval])",
+          "refId": "",
+          "legendFormat": "failure/s"
+        }
+      ],
+      "title": "Auth Outcomes",
+      "description": "Auth success vs failure rate. Failure spike after deploy = credential mismatch. Sustained failures = check source IPs in logs.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 78
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_auth_query_dynamic_pools{type=\"current\", instance=~\"$instance\", database=~\"$database\"}",
+          "refId": "",
+          "legendFormat": "current"
+        }
+      ],
+      "title": "Dynamic Pools",
+      "description": "Auto-created pools for auth_query users. Unexpected growth indicates wrong database names or unplanned user sprawl.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 78
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "collapsed": true,
+      "id": 0,
+      "panels": [],
+      "title": "System",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      }
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_total_memory{instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "Process Memory",
+      "description": "Process RSS over time. Correlate with Total Connections and Cache Memory to isolate growth driver.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "repeatDirection": "h"
+    },
+    {
+      "type": "timeseries",
+      "transparent": false,
+      "transformations": [],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pg_doorman_sockets{type=\"tcp\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "tcp"
+        },
+        {
+          "expr": "pg_doorman_sockets{type=\"tcp6\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "tcp6"
+        },
+        {
+          "expr": "pg_doorman_sockets{type=\"unix\", instance=~\"$instance\"}",
+          "refId": "",
+          "legendFormat": "unix"
+        }
+      ],
+      "title": "Sockets by Type",
+      "description": "Open sockets by protocol. Count growing faster than connections indicates FD leak \u2014 check CLOSE_WAIT via SHOW SOCKETS.",
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "repeatDirection": "h"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- 32-panel Grafana dashboard for pg_doorman monitoring
- Python generator (`grafana-foundation-sdk`)
- Docker Compose demo with live pgbench load

## Dashboard

Import `grafana/pg_doorman.json` into Grafana and select a Prometheus datasource.

**Rows (5 expanded, 6 collapsed):**

| Row | Panels | Focus |
|-----|--------|-------|
| Overview | 6 stat | waiting clients, wait time, p99, utilization, memory, connections |
| Client Load | 3 timeseries | clients by state, waiting per pool, wait time per pool |
| Server Pool | 3 timeseries | servers by state, pool size vs active, utilization % |
| Query Latency | 2 timeseries | p50/p90/p95/p99 + QPS |
| Transaction Latency | 2 timeseries | p50/p90/p95/p99 + TPS |
| Traffic | 2 timeseries | bytes received/sent |
| Pool Coordinator | 3 timeseries | connections vs max, reserve, evictions/exhaustions |
| Pool Scaling | 3 timeseries | inflight creates, scaling events, connection types |
| Prepared Statements | 3 timeseries | cache entries, memory, hit ratio |
| Auth Query | 3 timeseries | cache hit rate, auth outcomes, dynamic pools |
| System | 2 timeseries | process memory, sockets |

All timeseries panels have table legend with min/max/current. Each panel has a description explaining what it means and when to act.

## Demo

```bash
cd grafana/demo/
docker compose up -d
# Grafana: http://localhost:3000
```

Runs: PostgreSQL 16, pg_doorman (transaction mode, pool coordinator, auth query), Prometheus, Grafana, two pgbench workloads (prepared mode, two users).

## Structure

```
grafana/
├── pg_doorman.json          ← dashboard (import this)
├── generate_dashboard.py    ← Python generator
├── README.md
└── demo/                    ← docker compose demo
```