### PR TITLE
Add systemd Type=notify for zero-downtime binary upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"
@@ -63,6 +63,7 @@ postgres = "0.19.10"
 tokio-postgres = "0.7"
 postgres-native-tls = "0.5.1"
 flate2 = "1.0.28"
+sd-notify = "0.4"
 zerocopy = "0.8.24"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 ahash = "0.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ COPY --from=builder /app/target/release/patroni_proxy /usr/bin/patroni_proxy
 WORKDIR /etc/pg_doorman
 ENV RUST_LOG=info
 CMD ["pg_doorman"]
-STOPSIGNAL SIGINT
+# SIGTERM for immediate shutdown in containers.
+# SIGINT in non-TTY triggers binary upgrade (spawns child, PID 1 exits,
+# container dies). SIGTERM avoids this.
+STOPSIGNAL SIGTERM

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 3.5.1 <small>Apr 20, 2026</small>
+
+#### systemd Type=notify support
+
+pg_doorman now sends `sd_notify(READY=1)` on startup and `sd_notify(MAINPID=<child_pid>)` during binary upgrade. With `Type=notify` in the systemd unit, `systemctl reload` performs a zero-downtime binary upgrade without PID tracking issues — systemd follows the new process correctly and does not restart the service.
+
+The shipped `pg_doorman.service` changes from `Type=forking` + `--daemon` to `Type=notify` (foreground). Existing installations using `--daemon` continue to work but do not benefit from client migration.
+
+Docker `STOPSIGNAL` changed from `SIGINT` to `SIGTERM` to prevent binary upgrade in containers (where PID 1 exit kills the container).
+
 ### 3.5.0 <small>Apr 15, 2026</small>
 
 #### Client migration during binary upgrade

--- a/pg_doorman.service
+++ b/pg_doorman.service
@@ -2,21 +2,29 @@
 Description=PgDoorman connection pooling for PostgreSQL (https://github.com/ozontech/pg_doorman)
 
 [Service]
-Type=forking
-Nice=-15
-User=postgres
-Group=postgres
-LimitNOFILE=10000
-# SIGUSR2 = binary upgrade + graceful shutdown (recommended)
-# SIGINT  = binary upgrade + graceful shutdown (legacy, daemon mode only)
-# SIGHUP  = reload configuration
+Type=notify
+# Allow the child process (new binary after upgrade) to send
+# sd_notify messages to systemd. Required for MAINPID handoff
+# during SIGUSR2 binary upgrade.
+NotifyAccess=exec
+ExecStart=/usr/bin/pg_doorman /etc/pg_doorman/pg_doorman.toml
+# SIGUSR2 = binary upgrade + client migration + graceful shutdown
 ExecReload=/bin/kill -SIGUSR2 $MAINPID
 # SIGTERM = immediate shutdown
 ExecStop=/bin/kill -SIGTERM $MAINPID
 SyslogIdentifier=pg_doorman
-ExecStart=/usr/bin/pg_doorman /etc/pg_doorman/pg_doorman.toml --daemon
-Restart=always
-PIDFile=/tmp/pg_doorman.pid
+# mixed: SIGTERM to main PID, SIGKILL to remaining after timeout.
+# During binary upgrade, the child (new pg_doorman) survives because
+# MAINPID was reassigned via sd_notify before the old process exits.
+KillMode=mixed
+TimeoutStopSec=60
+# on-failure: don't restart after clean exit (binary upgrade exits
+# with code 0 after migrating clients to the child process).
+Restart=on-failure
+Nice=-15
+User=postgres
+Group=postgres
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -55,6 +55,12 @@ pub static MIGRATION_TX: std::sync::OnceLock<mpsc::Sender<MigrationPayload>> =
 const MIGRATION_CHANNEL_CAPACITY: usize = 4096;
 
 pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    if args.daemon && std::env::var("NOTIFY_SOCKET").is_ok() {
+        warn!(
+            "--daemon is incompatible with systemd Type=notify. \
+             Remove --daemon from ExecStart or switch to Type=forking."
+        );
+    }
     if args.daemon {
         let pid_file = config.general.daemon_pid_file.clone();
         let daemonize = daemon::lib::Daemonize::new()
@@ -345,6 +351,12 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
         let mut listener = Some(listener);
 
         info!("Accepting connections");
+
+        // Notify systemd that the service is ready to accept connections.
+        // No-op when NOTIFY_SOCKET is not set (non-systemd environments).
+        if let Err(e) = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]) {
+            error!("sd_notify READY failed: {e}. If running under systemd Type=notify, the service will not reach active state.");
+        }
         loop {
             // Create upgrade signal future (SIGUSR2 on unix, never resolves on windows)
             let upgrade_future = async {
@@ -763,7 +775,8 @@ async fn binary_upgrade_and_shutdown(
                 };
 
                 match child_result {
-                    Ok(_child) => {
+                    Ok(child) => {
+                        let child_pid = child.id();
                         unsafe {
                             libc::close(pipe_write_fd);
                             if migration_ok {
@@ -796,6 +809,16 @@ async fn binary_upgrade_and_shutdown(
                                 libc::read(pipe_read_fd, buf.as_mut_ptr() as *mut libc::c_void, 1);
                             }
                             info!("New process signaled readiness");
+
+                            // Tell systemd the new process is now the main PID.
+                            // systemd stops tracking the old process and won't
+                            // restart the service when we exit.
+                            if let Err(e) = sd_notify::notify(
+                                false,
+                                &[sd_notify::NotifyState::MainPid(child_pid.into())],
+                            ) {
+                                warn!("sd_notify MAINPID failed: {e}. systemd may restart the service after old process exits.");
+                            }
                         } else {
                             warn!("Timeout waiting for new process readiness");
                         }


### PR DESCRIPTION
## Summary

`systemctl reload pg_doorman` now works correctly — clients migrate to the new process, systemd tracks the new PID, no duplicate instances, no restart loops.

## Problem

The previous systemd unit (`Type=forking` + `--daemon`) had no client migration. With `Type=simple` (foreground), `systemctl reload` caused:
- Old process exits after migration → systemd thinks service died
- `Restart=always` → systemd starts a NEW instance
- Now two pg_doorman processes running, connections split randomly
- Or: systemd kills entire cgroup (including the new process) via `KillMode=control-group`

## Solution

pg_doorman now sends `sd_notify` messages to systemd:

1. **On startup**: `READY=1` — systemd knows when the pooler is accepting connections
2. **On SIGUSR2**: `MAINPID=<child_pid>` — systemd transfers PID tracking to the new process before the old one exits

`sd-notify` crate (pure Rust, zero deps). No-op when `NOTIFY_SOCKET` is not set (Docker, manual launch, non-systemd systems).

## Service file changes

```diff
-Type=forking
-ExecStart=/usr/bin/pg_doorman /etc/pg_doorman/pg_doorman.toml --daemon
-Restart=always
-PIDFile=/tmp/pg_doorman.pid
+Type=notify
+NotifyAccess=exec
+ExecStart=/usr/bin/pg_doorman /etc/pg_doorman/pg_doorman.toml
+Restart=on-failure
+KillMode=mixed
```

## Docker

`STOPSIGNAL` changed from `SIGINT` to `SIGTERM`. SIGINT in non-TTY containers triggered binary upgrade (fork → PID 1 exits → container dies).

## Backward compatibility

- `--daemon` flag still works. Warns if combined with `NOTIFY_SOCKET`
- Existing `Type=forking` units continue working (no migration, clients drain)
- Non-systemd environments: `sd_notify` is a no-op

## Test plan

- [x] BDD `@client-migration`: 16/16 passed
- [x] BDD `@binary-upgrade-grac-shutdown`: 9/9 passed
- [ ] Manual: `systemctl reload pg_doorman` on staging with pgbench load