### PR TITLE
docs: surface pg_doorman's unique features on the published site

### DIFF
--- a/documentation/en/src/SUMMARY.md
+++ b/documentation/en/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Home](index.md)
+[Comparison](comparison.md)
 
 ---
 
@@ -8,25 +9,53 @@
 
 - [Overview](tutorials/overview.md)
 - [Installation](tutorials/installation.md)
-
-# User Guide
-
 - [Basic Usage](tutorials/basic-usage.md)
-- [Binary Upgrade](tutorials/binary-upgrade.md)
-- [Patroni Proxy](tutorials/patroni-proxy.md)
+
+# Authentication
+
+- [Overview](authentication/overview.md)
+- [Passthrough (default)](authentication/passthrough.md)
+- [auth_query](authentication/auth-query.md)
+- [PAM](authentication/pam.md)
+- [JWT](authentication/jwt.md)
+- [Talos](authentication/talos.md)
+- [pg_hba.conf](authentication/hba.md)
+
+# TLS
+
+- [Client and Server TLS](guides/tls.md)
+
+# Pooling
+
+- [Pool Modes](concepts/pool-modes.md)
+- [Pool Coordinator](concepts/pool-coordinator.md)
+- [Pool Pressure (advanced)](tutorials/pool-pressure.md)
+
+# High Availability
+
 - [Patroni-assisted Fallback](tutorials/patroni-assisted-fallback.md)
-- [Pool Pressure](tutorials/pool-pressure.md)
+- [patroni_proxy](tutorials/patroni-proxy.md)
+
+# Operations
+
+- [Binary Upgrade](tutorials/binary-upgrade.md)
+- [Signals and Reload](operations/signals.md)
 - [Troubleshooting](tutorials/troubleshooting.md)
+
+# Observability
+
+- [Admin Commands](observability/admin-commands.md)
+- [JSON Structured Logging](observability/json-logging.md)
+- [Latency Percentiles](observability/percentiles.md)
 
 # Reference
 
 - [General Settings](reference/general.md)
 - [Pool Settings](reference/pool.md)
-- [Prometheus](reference/prometheus.md)
+- [Prometheus Settings](reference/prometheus.md)
 
 ---
 
 - [Benchmarks](benchmarks.md)
 - [Changelog](changelog.md)
 - [Contributing](tutorials/contributing.md)
-

--- a/documentation/en/src/authentication/auth-query.md
+++ b/documentation/en/src/authentication/auth-query.md
@@ -1,0 +1,117 @@
+# auth_query
+
+Look up user credentials from PostgreSQL itself instead of listing every user in the pool config. Useful when users are provisioned dynamically or rotated frequently.
+
+## Two modes
+
+PgDoorman supports two modes; both are configured in the same `auth_query` block. Choose by whether you set `server_user`:
+
+- **Passthrough mode** (no `server_user`): each authenticated user gets its own backend pool, authenticated as that user. Preserves per-user backend identity for `current_user`, row-level security, and audit logs.
+- **Dedicated mode** (with `server_user`): all dynamic users share a single backend pool authenticated as `server_user`. Trades per-user identity for higher pool reuse and lower connection count.
+
+PgBouncer-style auth_query is dedicated mode. Odyssey supports both. PgDoorman's passthrough mode is the default.
+
+## Passthrough mode
+
+```yaml
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    auth_query:
+      query: "SELECT passwd FROM pg_shadow WHERE usename = $1"
+      user: "postgres"
+      password: "md5..."
+      database: "postgres"
+      cache_ttl: "1h"
+      cache_failure_ttl: "30s"
+```
+
+The query must return a column named `passwd` or `password` containing the MD5 or SCRAM hash. Extra columns are ignored.
+
+`user` and `password` are the credentials PgDoorman uses to run the lookup query. They must have permission to read the credential column. Either grant access to a custom view (recommended) or use a user in `pg_read_server_files` group.
+
+When a client connects as `alice`:
+
+1. PgDoorman runs the query with `$1 = 'alice'` and gets her hash.
+2. Caches the hash in memory for `cache_ttl` seconds.
+3. Performs MD5 or SCRAM passthrough authentication (see [Passthrough](passthrough.md)).
+4. Opens a backend connection authenticated as `alice` with the same hash.
+
+## Dedicated mode
+
+```yaml
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    auth_query:
+      query: "SELECT passwd FROM pg_shadow WHERE usename = $1"
+      user: "auth_lookup"
+      password: "md5..."
+      database: "postgres"
+      server_user: "app"
+      server_password: "md5..."
+      pool_size: 40
+      min_pool_size: 5
+      cache_ttl: "1h"
+```
+
+Setting `server_user` switches the mode. Now:
+
+1. The client authenticates as `alice` against the hash returned by the query.
+2. The backend pool is authenticated as `app` (the `server_user`), and is shared across all dynamic users.
+3. `current_user` in PostgreSQL will always be `app`, regardless of which client connected.
+
+Use this when you have many users (thousands) and per-user backend pools would exhaust PostgreSQL's connection slots.
+
+## Recommended PostgreSQL setup
+
+Avoid using a superuser for the lookup. Create a dedicated function with `SECURITY DEFINER`:
+
+```sql
+CREATE OR REPLACE FUNCTION pg_doorman_lookup(uname text)
+RETURNS TABLE(passwd text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+  SELECT passwd FROM pg_shadow WHERE usename = uname;
+$$;
+
+REVOKE ALL ON FUNCTION pg_doorman_lookup(text) FROM public;
+GRANT EXECUTE ON FUNCTION pg_doorman_lookup(text) TO auth_lookup;
+```
+
+Then in the pool config:
+
+```yaml
+auth_query:
+  query: "SELECT passwd FROM pg_doorman_lookup($1)"
+  user: "auth_lookup"
+  password: "md5..."
+```
+
+## Caching
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `cache_ttl` | `"1h"` | How long a successful lookup is cached. |
+| `cache_failure_ttl` | `"30s"` | How long a failed lookup is cached. Prevents brute-force amplification. |
+| `min_interval` | `"1s"` | Minimum interval between repeated lookups for the same user. |
+
+Duration values are quoted strings: `"1h"`, `"30m"`, `"300s"`. A bare integer is interpreted as milliseconds — `cache_ttl: 3600` would cache for 3.6 seconds, not one hour.
+
+Cache is per-pool, in-memory, evicted on `RELOAD`. Restart or `RELOAD` after rotating a user's password.
+
+## Observability
+
+`SHOW AUTH_QUERY` exposes per-database stats:
+
+```
+database | cache_entries | cache_hits | cache_misses | cache_refetches | rate_limited | auth_success | auth_failure | executor_queries | executor_errors
+```
+
+Prometheus metrics: `pg_doorman_auth_query_cache`, `pg_doorman_auth_query_auth`, `pg_doorman_auth_query_executor`, `pg_doorman_auth_query_dynamic_pools`. See [Admin commands](../observability/admin-commands.md).

--- a/documentation/en/src/authentication/hba.md
+++ b/documentation/en/src/authentication/hba.md
@@ -1,0 +1,128 @@
+# pg_hba.conf
+
+Restrict who can connect to PgDoorman based on source address, database, user, and connection type. Uses the same rule format as PostgreSQL's `pg_hba.conf`.
+
+This is a network-level access control layer that runs **before** credential authentication. A connection rejected by `pg_hba` never gets to the password check.
+
+## Configuration
+
+Three formats. Pick whichever fits your deployment.
+
+### Inline string
+
+```yaml
+general:
+  hba: |
+    hostssl all all 0.0.0.0/0 scram-sha-256
+    host    all all 127.0.0.1/32 trust
+    local   all all              trust
+    host    all all 0.0.0.0/0    reject
+```
+
+### From file
+
+```yaml
+general:
+  hba:
+    path: "/etc/pg_doorman/pg_hba.conf"
+```
+
+The file is read on startup and on `SIGHUP`.
+
+### Inline content under structured key
+
+```yaml
+general:
+  hba:
+    content: |
+      hostssl all all 0.0.0.0/0 scram-sha-256
+      host    all all 127.0.0.1/32 trust
+```
+
+Same as the inline string, useful when you generate the config from templating tools.
+
+## Rule format
+
+Each line:
+
+```
+<connection_type> <database> <user> [<source_cidr>] <method>
+```
+
+**connection_type** — one of:
+
+| Type | Matches |
+| --- | --- |
+| `host` | TCP, with or without TLS |
+| `hostssl` | TCP only when TLS is active |
+| `hostnossl` | TCP only when TLS is **not** active |
+| `local` | Unix domain socket |
+
+**database** — `all`, a specific database name, or a comma-separated list. `replication` is not handled (PgDoorman doesn't support replication passthrough).
+
+**user** — `all`, a specific user, or a comma-separated list. `+groupname` (PostgreSQL role membership) is not supported.
+
+**source_cidr** — IPv4 or IPv6 CIDR. Required for `host`, `hostssl`, `hostnossl`. Not applicable to `local`.
+
+**method** — one of:
+
+| Method | Behavior |
+| --- | --- |
+| `trust` | Skip credential check entirely. The client is admitted with the username it claimed. |
+| `md5` | Force MD5 password authentication. |
+| `scram-sha-256` | Force SCRAM-SHA-256 authentication. |
+| `reject` | Refuse the connection before any credential check. |
+
+Rules are evaluated top to bottom. The first match wins.
+
+## Examples
+
+### Require TLS from the network, allow plain local
+
+```
+hostssl   all all 10.0.0.0/8     scram-sha-256
+hostnossl all all 10.0.0.0/8     reject
+host      all all 127.0.0.1/32   trust
+local     all all                trust
+```
+
+### Per-database ACL
+
+```
+host billing  app_billing  10.0.0.0/8 scram-sha-256
+host billing  all          0.0.0.0/0  reject
+host inventory app_inv     10.0.0.0/8 scram-sha-256
+host all       admin       10.1.1.0/24 scram-sha-256
+host all       all         0.0.0.0/0  reject
+```
+
+### Block legacy MD5 from the open internet
+
+```
+hostssl all all 0.0.0.0/0 scram-sha-256
+host    all all 0.0.0.0/0 reject
+```
+
+If your database stores MD5 hashes only and a client requests SCRAM, authentication fails with a clear error. Switch the database to SCRAM-SHA-256 (`ALTER ROLE ... PASSWORD`) before tightening rules.
+
+## Differences from PostgreSQL's `pg_hba.conf`
+
+- No `replication` keyword (PgDoorman does not pass replication connections).
+- No `peer`, `ident`, `cert`, `gss`, `sspi`, or `pam` methods. PAM is configured per-user with `auth_pam_service`, not via HBA.
+- No `+groupname` user prefix.
+- No regex (`/regex` syntax).
+- IPv6 CIDR is supported. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) is matched against IPv4 rules.
+
+## Reload
+
+```bash
+kill -HUP $(pidof pg_doorman)
+```
+
+Existing connections are not re-evaluated. New connections use the new rules.
+
+## Caveats
+
+- Rules apply to clients connecting **to PgDoorman**, not to PostgreSQL. PostgreSQL's own `pg_hba.conf` still matters for the backend connection.
+- `trust` admits the client without any credential check. The backend still has to authenticate as the pool user — but the client side is unverified. Use `trust` only on networks where the source address is trustworthy (loopback, restricted Unix socket).
+- For LDAP, Kerberos, or `peer` authentication, see [Comparison](../comparison.md#authentication) — these are not supported.

--- a/documentation/en/src/authentication/jwt.md
+++ b/documentation/en/src/authentication/jwt.md
@@ -1,0 +1,89 @@
+# JWT Authentication
+
+Authenticate clients with a JSON Web Token signed by an external identity provider. PgDoorman verifies the token's RSA-SHA256 signature using a public key from disk, checks the `preferred_username` claim, and forwards the connection to PostgreSQL with a configured backend identity.
+
+This fits service-to-database access where short-lived tokens are issued by an OIDC provider, Vault, or an internal token service.
+
+## Configuration
+
+Generate (or obtain) an RSA public key and reference it in the user's `password` field with the `jwt-pkey-fpath:` prefix:
+
+```yaml
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    users:
+      - username: "billing-service"
+        password: "jwt-pkey-fpath:/etc/pg_doorman/jwt-public.pem"
+        server_username: "billing"
+        server_password: "md5..."
+        pool_size: 40
+```
+
+Whatever the client sends as a password is treated as a JWT and verified against `/etc/pg_doorman/jwt-public.pem`. The token must:
+
+- Be signed with RS256 (RSA-SHA256). HS256 and EC variants are not supported.
+- Have a `preferred_username` claim equal to the configured `username` (`billing-service` in the example above).
+- Pass standard `exp` and `nbf` validation.
+
+The backend connection is opened as `billing` with the `server_password` hash. The client's identity (`billing-service`) is decoupled from the database identity (`billing`).
+
+## Generating a key pair
+
+```bash
+openssl genrsa -out jwt-private.pem 2048
+openssl rsa -in jwt-private.pem -pubout -out jwt-public.pem
+```
+
+Keep `jwt-private.pem` on the token issuer. Distribute `jwt-public.pem` to PgDoorman.
+
+## Issuing a token
+
+Any RS256 JWT library works. Example with Python (`PyJWT`):
+
+```python
+import jwt
+import time
+
+private_key = open("jwt-private.pem").read()
+
+token = jwt.encode(
+    {
+        "preferred_username": "billing-service",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,  # 5 minutes
+    },
+    private_key,
+    algorithm="RS256",
+)
+```
+
+The client connects to PgDoorman with `user=billing-service` and `password=<token>`. Most PostgreSQL drivers accept any string in the password field.
+
+## Token rotation
+
+PgDoorman reads the public key file once at startup and on `SIGHUP`. Rotate the key by:
+
+1. Add the new public key to a second user entry with a parallel name.
+2. Reload (`kill -HUP`).
+3. Switch the issuer to the new key.
+4. Remove the old user entry after the grace period.
+
+Or, simpler, replace the file in place and `SIGHUP`. There is no support for multiple keys per user.
+
+## Dispatch order
+
+JWT is the lowest-priority password format: PgDoorman checks `SCRAM-SHA-256$` and `md5` prefixes first, then `jwt-pkey-fpath:`. In practice this only matters if you use a placeholder password — set `auth_pam_service` for PAM, or use the `jwt-pkey-fpath:` prefix exclusively for JWT users.
+
+If the same user has both `auth_pam_service` and a `jwt-pkey-fpath:` password, PAM wins.
+
+See [Overview](overview.md#dispatch-order).
+
+## Caveats
+
+- The `preferred_username` claim must match exactly. There is no claim mapping or aliasing.
+- No JWKS endpoint support: the public key must be on disk.
+- No issuer (`iss`) or audience (`aud`) checks. If you need them, terminate JWT at a sidecar and translate to passthrough.
+- For client identity carrying database role information (e.g., `read_only` vs `read_write`), see [Talos](talos.md).

--- a/documentation/en/src/authentication/overview.md
+++ b/documentation/en/src/authentication/overview.md
@@ -1,0 +1,63 @@
+# Authentication
+
+PgDoorman authenticates clients before forwarding them to PostgreSQL. It supports six methods, dispatched in priority order based on what the client sends and what the pool config defines.
+
+This page explains how PgDoorman picks an authentication method. For setup details, follow the per-method links below.
+
+## Methods at a glance
+
+| Method | When to use | Stores secret in config? |
+| --- | --- | --- |
+| [Passthrough](passthrough.md) (MD5 / SCRAM) | Default. Pool user matches PostgreSQL user. | MD5 hash or SCRAM ClientKey, never plaintext |
+| [auth_query](auth-query.md) | Many users, dynamic onboarding. Lookup credentials from PostgreSQL itself. | One service-user secret only |
+| [PAM](pam.md) | OS-level authentication (LDAP via `pam_ldap`, Kerberos, local accounts). Linux only. | No |
+| [JWT](jwt.md) | Service-to-database with short-lived tokens signed by an external IdP. | Public key only |
+| [Talos](talos.md) | JWT with role extraction baked in. Used at Ozon. | Public key only |
+| [pg_hba.conf](hba.md) | Restrict who can connect from where (network ACL), independent of credential method. | No |
+
+LDAP, Kerberos GSSAPI, certificate-based auth, and SCRAM channel binding (`scram-sha-256-plus`) are not supported. See [Comparison](../comparison.md#authentication).
+
+## Dispatch order
+
+`pg_hba.conf` is evaluated first, before any credential check. A `reject` rule terminates the connection; a `trust` rule skips the credential check entirely.
+
+After HBA, PgDoorman picks a credential method in this order:
+
+1. **Talos.** Activated when the client connects with username `talos`. The client's password is parsed as a JWT, the role (`owner` / `read_write` / `read_only`) is extracted, and the connection continues under that derived identity.
+2. **HBA Trust.** If `pg_hba.conf` matched a `trust` rule, no credential check happens.
+3. **PAM.** If the matched user has `auth_pam_service` set, credentials go to PAM (Linux only). PAM wins over a static password.
+4. **SCRAM static.** If the user's `password` in config starts with `SCRAM-SHA-256$`, PgDoorman runs SCRAM authentication.
+5. **MD5 static.** If the user's `password` starts with `md5`, PgDoorman runs MD5 authentication.
+6. **JWT.** If the user's `password` starts with `jwt-pkey-fpath:`, the client's password is verified as a JWT against the public key on disk.
+
+`auth_query` is not in this dispatch list — it runs **before** the dispatch to populate the pool's user list with hashes pulled from PostgreSQL. After `auth_query` returns a `passwd` value, dispatch picks the right method based on that value's prefix (`SCRAM-SHA-256$` or `md5`).
+
+If none of the methods matches the password format, PgDoorman returns "Authentication method not supported" and closes the connection.
+
+## Talking to PostgreSQL: passthrough vs configured
+
+PgDoorman has to authenticate twice: once as the gateway (client → PgDoorman) and once as the backend (PgDoorman → PostgreSQL). Three patterns:
+
+- **Passthrough (default).** The client's MD5 hash or SCRAM `ClientKey` is reused to authenticate to PostgreSQL. No plaintext password in config. Requires `server_username` to be unset (or equal to the client username).
+- **Configured backend user.** Set `server_username` and `server_password` in the user block. PgDoorman authenticates to PostgreSQL with these instead. Use this when the pool username is decoupled from the database user (Talos, JWT, name remapping).
+- **auth_query in dedicated mode.** Set `server_user` inside the `auth_query` block. All dynamically-discovered users share one backend pool authenticated as `server_user`. Trades per-user backend identity for pool reuse efficiency.
+
+See [Passthrough](passthrough.md) for details and [auth_query](auth-query.md) for dedicated mode.
+
+## Restricting connections
+
+`pg_hba.conf` is enforced before credentials are checked. Common patterns:
+
+- Reject everything except localhost: `host all all 0.0.0.0/0 reject` followed by `host all all 127.0.0.1/32 trust`.
+- Require TLS for non-local connections: `hostssl all all 0.0.0.0/0 scram-sha-256` and `hostnossl all all 127.0.0.1/32 trust`.
+- Per-database ACL: `host mydb appuser 10.0.0.0/8 scram-sha-256`.
+
+See [pg_hba.conf](hba.md).
+
+## Where to next
+
+- New deployment? Read [Passthrough](passthrough.md) and [Basic usage](../tutorials/basic-usage.md).
+- Many users with rotating credentials? Use [auth_query](auth-query.md).
+- Token-based service identity? Use [JWT](jwt.md).
+- OS-integrated authentication? Use [PAM](pam.md).
+- Network-level restrictions? Configure [pg_hba.conf](hba.md).

--- a/documentation/en/src/authentication/pam.md
+++ b/documentation/en/src/authentication/pam.md
@@ -1,0 +1,56 @@
+# PAM Authentication
+
+PgDoorman delegates client authentication to a PAM service on the host. Use this for OS-integrated authentication (LDAP via `pam_ldap`, Kerberos, local PAM modules) without putting per-user credentials in the pool config.
+
+PAM is Linux-only. The pre-built binaries ship with PAM support enabled.
+
+## Configuration
+
+```yaml
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    users:
+      - username: "alice"
+        auth_pam_service: "pg_doorman"
+        server_username: "alice"
+        server_password: "md5..."
+        pool_size: 20
+```
+
+`auth_pam_service` is the name of the PAM service file under `/etc/pam.d/`. PgDoorman does not validate the service name at startup — make sure the file exists.
+
+The `password` field is omitted because PAM does the verification. `server_username` and `server_password` are required: PAM only authenticates the client to PgDoorman; PgDoorman still needs credentials for the backend connection.
+
+## Example PAM service
+
+`/etc/pam.d/pg_doorman`:
+
+```
+auth     required pam_unix.so
+account  required pam_unix.so
+```
+
+For LDAP-backed authentication:
+
+```
+auth     required pam_ldap.so
+account  required pam_ldap.so
+```
+
+Configure `pam_ldap` in `/etc/ldap.conf` (or `/etc/nslcd.conf`) per your environment.
+
+## Dispatch order
+
+PAM is checked after Talos and HBA Trust, but before any password-based method. If a user has both `auth_pam_service` and a static `password` (MD5, SCRAM, or JWT prefix), PAM wins.
+
+See [Overview](overview.md#dispatch-order).
+
+## Caveats
+
+- PAM blocks the worker thread during the authentication call. If your PAM stack does network calls (LDAP, Kerberos), expect occasional latency spikes.
+- `pam_unix.so` requires read access to `/etc/shadow` — usually only `root`. Run PgDoorman as a user with the right group membership, or use a different PAM module.
+- PAM does not support SCRAM passthrough. The backend connection always uses `server_username` and `server_password`.
+- For LDAP without PAM machinery, PgDoorman has no native LDAP support. Use Odyssey or PgBouncer 1.25+ for that.

--- a/documentation/en/src/authentication/passthrough.md
+++ b/documentation/en/src/authentication/passthrough.md
@@ -1,0 +1,93 @@
+# Passthrough Authentication (Default)
+
+PgDoorman reuses the client's cryptographic proof — MD5 hash or SCRAM `ClientKey` — to authenticate to PostgreSQL. The plaintext password never leaves the client and is never stored in the pool config.
+
+This is the recommended setup when the pool username matches the PostgreSQL user.
+
+## How it works
+
+### MD5
+
+PostgreSQL's MD5 password protocol stores `md5(password + username)` server-side. The client also hashes the password the same way and sends `md5(stored_hash + salt)`. PgDoorman:
+
+1. Receives the client's hashed response.
+2. Looks up the stored MD5 hash in its config (or via `auth_query`).
+3. Verifies the client response matches.
+4. Forwards the **stored hash** to PostgreSQL as the password during backend authentication. PostgreSQL accepts it because the hash is what `pg_authid` actually stores.
+
+The `password` field in the pool config holds the stored hash, formatted as `md5XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` (the 32-character MD5 of `password + username`, prefixed with literal `md5`).
+
+### SCRAM-SHA-256
+
+SCRAM verifies the client without sending any password-equivalent material. PgDoorman:
+
+1. Performs SCRAM handshake with the client, validating the `ClientProof`.
+2. Extracts the `ClientKey` from a successful exchange.
+3. Performs SCRAM handshake with PostgreSQL, replaying the same `ClientKey` to compute a fresh `ClientProof` for the backend nonce.
+
+The `password` field in the pool config holds the SCRAM verifier from `pg_authid.rolpassword`, formatted as `SCRAM-SHA-256$<iterations>:<salt>$<StoredKey>:<ServerKey>`.
+
+PgDoorman does not support SCRAM channel binding (`scram-sha-256-plus`).
+
+## Configuration
+
+```yaml
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    users:
+      - username: "app"
+        password: "md5d41d8cd98f00b204e9800998ecf8427e"
+        pool_size: 40
+```
+
+Note what is **not** there: no `server_username`, no `server_password`. PgDoorman infers passthrough from the absence of these fields.
+
+For SCRAM, the password field looks like:
+
+```yaml
+password: "SCRAM-SHA-256$4096:random_salt$stored_key:server_key"
+```
+
+## Getting the hash
+
+Connect as a superuser to PostgreSQL and read `pg_shadow` (or `pg_authid`):
+
+```sql
+SELECT usename, passwd FROM pg_shadow WHERE usename = 'app';
+```
+
+The `passwd` column contains either an MD5 hash (`md5...`) or a SCRAM verifier (`SCRAM-SHA-256$...`), depending on `password_encryption` setting at the time the password was set.
+
+To force MD5 storage: `SET password_encryption = 'md5'; ALTER ROLE app PASSWORD 'plaintext';`
+To force SCRAM: `SET password_encryption = 'scram-sha-256'; ALTER ROLE app PASSWORD 'plaintext';`
+
+## When passthrough is not enough
+
+Set `server_username` and `server_password` explicitly when:
+
+- The pool user differs from the backend user (username remapping).
+- The client authenticates with [JWT](jwt.md) — there is no MD5 hash or SCRAM key to pass through.
+- The client authenticates with [Talos](talos.md) and you want a fixed backend identity per role.
+- You use [auth_query](auth-query.md) in dedicated mode.
+
+```yaml
+users:
+  - username: "external_app"
+    password: "jwt-pkey-fpath:/etc/pg_doorman/jwt.pub"
+    server_username: "app"
+    server_password: "md5..."
+    pool_size: 40
+```
+
+## Auto-generated config
+
+`pg_doorman generate --host your-pg-host --user your-admin-user` introspects PostgreSQL and produces a config with hashes from `pg_shadow` filled in automatically. Use this for new deployments to avoid copy-paste mistakes.
+
+```bash
+pg_doorman generate --host db.example.com --user postgres --output pg_doorman.yaml
+```
+
+See [Basic Usage](../tutorials/basic-usage.md) for the full generate flow.

--- a/documentation/en/src/authentication/talos.md
+++ b/documentation/en/src/authentication/talos.md
@@ -1,0 +1,89 @@
+# Talos Authentication
+
+Talos is a JWT-based authentication scheme developed at Ozon. The token carries a role assignment per database in its `resource_access` claim, and PgDoorman extracts the highest role to pick the backend identity. Multiple signing keys are supported via the `kid` header.
+
+If you operate inside Ozon's Talos identity stack, this is the integration. Outside, prefer plain [JWT](jwt.md).
+
+## How it works
+
+1. A client connects with username `talos` and a JWT as the password.
+2. PgDoorman reads the `kid` field from the JWT header and looks up the matching public key in `general.talos.keys`.
+3. The token is verified (RS256, `exp`, `nbf`).
+4. PgDoorman walks `resource_access` keys, splits each on `:`, and matches the part **after the colon** against `general.talos.databases`. So a key like `"postgres.stg:billing"` matches the `billing` database. The roles from every matching entry are collected; the highest wins (`owner` > `read_write` > `read_only`).
+5. The connection is authenticated against a pool user named after the role: `owner`, `read_write`, or `read_only`. That user must exist in the pool with `server_username` and `server_password` configured.
+
+The client identity (`clientId` from the token) is preserved in `application_name` and audit logs.
+
+## Configuration
+
+```yaml
+general:
+  host: "0.0.0.0"
+  port: 6432
+  talos:
+    keys:
+      - "/etc/pg_doorman/talos/keys/abc123.pem"
+      - "/etc/pg_doorman/talos/keys/def456.pem"
+    databases:
+      - "billing"
+      - "inventory"
+
+pools:
+  billing:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    users:
+      - username: "owner"
+        server_username: "billing_owner"
+        server_password: "md5..."
+        pool_size: 20
+      - username: "read_write"
+        server_username: "billing_app"
+        server_password: "md5..."
+        pool_size: 40
+      - username: "read_only"
+        server_username: "billing_ro"
+        server_password: "md5..."
+        pool_size: 60
+```
+
+The file stem of each key (`abc123`, `def456`) is the `kid` matched against the JWT header.
+
+`databases` is a filter: only listed databases are eligible for Talos. A token without an entry for the requested database is rejected.
+
+## Token shape
+
+```json
+{
+  "kid": "abc123",
+  "alg": "RS256"
+}
+.
+{
+  "exp": 1714500000,
+  "nbf": 1714400000,
+  "clientId": "billing-service",
+  "resource_access": {
+    "postgres.stg:billing": { "roles": ["read_write"] },
+    "postgres.stg:inventory": { "roles": ["read_only", "read_write"] }
+  }
+}
+```
+
+`resource_access` keys must include a colon. PgDoorman ignores everything before it and matches the suffix against `general.talos.databases`. A token built without the colon prefix will produce no role and authentication will fail with "Token may not contain valid roles for the requested databases".
+
+A client connecting to `inventory` with this token lands in the `read_write` user (max of the two listed roles).
+
+## Dispatch order
+
+Talos has highest priority. If a client connects with username `talos` and `general.talos.keys` is non-empty, no other authentication method is tried.
+
+See [Overview](overview.md#dispatch-order).
+
+## Caveats
+
+- Talos requires the special `talos` username. Non-Talos clients use other authentication methods normally.
+- The role-to-user mapping is fixed: `owner`, `read_write`, `read_only`. Custom role names need code changes.
+- Multiple roles in the same `resource_access` entry collapse to the maximum. There is no "deny" semantics.
+- Public keys are loaded once at startup and reloaded on `SIGHUP`.

--- a/documentation/en/src/comparison.md
+++ b/documentation/en/src/comparison.md
@@ -1,0 +1,150 @@
+# PgDoorman vs PgBouncer vs Odyssey vs PgCat
+
+A practical feature matrix for choosing a PostgreSQL connection pooler. PgDoorman targets workloads where prepared statements in transaction mode, multithreaded performance, and operational ergonomics matter.
+
+For benchmark numbers, see [Benchmarks](benchmarks.md).
+
+## Authentication
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| MD5 password | Yes | Yes | Yes |
+| SCRAM-SHA-256 (client) | Yes | Yes | Yes |
+| SCRAM-SHA-256 passthrough (no plaintext password in config) | Yes | No | Yes |
+| MD5 passthrough | Yes | Yes | Yes |
+| `auth_query` (dynamic users) | Yes | Yes | Yes |
+| `auth_query` passthrough mode (per-user backend identity) | Yes | No | Yes |
+| `pg_hba.conf` format | Yes (file or inline) | No | Since 1.4 |
+| PAM | Yes (Linux) | Yes (HBA) | Yes |
+| JWT (RSA-SHA256) | Yes | No | No |
+| Talos (custom JWT with role extraction) | Yes | No | No |
+| LDAP | No | Since 1.25 | Yes |
+| SCRAM channel binding (`scram-sha-256-plus`) | No | Yes | Yes |
+| User name maps (cert/peer → DB user) | No | Since 1.23 | Yes |
+| Tunable `scram_iterations` | No | Since 1.25 | No |
+
+See [Authentication](authentication/overview.md).
+
+## TLS
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Client-side TLS (4 modes: disable, allow, require, verify-full) | Yes | Yes | Yes |
+| Server-side TLS to PostgreSQL (6 modes incl. verify-ca, verify-full) | Yes | Yes | No |
+| mTLS to PostgreSQL (client cert) | Yes | Yes | No |
+| Hot reload of TLS certificates on `SIGHUP` | Yes (server-side) | No | No |
+| Minimum TLS 1.2 + Mozilla cipher list | Yes | Yes | No (allows TLS 1.0) |
+| Direct TLS handshake (PG17, no `SSLRequest`) | No | Since 1.25 | No |
+| TLS 1.3 cipher control | No | Since 1.25 | No |
+
+See [TLS](guides/tls.md).
+
+## Routing and high availability
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Patroni-assisted fallback (built-in `/cluster` lookup) | Yes | No | No |
+| Bundled TCP proxy with role-based routing (`patroni_proxy`) | Yes | No | No |
+| Replica lag guard | Yes (`max_lag_in_bytes` in `patroni_proxy`) | No | Yes (watchdog query) |
+| Round-robin / least-connections multi-host | Yes (`patroni_proxy`) | Since 1.24 | Yes |
+| `target_session_attrs` (read-write / read-only) | Yes (via `patroni_proxy` roles) | No | Yes |
+| Sequential routing (rules in order) | No | No | Yes |
+| Connection type routing (TCP vs UNIX) | No | No | Yes |
+| Availability zone-aware host selection | No | No | Yes |
+
+See [Patroni-assisted fallback](tutorials/patroni-assisted-fallback.md), [`patroni_proxy`](tutorials/patroni-proxy.md).
+
+## Pooling
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Pool modes (transaction, session) | Yes | Yes (+ statement) | Yes |
+| Pool Coordinator (cross-user `max_db_connections` with priority eviction) | Yes | No (no eviction) | No |
+| Reserve pool with `min_guaranteed_pool_size` | Yes | Reserve only | No |
+| Pre-replacement on `server_lifetime` expiry | Yes | No | No |
+| Anticipation/burst scaling (`scaling_warm_pool_ratio`, fast retries) | Yes | No | No |
+| Direct-handoff (waiter receives returning connection in microseconds) | Yes | No | No |
+| `min_pool_size` (warm connections) | Yes | No | Yes |
+| Prepared statement cache (two-level, query interner, statement remap) | Yes | Since 1.21 | Since 1.3 |
+| Smart `DISCARD` on checkin | RESET ALL + drop cache | No | Yes (auto) |
+| LISTEN / NOTIFY pinning in transaction mode | No | No | Experimental |
+| Cross-rule connection cap (`shared_pool`) | No | No | Since 1.5.1 |
+| `PAUSE` / `RESUME` / `RECONNECT` | Yes | Yes | Yes (1.4.1+) |
+
+See [Pool Coordinator](concepts/pool-coordinator.md), [Pool pressure](tutorials/pool-pressure.md).
+
+## Limits and timeouts
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| `server_idle_check_timeout` (probe before checkout) | Yes | No | No |
+| `idle_timeout` (server connection) | Yes | Yes | Yes |
+| `server_lifetime` | Yes | Yes | Yes |
+| `query_wait_timeout` | Yes | Yes | Yes |
+| `client_idle_timeout` | No | Since 1.24 | No |
+| `transaction_timeout` | No | Since 1.25 | No |
+| `max_user_client_connections` | No | Since 1.24 | No |
+| Per-user `query_timeout` | No | Since 1.24 | No |
+| Per-user `reserve_pool_size` | No | Since 1.24 | No |
+| `query_wait_notify` (NOTICE while waiting for backend) | No | Since 1.25 | Yes (`pool_notice_after_waiting_ms`) |
+
+See [General settings reference](reference/general.md), [Pool settings reference](reference/pool.md).
+
+## Observability
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Built-in Prometheus endpoint | Yes | External (`pgbouncer_exporter`) | Yes |
+| Latency percentiles per pool (p50, p90, p95, p99) | Yes (HDR Histogram) | No | Yes (TDigest) |
+| Prepared statement counters in stats | Yes | Since 1.24 | No |
+| JSON structured logging | Yes (`--log-format Structured`) | No | Yes |
+| Runtime log level control (`SET log_level`) | Yes | No | No |
+| Admin `SHOW POOL_COORDINATOR` / `SHOW POOL_SCALING` / `SHOW SOCKETS` | Yes | No | No |
+| Admin `SHOW PREPARED_STATEMENTS` | Yes | No | No |
+| Admin `SHOW HOSTS` (host CPU/memory) | No | No | Yes |
+| Admin `SHOW RULES` (dump routing) | No | No | Yes |
+| TLS connection metrics (handshake duration, errors, active count) | Yes (server-side) | No | No |
+| Patroni API metrics | Yes | No | No |
+| Fallback metrics (active flag, current host, hits) | Yes | No | No |
+
+See [Prometheus metrics reference](reference/prometheus.md), [Admin commands](observability/admin-commands.md).
+
+## Operations
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Graceful binary upgrade (zero-downtime, in-flight clients preserved) | Yes | Limited (`SO_REUSEPORT`) | No |
+| YAML config | Yes | No (INI) | No (own format) |
+| TOML config | Yes (legacy) | No | No |
+| Human-readable durations & sizes (`30s`, `1h`, `256MB`) | Yes | No | No |
+| Config test mode (`pg_doorman -t`) | Yes | No | No |
+| Auto-config from PostgreSQL (`pg_doorman generate --host`) | Yes | No | No |
+| `SIGHUP` reload | Yes (incl. server TLS certs) | Yes | Yes |
+| systemd `sd-notify` integration | Yes (`Type=notify`) | No | No |
+| Memory cap (`max_memory_usage`) | Yes | No | No |
+
+See [Binary upgrade](tutorials/binary-upgrade.md), [Signals](operations/signals.md).
+
+## Protocol
+
+| Feature | PgDoorman | PgBouncer | Odyssey |
+| --- | :-: | :-: | :-: |
+| Simple query | Yes | Yes | Yes |
+| Extended query | Yes | Yes | Partial |
+| Pipelined batches | Yes | Yes | Partial |
+| Async Flush | Yes | Yes | No |
+| Cancel requests over TLS | Yes | Yes | Yes |
+| `COPY IN` / `COPY OUT` | Yes | Yes | Yes |
+| Replication passthrough (`replication=true` startup) | No | Since 1.23 | No |
+| Protocol version negotiation (3.2) | No | Since 1.23 | No |
+| `server_drop_on_cached_plan_error` | No | No | Since 1.5.1 |
+
+## When PgDoorman is not the right fit
+
+- You need LDAP authentication. Use Odyssey or PgBouncer 1.25+.
+- You need SCRAM channel binding (`scram-sha-256-plus`) end-to-end. Use PgBouncer or Odyssey.
+- You need replication passthrough for logical replication tools. Use PgBouncer 1.23+.
+- You need availability-zone-aware routing or sequential `pg_hba`-style routing rules. Use Odyssey.
+- You need `transaction_timeout` enforced by the pooler. Use PgBouncer 1.25+.
+
+For prepared statements in transaction mode, Patroni HA without external proxies, multithreaded throughput, and zero-downtime restarts, PgDoorman is the closer fit.

--- a/documentation/en/src/concepts/pool-coordinator.md
+++ b/documentation/en/src/concepts/pool-coordinator.md
@@ -1,0 +1,110 @@
+# Pool Coordinator
+
+The Pool Coordinator caps total backend connections per database across all users in that pool, with priority eviction when the cap is reached. It is what PgBouncer's `max_db_connections` should have been: enforced fairly, with a reserve for short bursts, and per-user minimums to protect critical workloads.
+
+This page explains the concept and when to use it. For tuning recipes and read-out from `SHOW POOL_COORDINATOR`, see [Pool Pressure](../tutorials/pool-pressure.md#coordinator-mode).
+
+## What problem it solves
+
+Without a coordinator, every user-pool is independent. A `pool_size` of 40 across 5 users means up to 200 backend connections — and PostgreSQL fights to maintain its own limits.
+
+`max_db_connections` in PgBouncer caps the total but blocks new requests once the cap is reached. Whoever hit the cap first keeps their connections regardless of how heavily they use them, and slow workloads never yield to fast ones.
+
+PgDoorman's Pool Coordinator caps the total **and**:
+
+- **Evicts** idle connections from over-allocated users when another user needs to grow.
+- **Ranks** users by p95 transaction time so slow pools donate first. Users with fast queries keep their reuse advantage; users with long transactions release first because their connections were idle longer anyway.
+- **Reserves** a small overflow for short bursts. Configured separately from the main cap.
+- **Guarantees** a per-user minimum that is never evicted. Critical workloads keep their footing during contention.
+
+## When to use it
+
+Turn on the coordinator when:
+
+- Multiple distinct workloads share the same database and you need an upper bound on backend connection count (PostgreSQL `max_connections`, RAM, file descriptors).
+- One workload has bursty demand and you want it to absorb idle slots from others without crowding them out permanently.
+- You operate near the PostgreSQL connection ceiling and need fair degradation rather than first-come-first-served.
+
+You do **not** need it when:
+
+- Each user's `pool_size` is small enough that the sum is comfortably below PostgreSQL's `max_connections`.
+- Workloads are predictable and pre-sized.
+- You want PgBouncer-level simplicity. `max_db_connections` without eviction is supported but discouraged for shared databases.
+
+## Configuration
+
+```yaml
+pools:
+  shared_db:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+
+    # Total cap across all users in this pool.
+    max_db_connections: 80
+
+    # Reserve overflow above max_db_connections for short bursts.
+    # Acquired only when no idle connection is available within reserve_pool_timeout.
+    reserve_pool_size: 16
+    reserve_pool_timeout: "3s"
+
+    # Per-user safety net: connections never evicted from a user, even under pressure.
+    # Sum across users should be ≤ max_db_connections.
+    min_guaranteed_pool_size: 5
+
+    # Eviction grace period: connections younger than this are not evicted.
+    # Prevents thrashing when a workload briefly idles.
+    min_connection_lifetime: "30s"
+
+    users:
+      - username: "fast_app"
+        password: "md5..."
+        pool_size: 40
+
+      - username: "batch_job"
+        password: "md5..."
+        pool_size: 60
+```
+
+Effective ceiling: `max_db_connections + reserve_pool_size = 96`. The reserve absorbs sub-second spikes; if the spike persists, eviction kicks in.
+
+## How it picks who donates
+
+When a user requests a new backend and the cap is reached:
+
+1. **Find candidates with idle connections.** A user holding only active connections cannot donate — its work is in flight.
+2. **Skip protected users.** A user below `min_guaranteed_pool_size` is excluded.
+3. **Skip recently-created connections.** Connections younger than `min_connection_lifetime` are not evicted (avoids churn during minor idle gaps).
+4. **Rank by surplus.** Users with the most idle connections above their `min_guaranteed_pool_size` rank highest.
+5. **Tiebreak by p95 transaction time.** Among equally-idle users, the slow pool donates first. Their connections were probably idle because their next query is still being prepared upstream.
+
+The chosen idle connection is closed; the requesting user receives a fresh connection from PostgreSQL.
+
+## Observability
+
+`SHOW POOL_COORDINATOR` shows current state per database:
+
+```
+database    | max_db_conn | current | reserve_size | reserve_used | evictions | reserve_acq | exhaustions
+shared_db   | 80          | 78      | 16           | 2            | 142       | 18          | 0
+```
+
+- `evictions` rising fast — one user is starved repeatedly. Either raise `max_db_connections` or set `min_guaranteed_pool_size` for that user.
+- `reserve_acq` high — bursts are normal but you might be undersized; consider raising `max_db_connections` instead of relying on reserve.
+- `exhaustions` non-zero — even reserve was full. Clients hit `query_wait_timeout` waiting for a backend. Raise the cap.
+
+Prometheus: `pg_doorman_pool_coordinator{type="..."}` (gauges) and `pg_doorman_pool_coordinator_total{type="evictions|reserve_acquisitions|exhaustions"}` (counters). See [Admin commands](../observability/admin-commands.md) and [Prometheus reference](../reference/prometheus.md).
+
+## Caveats
+
+- The coordinator only operates within one pool (one database). Cross-pool / cross-database limits are not supported.
+- Eviction picks idle connections; a user holding all connections in long transactions cannot donate, so other users may starve. If this is your shape, raise `max_db_connections` or split the workload.
+- `min_guaranteed_pool_size` is a floor for eviction, not a `min_pool_size` for warm-up. The pool still has to create those connections on demand.
+- Setting `max_db_connections` without `min_guaranteed_pool_size` is the PgBouncer mode — works, but starves smaller users under pressure. Always set both for shared databases.
+
+## Where to next
+
+- Sizing recipe with worked examples: [Pool Pressure → Sizing the cap](../tutorials/pool-pressure.md#sizing-the-cap-against-postgresql).
+- Tuning under load: [Pool Pressure → Tuning parameters](../tutorials/pool-pressure.md#tuning-parameters).
+- Reading admin output: [Admin Commands → SHOW POOL_COORDINATOR](../observability/admin-commands.md).
+- Pool modes (transaction vs session): [Pool Modes](pool-modes.md).

--- a/documentation/en/src/concepts/pool-modes.md
+++ b/documentation/en/src/concepts/pool-modes.md
@@ -1,0 +1,98 @@
+# Pool Modes
+
+PgDoorman supports two pool modes: `transaction` and `session`. Set per pool, with optional per-user override.
+
+There is no `statement` mode. Statement-level pooling breaks more drivers than it helps and PgDoorman optimizes for transaction mode aggressively (prepared statement cache, direct handoff, FIFO scheduling).
+
+## Transaction mode (recommended)
+
+```yaml
+pools:
+  mydb:
+    pool_mode: "transaction"
+```
+
+A backend connection is held for the duration of a transaction, then returned to the pool on `COMMIT`, `ROLLBACK`, or implicit completion.
+
+This is the mode that delivers PgDoorman's connection efficiency: a `pool_size` of 40 can serve thousands of clients as long as transactions are short.
+
+What works in transaction mode (where most poolers fail):
+
+- Prepared statements. PgDoorman caches them per-pool, remaps statement names across backend connections, and replays preparation transparently. Drivers that pin to `unnamed` statement (Go pgx, .NET Npgsql, Python asyncpg) work without configuration.
+- Pipelined batches and async `Flush` flow.
+- Cancel requests over TLS.
+- `LISTEN` / `NOTIFY` — but only inside a transaction; cross-transaction notifications are lost (PgBouncer same).
+
+What does **not** work in transaction mode:
+
+- `SET` and `RESET` outside a transaction. Use session mode for clients that rely on session-level GUC changes (`SET TIME ZONE`, `SET search_path` once per connection).
+- Advisory locks held across transactions. Use session mode.
+- Cursors held outside transactions (`WITH HOLD`). Use session mode.
+- `SET LOCAL` works as expected — it is transaction-scoped.
+
+## Session mode
+
+```yaml
+pools:
+  legacy_app:
+    pool_mode: "session"
+```
+
+A backend connection is held for the duration of the client session. Returned to the pool only when the client disconnects.
+
+Use this when:
+
+- The application uses session-scoped state (`SET search_path`, `SET TIME ZONE`).
+- The application uses `WITH HOLD` cursors.
+- The application uses advisory locks across transactions.
+- You are migrating an unmodified PgBouncer deployment that was using session mode and you want a like-for-like swap.
+
+In session mode, `pool_size` is effectively the maximum number of concurrent clients. Sizing matches PostgreSQL's `max_connections` minus reserves.
+
+## Per-user override
+
+A pool's mode can be overridden per user:
+
+```yaml
+pools:
+  mydb:
+    pool_mode: "transaction"
+    users:
+      - username: "app"
+        password: "md5..."
+        pool_size: 40
+      - username: "admin_tools"
+        password: "md5..."
+        pool_size: 4
+        pool_mode: "session"
+```
+
+Useful when one user (operations tooling, migrations) needs session semantics but the main application stays in transaction mode.
+
+## Cleanup on checkin
+
+Returning to transaction mode in detail: when a backend goes back to the pool, PgDoorman runs `RESET ALL` and `ROLLBACK` (if `cleanup_server_connections: true`, the default). This drops:
+
+- Session-level `SET` values.
+- Cursors.
+- Prepared statement names that the driver bound to specific backend names (PgDoorman's prepared statement cache survives — it is keyed by query text, not backend statement name).
+- Advisory locks (`pg_advisory_unlock_all` is implicit in `RESET ALL`).
+
+`DEALLOCATE ALL` and `DISCARD ALL` from the client also trigger PgDoorman's prepared statement cache to drop everything cached for that client. The pool-level cache is not affected.
+
+To opt out of cleanup (for performance, in tightly-controlled deployments):
+
+```yaml
+pools:
+  mydb:
+    pool_mode: "transaction"
+    cleanup_server_connections: false
+```
+
+Only do this if you are sure your application never leaks session state.
+
+## Reference
+
+- `pool_mode` parameter: [Pool Settings](../reference/pool.md#pool_mode).
+- `cleanup_server_connections`: [Pool Settings](../reference/pool.md#cleanup_server_connections).
+- Pool sizing: [Pool Coordinator](pool-coordinator.md), [Pool Pressure](../tutorials/pool-pressure.md).

--- a/documentation/en/src/guides/tls.md
+++ b/documentation/en/src/guides/tls.md
@@ -1,0 +1,112 @@
+# TLS
+
+PgDoorman terminates TLS on the client side (clients → PgDoorman) and originates TLS on the server side (PgDoorman → PostgreSQL). The two sides are configured independently.
+
+## Client-side TLS
+
+Encrypt connections between client applications and PgDoorman.
+
+### Modes
+
+| Mode | Behavior |
+| --- | --- |
+| `disable` | Do not advertise TLS. Clients sending `SSLRequest` get `'N'` (rejected). |
+| `allow` | Advertise TLS but accept plain TCP. |
+| `require` | Require TLS. Plain connections are dropped after `SSLRequest` fails. |
+| `verify-full` | Require TLS and a valid client certificate. Used for mTLS. |
+
+`verify-full` is mTLS — the server verifies the client's certificate. Set up a client CA bundle with `tls_ca_cert`.
+
+### Configuration
+
+```yaml
+general:
+  tls_mode: "require"
+  tls_certificate: "/etc/pg_doorman/tls/server.crt"
+  tls_private_key: "/etc/pg_doorman/tls/server.key"
+  tls_ca_cert: "/etc/pg_doorman/tls/client_ca.pem"   # only for verify-full
+  tls_rate_limit_per_second: 100                       # optional handshake throttle
+```
+
+The certificate may be self-signed for development; production deployments typically use Let's Encrypt or an internal CA.
+
+### Reload (client side)
+
+Client-side certificates are loaded at startup. Changing them requires a process restart. There is no `SIGHUP` reload for client-side TLS.
+
+For zero-downtime certificate rotation, see [Binary Upgrade](../tutorials/binary-upgrade.md).
+
+### Cipher policy
+
+Minimum TLS 1.2. The cipher list is the Mozilla "intermediate" recommendation; this is not configurable. Direct TLS handshake (PG17, no `SSLRequest`) is not supported.
+
+For TLS 1.3 cipher control or PG17 direct TLS, use PgBouncer 1.25+.
+
+## Server-side TLS
+
+Encrypt connections between PgDoorman and PostgreSQL backends. Added in 3.6.0.
+
+### Modes
+
+| Mode | Behavior |
+| --- | --- |
+| `disable` | Plain TCP. |
+| `allow` (default) | Try plain first; if the server rejects, retry on a new socket with TLS. Matches `libpq sslmode=allow`. |
+| `prefer` | Send `SSLRequest`; if the server says `'N'`, fall back to plain. |
+| `require` | Require TLS. Fail if the server does not support it. |
+| `verify-ca` | Require TLS and verify the server certificate against the configured CA. |
+| `verify-full` | Require TLS, verify CA, and verify the server hostname against the certificate. |
+
+`allow` is the default to keep backward compatibility — existing deployments where PostgreSQL has TLS configured automatically upgrade without config changes. New deployments wanting explicit guarantees should use `require` or `verify-full`.
+
+### Configuration
+
+```yaml
+general:
+  server_tls_mode: "verify-full"
+  server_tls_ca_cert: "/etc/pg_doorman/tls/pg_ca_bundle.pem"
+
+# Optional: client certificate for mTLS to PostgreSQL
+  server_tls_certificate: "/etc/pg_doorman/tls/pg_client.crt"
+  server_tls_private_key: "/etc/pg_doorman/tls/pg_client.key"
+```
+
+`server_tls_ca_cert` accepts a PEM bundle (multiple CA certificates concatenated). All are loaded.
+
+### Hot reload
+
+On `SIGHUP`, server-side certificates are re-read from disk. Existing connections keep using their original TLS context; new connections use the reloaded certificates. The reload is lock-free via `Arc<ArcSwap<...>>` — no connection drop, no handshake stall.
+
+```bash
+kill -HUP $(pidof pg_doorman)
+```
+
+This is the only TLS reload path. Client-side certificates do not reload on `SIGHUP`.
+
+### mTLS to PostgreSQL
+
+Set `server_tls_certificate` and `server_tls_private_key`. PostgreSQL must be configured with `ssl_ca_file` matching the client cert's signer, and the role must have `clientcert=verify-ca` (or `verify-full`) in `pg_hba.conf` on the PostgreSQL side.
+
+## Observability
+
+Three Prometheus series cover server-side TLS:
+
+| Metric | Type | Purpose |
+| --- | --- | --- |
+| `pg_doorman_server_tls_connections` | gauge per pool | Number of active TLS connections to PostgreSQL. |
+| `pg_doorman_server_tls_handshake_duration_seconds` | histogram per pool | Handshake duration buckets. |
+| `pg_doorman_server_tls_handshake_errors_total` | counter per pool | Failed handshakes. Alert if non-zero rate. |
+
+See [Prometheus reference](../reference/prometheus.md).
+
+## Known limitations
+
+- The `COPY` protocol over server TLS is not exercised by the BDD test suite. Behavior is expected to work but unverified.
+- Cancel requests to the backend bypass server TLS — they use a fresh plain TCP connection. This matches PostgreSQL's protocol design (cancel is sent on a separate socket).
+- Direct TLS handshake (PG17 fast handshake without `SSLRequest`) is not supported on either side.
+
+## Where to next
+
+- New cluster setup? See [Installation](../tutorials/installation.md).
+- Rotating certificates? See [Binary Upgrade](../tutorials/binary-upgrade.md) and [Signals](../operations/signals.md).
+- Hardening an existing deployment? Combine with [pg_hba.conf](../authentication/hba.md): force `hostssl` for non-local connections.

--- a/documentation/en/src/index.md
+++ b/documentation/en/src/index.md
@@ -1,50 +1,123 @@
-## PgDoorman: PostgreSQL Pooler
+# PgDoorman
 
-PgDoorman is a stable and high-performance alternative to [PgBouncer](https://www.pgbouncer.org/), [Odyssey](https://github.com/yandex/odyssey), or [PgCat](https://github.com/postgresml/pgcat).
-It was created with the Unix philosophy in mind. Development focused on performance, efficiency, and reliability.
-Additionally, PgDoorman provides improved driver support for languages like Go (pgx), .NET (npgsql), and asynchronous drivers for Python and Node.js.
+A multithreaded PostgreSQL connection pooler written in Rust. Drop-in alternative to [PgBouncer](https://www.pgbouncer.org/), [Odyssey](https://github.com/yandex/odyssey), and [PgCat](https://github.com/postgresml/pgcat). Used in production at Ozon for two years across Go (pgx), .NET (Npgsql), Python (asyncpg, SQLAlchemy), and Node.js workloads.
 
-[Get PgDoorman {{VERSION}}](tutorials/installation.md)
+[Get PgDoorman {{VERSION}}](tutorials/installation.md) · [Compare](comparison.md) · [Benchmarks](benchmarks.md)
 
-### Quick Start
+## What makes PgDoorman different
 
-Run PgDoorman instantly using Docker:
+Three things you will not find in PgBouncer or Odyssey.
+
+```admonish success title="Pool Coordinator"
+Database-level connection cap with priority eviction. `max_db_connections` limits total backend connections per database; when exhausted, idle connections are evicted from users with the largest surplus, ranked by p95 transaction time so slow pools donate first. A reserve pool absorbs short bursts. Per-user `min_guaranteed_pool_size` protects critical workloads.
+
+PgBouncer has `max_db_connections` without eviction or fairness. Odyssey has no equivalent.
+
+[Read more →](concepts/pool-coordinator.md)
+```
+
+```admonish success title="Patroni-assisted Fallback"
+When PgDoorman runs next to PostgreSQL on the same machine and a Patroni switchover kills the local backend, PgDoorman queries the Patroni REST API `/cluster` endpoint, picks a live cluster member (`sync_standby` preferred), and routes new connections there within 1–2 TCP round trips. The local backend stays in cooldown; fallback connections use a short lifetime so the pool returns to local once it recovers.
+
+One line in `[general]` enables it for every pool. No external HAProxy, no consul-template.
+
+[Read more →](tutorials/patroni-assisted-fallback.md)
+```
+
+```admonish success title="Graceful Binary Upgrade"
+Replace the binary without dropping a single client. The new process accepts new connections immediately while existing clients finish their transactions on the old process. TLS, connection state, and cancel keys all transfer cleanly.
+
+PgBouncer requires `SO_REUSEPORT` with separate processes (which causes pool imbalance). Odyssey lacks an equivalent flow.
+
+[Read more →](tutorials/binary-upgrade.md)
+```
+
+## Why PgDoorman
+
+- **Drop-in replacement.** Caches and remaps prepared statements transparently in transaction mode — no `DISCARD ALL`, no `DEALLOCATE`, no driver hacks.
+- **Multithreaded.** Single shared pool across all worker threads. PgBouncer is single-threaded; running multiple instances via `SO_REUSEPORT` causes unbalanced pools.
+- **Thundering herd suppression.** When 200 clients race for 4 idle connections, PgDoorman caps concurrent backend creates and routes waiters to recycled connections via direct handoff — most land within microseconds.
+- **Bounded tail latency.** Strict FIFO via direct-handoff channels keeps p99 within 10% of p50 regardless of client count. Pre-replacement on `server_lifetime` expiry — no spike during connection rotation.
+- **Dead backend detection.** When a client holds a transaction open and the backend dies (failover, OOM kill), PgDoorman returns an error immediately. Other poolers wait for TCP keepalive, leaving clients hanging for minutes.
+- **Built for operations.** YAML or TOML config with human-readable durations (`"30s"`, `"5m"`). `pg_doorman generate --host your-db` introspects PostgreSQL to produce a config. `pg_doorman -t` validates before deploy. Prometheus endpoint is built-in.
+
+## Comparison
+
+|                                                          |    PgDoorman    | PgBouncer | Odyssey |
+| -------------------------------------------------------- | :-------------: | :-------: | :-----: |
+| Multithreaded                                            |       Yes       |    No     |   Yes   |
+| Prepared statements in transaction mode                  |       Yes       | Since 1.21 | Since 1.3 |
+| Full extended query protocol                             |       Yes       |    Yes    | Partial |
+| Pool Coordinator with priority eviction                  |       Yes       |    No     |   No    |
+| Patroni-assisted fallback (built-in)                     |       Yes       |    No     |   No    |
+| Pre-replacement on `server_lifetime` expiry              |       Yes       |    No     |   No    |
+| Stale backend detection (idle-in-transaction)            |       Yes       |    No     |   No    |
+| Graceful binary upgrade                                  |       Yes       |  Limited  |   No    |
+| Server-side TLS (mTLS, hot reload)                       |       Yes       |    No     |   No    |
+| Auth: SCRAM passthrough (no plaintext password in config) |      Yes       |    No     |   Yes   |
+| Auth: JWT                                                |       Yes       |    No     |   No    |
+| Auth: PAM / `pg_hba.conf` / auth_query                   |       Yes       |   Yes     |   Yes   |
+| Auth: LDAP                                               |       No        | Since 1.25 |   Yes  |
+| YAML / TOML config                                       |       Yes       | No (INI)  | No (own format) |
+| JSON structured logging                                  |       Yes       |    No     |   Yes   |
+| Latency percentiles (p50/90/95/99)                       |       Yes       |    No     |   Yes   |
+| Config test mode (`-t`)                                  |       Yes       |    No     |   No    |
+| Auto-config from PostgreSQL                              |       Yes       |    No     |   No    |
+| Built-in Prometheus endpoint                             |       Yes       | External  |   Yes   |
+
+[Full feature matrix →](comparison.md)
+
+## Benchmarks
+
+AWS Fargate (16 vCPU), pool size 40, `pgbench` 30s per test:
+
+| Scenario                                | vs PgBouncer | vs Odyssey |
+| --------------------------------------- | :----------: | :--------: |
+| Extended protocol, 500 clients + SSL    |     ×3.5     |    +61%    |
+| Prepared statements, 500 clients + SSL  |     ×4.0     |    +5%     |
+| Simple protocol, 10 000 clients         |     ×2.8     |    +20%    |
+| Extended + SSL + Reconnect, 500 clients |    +96%     |    ~0%     |
+
+[Full results →](benchmarks.md)
+
+## Quick start
+
+Run via Docker:
 
 ```bash
 docker run -p 6432:6432 \
-  -v $(pwd)/pg_doorman.toml:/etc/pg_doorman/pg_doorman.toml \
+  -v $(pwd)/pg_doorman.yaml:/etc/pg_doorman/pg_doorman.yaml \
   ghcr.io/ozontech/pg_doorman
 ```
 
-*For more details, see the [Installation Guide](tutorials/installation.md).*
+Minimal config (`pg_doorman.yaml`):
 
+```yaml
+general:
+  host: "0.0.0.0"
+  port: 6432
+  admin_username: "admin"
+  admin_password: "change_me"
 
-### Why not multi-PgBouncer?
+pools:
+  mydb:
+    server_host: "127.0.0.1"
+    server_port: 5432
+    pool_mode: "transaction"
+    users:
+      - username: "app"
+        password: "md5..."   # hash from pg_shadow / pg_authid
+        pool_size: 40
+```
 
-Why do we think that using [multiple instances of PgBouncer](https://www.pgbouncer.org/config.html#so_reuseport) is not a suitable solution?
-This approach has problems with reusing prepared statements and strange and inefficient control over query cancellation.
-Additionally, the main issue we have encountered is that the operating system distributes new clients round-robin,
-but each client can disconnect at any time, leading to an imbalance after prolonged use.
+`server_username` and `server_password` are omitted on purpose — PgDoorman reuses the client's MD5 hash or SCRAM ClientKey to authenticate to PostgreSQL. No plaintext passwords in config.
 
-### Why not Odyssey?
+[Installation guide →](tutorials/installation.md) · [Configuration reference →](reference/general.md)
 
-We had difficulties using NPGSQL and SCRAM, as well as with `prepared_statements` support.
-However, the main serious problem related to data consistency and, for a long time, we were unable to solve it.
+## Where to next
 
-### Differences from PgCat
-
-While PgDoorman was initially based on the PgCat project, it has since evolved into a standalone solution with its own set of features.
-Some of the key differences include:
-
-- Performance improvements compared to PgCat/PgBouncer/Odyssey.
-- Support for extended protocol with popular programming language drivers.
-- Enhanced monitoring metrics to improve visibility into database activity.
-- Careful resource management to avoid memory issues (`max_memory_usage`, `message_size_to_be_stream`).
-- SCRAM client/server authentication support.
-- [Gracefully binary upgrade](tutorials/binary-upgrade.md).
-- Supporting JWT for service-to-database authentication.
-- Many micro-optimizations (for example, the time spent with the client is longer than the server's busy time).
-
-### Additional Binary: patroni_proxy
-
-This repository also includes [patroni_proxy](tutorials/patroni-proxy.md) — a specialized high-performance TCP proxy for Patroni-managed PostgreSQL clusters. Unlike HAProxy + confd, it preserves existing connections during cluster topology changes and provides native role-based routing with replication lag awareness.
+- New to PgDoorman? Start with [Overview](tutorials/overview.md), then [Installation](tutorials/installation.md) and [Basic usage](tutorials/basic-usage.md).
+- Migrating from PgBouncer or Odyssey? Read [Comparison](comparison.md) and [Authentication](authentication/overview.md).
+- Running Patroni? See [Patroni-assisted fallback](tutorials/patroni-assisted-fallback.md) and [`patroni_proxy`](tutorials/patroni-proxy.md).
+- Production sizing? Read [Pool pressure](tutorials/pool-pressure.md) and [Pool Coordinator](concepts/pool-coordinator.md).
+- Operating PgDoorman? See [Binary upgrade](tutorials/binary-upgrade.md), [Signals](operations/signals.md), [Troubleshooting](tutorials/troubleshooting.md).

--- a/documentation/en/src/observability/admin-commands.md
+++ b/documentation/en/src/observability/admin-commands.md
@@ -1,0 +1,115 @@
+# Admin Commands
+
+PgDoorman exposes a Postgres-compatible admin database. Connect to the same port as your data clients, but with `dbname=pgdoorman` and the admin credentials from your config:
+
+```bash
+psql -h 127.0.0.1 -p 6432 -U admin pgdoorman
+```
+
+Or via `psql` connection string:
+
+```bash
+psql "host=127.0.0.1 port=6432 user=admin dbname=pgdoorman"
+```
+
+Admin commands are read with `SHOW <subcommand>` or executed with bare verbs (`PAUSE`, `RESUME`, `RECONNECT`, `RELOAD`, `SHUTDOWN`, `SET <param> = <value>`).
+
+## SHOW commands
+
+| Command | Purpose |
+| --- | --- |
+| `SHOW HELP` | List available commands. |
+| `SHOW CONFIG` | Current effective configuration. Read-only. |
+| `SHOW DATABASES` | One row per pool: host, port, database, pool size, mode. |
+| `SHOW POOLS` | Pool utilization snapshot per user×database: idle/active/waiting clients, idle/active servers. |
+| `SHOW POOLS_EXTENDED` | `SHOW POOLS` plus bytes received/sent and average wait time. |
+| `SHOW POOLS_MEMORY` | Per-pool memory accounting for prepared statement cache (client-side and server-side). |
+| `SHOW POOL_COORDINATOR` | Pool Coordinator state per database: current connections, reserve usage, eviction count. See [Pool Coordinator](../concepts/pool-coordinator.md). |
+| `SHOW POOL_SCALING` | Anticipation/burst metrics: in-flight creates, gate waits, anticipation notifies/timeouts. |
+| `SHOW PREPARED_STATEMENTS` | Cached prepared statements per pool: hash, name, query text, hit count. |
+| `SHOW CLIENTS` | Active clients: ID, database, user, app name, address, TLS state, transaction/query/error counts, age. |
+| `SHOW SERVERS` | Active backend connections: server ID, backend PID, database, user, TLS, state, transaction/query counts, prepare cache hits/misses, bytes. |
+| `SHOW CONNECTIONS` | Connection counts by type: total, errors, TLS, plain, cancel. |
+| `SHOW STATS` | Aggregated stats per user×database: total transactions, queries, time, bytes, averages. |
+| `SHOW LISTS` | Counts by category (databases, users, pools, clients, servers). |
+| `SHOW USERS` | List of users and their pool modes. |
+| `SHOW AUTH_QUERY` | `auth_query` cache hit/miss/refetch rates, auth success/failure, executor errors, dynamic pool counts. |
+| `SHOW SOCKETS` | TCP and Unix socket counts by state (Linux only — reads `/proc/net/`). |
+| `SHOW LOG_LEVEL` | Current log level. |
+| `SHOW VERSION` | PgDoorman version. |
+
+`SHOW POOL_COORDINATOR` and `SHOW POOL_SCALING` have no equivalent in PgBouncer or Odyssey — they expose PgDoorman-specific machinery.
+
+## Control commands
+
+| Command | Effect |
+| --- | --- |
+| `PAUSE` | Stop accepting new client requests. Existing clients finish their transactions. |
+| `PAUSE <database>` | Pause a single pool. |
+| `RESUME` / `RESUME <database>` | Resume after `PAUSE`. |
+| `RECONNECT` / `RECONNECT <database>` | Force-recycle backend connections (close idle, drain active). New connections come from PostgreSQL. |
+| `RELOAD` | Same as `SIGHUP` — reload config from disk. |
+| `SHUTDOWN` | Same as `SIGTERM` — graceful shutdown. |
+| `KILL <database>` | Drop all clients connected to a specific pool. |
+| `SET log_level = '<level>'` | Change runtime log level (`error`, `warn`, `info`, `debug`, `trace`). |
+
+`PAUSE`/`RESUME` are useful during failovers or maintenance windows. `RECONNECT` after rotating credentials in `pg_authid` ensures backends use the new password.
+
+## Reading common output
+
+### `SHOW POOLS`
+
+```
+database | user | cl_idle | cl_active | cl_waiting | sv_active | sv_idle | sv_used | maxwait
+mydb     | app  | 12      | 4         | 0          | 4         | 36      | 0       | 0.0
+```
+
+- `cl_waiting > 0` means clients are stuck waiting for a backend. Either raise `pool_size` or check for slow queries.
+- `sv_idle` matches free backends; `sv_active` is in-use; `sv_used` is reserved by the coordinator (see below).
+- `maxwait` is the longest current wait in seconds. If it grows beyond `query_wait_timeout`, clients get errors.
+
+### `SHOW POOL_COORDINATOR`
+
+```
+database | max_db_conn | current | reserve_size | reserve_used | evictions | reserve_acq | exhaustions
+mydb     | 80          | 78      | 16           | 2            | 142       | 18          | 0
+```
+
+- `evictions` rising rapidly: a user is starved repeatedly. Set or raise `min_guaranteed_pool_size` for that user.
+- `reserve_acq` high: bursts are normal but you might be undersized. Consider raising `max_db_connections` instead of relying on the reserve.
+- `exhaustions` non-zero: even reserve was full. Clients hit `query_wait_timeout`. Raise the cap.
+
+See [Pool Coordinator](../concepts/pool-coordinator.md) for tuning.
+
+### `SHOW POOL_SCALING`
+
+```
+user | database | inflight | creates | gate_waits | burst_gate_budget_ex | antic_notify | antic_timeout | create_fallback | replenish_def
+app  | mydb     | 1        | 12345   | 87         | 3                    | 142          | 8             | 22              | 0
+```
+
+- `inflight` is current backend creations in progress.
+- `gate_waits` rising: `scaling_max_parallel_creates` is throttling you. Acceptable if PostgreSQL is under load; raise it if PG can handle more parallel `connect()` calls.
+- `antic_notify` vs `antic_timeout` ratio: high timeout count means anticipation is not finding a returning connection in time. Raise `scaling_warm_pool_ratio` so the pool grows ahead of demand.
+- `create_fallback` rising means pre-replacement is firing — connections expired before naturally being returned.
+
+See [Pool Pressure → Tuning](../tutorials/pool-pressure.md#tuning-parameters).
+
+## Authentication
+
+The admin database uses the credentials from `general.admin_username` and `general.admin_password`:
+
+```yaml
+general:
+  admin_username: "admin"
+  admin_password: "change_me"
+```
+
+Admin connections do not pass through `pg_hba.conf` rules — they go directly to the admin handler. Restrict admin access at the network layer (`listen_addresses`, firewall) or use Unix sockets.
+
+## Where to next
+
+- [Prometheus reference](../reference/prometheus.md) — same data, machine-readable.
+- [Pool Coordinator](../concepts/pool-coordinator.md) — what `SHOW POOL_COORDINATOR` is telling you.
+- [Pool Pressure](../tutorials/pool-pressure.md) — what `SHOW POOL_SCALING` is telling you.
+- [Troubleshooting](../tutorials/troubleshooting.md) — common failure modes and their `SHOW` output.

--- a/documentation/en/src/observability/json-logging.md
+++ b/documentation/en/src/observability/json-logging.md
@@ -1,0 +1,105 @@
+# JSON Structured Logging
+
+PgDoorman emits structured JSON logs when run with `--log-format Structured`. Each line is a self-contained JSON object with timestamp, level, source location, and message — ready for ingestion into Loki, Elasticsearch, Datadog, or any log pipeline that expects JSON.
+
+## Enabling
+
+Three equivalent ways:
+
+```bash
+# Command line flag
+pg_doorman -F Structured /etc/pg_doorman/pg_doorman.yaml
+
+# Long form
+pg_doorman --log-format Structured /etc/pg_doorman/pg_doorman.yaml
+
+# Environment variable
+LOG_FORMAT=Structured pg_doorman /etc/pg_doorman/pg_doorman.yaml
+```
+
+The default is `Text` (human-readable). The `--log-format` flag accepts `Text`, `Structured`, or `Debug`; the last is currently an alias for `Text`.
+
+## Output
+
+```json
+{"timestamp":"2026-04-25T08:32:14.512Z","level":"INFO","file":"src/app/server.rs","line":357,"message":"Server is up at 0.0.0.0:6432"}
+{"timestamp":"2026-04-25T08:32:14.514Z","level":"INFO","file":"src/pool/mod.rs","line":421,"message":"Pool 'mydb' initialized: 1 user, pool_size=40"}
+{"timestamp":"2026-04-25T08:32:18.103Z","level":"WARN","file":"src/server/protocol_io.rs","line":189,"message":"Backend connection lost: connection reset by peer"}
+```
+
+Fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `timestamp` | RFC 3339 string | UTC, millisecond precision. |
+| `level` | string | `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`. |
+| `file` | string | Source file emitting the log. |
+| `line` | integer | Line number. |
+| `message` | string | Human-readable message. |
+
+There are no nested fields or per-event labels — PgDoorman's logger is plain `log` macro events serialized to JSON. For richer metadata (per-pool counters, per-client events), use Prometheus metrics instead. See [Prometheus reference](../reference/prometheus.md).
+
+## Log level
+
+Set via `general.log_level` in the config or override at startup:
+
+```yaml
+general:
+  log_level: "info"
+```
+
+```bash
+pg_doorman -l debug -F Structured /etc/pg_doorman/pg_doorman.yaml
+```
+
+Change at runtime via the admin database:
+
+```sql
+SET log_level = 'debug';
+SHOW LOG_LEVEL;
+```
+
+This affects the running process only. Persisting requires editing the config and `RELOAD`/`SIGHUP`.
+
+## Recommended pipeline
+
+For Kubernetes:
+
+```yaml
+spec:
+  containers:
+    - name: pg_doorman
+      image: ghcr.io/ozontech/pg_doorman:latest
+      args:
+        - "-F"
+        - "Structured"
+        - "/etc/pg_doorman/pg_doorman.yaml"
+      env:
+        - name: LOG_LEVEL
+          value: "info"
+```
+
+Logs go to stdout, container runtime captures them, your log shipper (Promtail, Fluent Bit, Vector) forwards as-is — JSON is preserved end to end.
+
+For systemd:
+
+```ini
+[Service]
+ExecStart=/usr/bin/pg_doorman -F Structured /etc/pg_doorman/pg_doorman.yaml
+StandardOutput=journal
+StandardError=journal
+```
+
+`journalctl -u pg_doorman -o json` gives you the JSON back.
+
+## Caveats
+
+- For production, choose `Text` (terminals, syslog) or `Structured` (log shippers). `Debug` is reserved for future use and currently equals `Text`.
+- Source `file` and `line` come from `log` macro call sites. They survive in release builds because PgDoorman ships with debug info enabled.
+- The logger does not include trace IDs or request correlation. For per-request tracing, use `SHOW CLIENTS` and Prometheus metrics.
+
+## Where to next
+
+- [Prometheus reference](../reference/prometheus.md) — for machine-readable metrics.
+- [Latency Percentiles](percentiles.md) — for performance signals.
+- [Admin Commands](admin-commands.md) — for runtime introspection.

--- a/documentation/en/src/observability/percentiles.md
+++ b/documentation/en/src/observability/percentiles.md
@@ -1,0 +1,118 @@
+# Latency Percentiles
+
+PgDoorman tracks query and transaction latency per pool using HDR Histograms. Four percentiles are exposed to Prometheus: p50, p90, p95, p99.
+
+This page explains where the numbers come from and how to read them.
+
+## What is measured
+
+Three latency series per user×database:
+
+| Series | What it covers |
+| --- | --- |
+| `query_histogram` | Time from query start to query completion on a backend. Measures PostgreSQL execution time as observed by PgDoorman. |
+| `xact_histogram` | Time from `BEGIN` (or first statement of an implicit transaction) to `COMMIT` / `ROLLBACK`. |
+| `wait_histogram` | Time a client spent waiting for a backend connection to become available. |
+
+`wait_histogram` is the pool's own contribution to latency. If `wait_histogram` p99 is high but `query_histogram` p99 is low, the bottleneck is connection acquisition, not PostgreSQL.
+
+## Histogram details
+
+PgDoorman uses [HDR Histogram](https://github.com/HdrHistogram/HdrHistogram_rust) with:
+
+- Maximum value: 10 minutes (600 seconds).
+- Significant figures: 2 (about 0.1% relative error).
+
+Memory cost: about 10 KB per histogram. Three histograms per user×database means ~30 KB per pool — comfortable for hundreds of pools.
+
+The default reporting horizon is the lifetime of the process. Histograms reset on `SIGHUP` (config reload) and on explicit `RECONNECT`.
+
+Odyssey uses TDigest, PgBouncer does not expose percentiles. HDR is preferred when you know the upper bound (10 minutes is generous for a connection pool); TDigest handles unbounded streams.
+
+## Prometheus exposure
+
+```
+# HELP pg_doorman_pools_queries_percentile Query latency percentiles in milliseconds
+# TYPE pg_doorman_pools_queries_percentile gauge
+pg_doorman_pools_queries_percentile{percentile="50",user="app",database="mydb"} 1.2
+pg_doorman_pools_queries_percentile{percentile="90",user="app",database="mydb"} 4.7
+pg_doorman_pools_queries_percentile{percentile="95",user="app",database="mydb"} 8.1
+pg_doorman_pools_queries_percentile{percentile="99",user="app",database="mydb"} 24.5
+
+# HELP pg_doorman_pools_transactions_percentile Transaction latency percentiles in milliseconds
+# TYPE pg_doorman_pools_transactions_percentile gauge
+pg_doorman_pools_transactions_percentile{percentile="50",user="app",database="mydb"} 3.8
+# ... (90, 95, 99)
+
+# HELP pg_doorman_pools_avg_wait_time Average client wait time in milliseconds
+# TYPE pg_doorman_pools_avg_wait_time gauge
+pg_doorman_pools_avg_wait_time{user="app",database="mydb"} 0.05
+```
+
+`avg_wait_time` is the mean rather than a percentile (HDR for waits is also tracked but only the mean is currently exported).
+
+## Reading the numbers
+
+### Healthy pool
+
+```
+queries:    p50=1.2  p90=4.7   p95=8.1   p99=24.5
+xacts:      p50=3.8  p90=11.2  p95=18.5  p99=42.7
+wait avg:   0.05ms
+```
+
+p99 is within 20× of p50 — typical for OLTP workloads with rare slow queries. Wait time is microseconds — pool is not the bottleneck.
+
+### Pool under pressure
+
+```
+queries:    p50=1.5   p90=4.9   p95=8.5   p99=25.0
+xacts:      p50=215   p90=1850  p95=2400  p99=4900
+wait avg:   180ms
+```
+
+Query latency is fine — PostgreSQL is healthy. But transactions are slow and wait time is 180ms. Clients are queuing for backends. Check `SHOW POOLS` for `cl_waiting > 0` and `SHOW POOL_COORDINATOR` for evictions or exhaustions. Likely fix: raise `pool_size` or `max_db_connections`. See [Pool Coordinator](../concepts/pool-coordinator.md).
+
+### One slow user
+
+```
+user "fast_app":   queries p99=12   xacts p99=35
+user "report_job": queries p99=4500 xacts p99=8000
+```
+
+`report_job` is dragging down the shared database. With Pool Coordinator on, `report_job`'s slow transactions cause it to donate connections first under pressure (eviction is biased by p95 transaction time). Without Coordinator, isolate `report_job` to its own `min_guaranteed_pool_size` so it cannot starve `fast_app`.
+
+## Grafana
+
+Sample query for query latency by percentile:
+
+```promql
+pg_doorman_pools_queries_percentile{database="mydb"}
+```
+
+Sample alert: query p99 above 100ms for 5 minutes:
+
+```promql
+pg_doorman_pools_queries_percentile{percentile="99"} > 100
+```
+
+Sample queue saturation alert:
+
+```promql
+pg_doorman_pools_avg_wait_time > 50
+```
+
+A dashboard JSON is available in the project's `grafana/` directory.
+
+## Caveats
+
+- Percentiles are per pool, not per query. PgDoorman cannot tell you which query is slow — use `pg_stat_statements` on PostgreSQL for that.
+- HDR histograms hold values, not events. The same query running 100k times contributes to 100k samples; sampling rate is not adjustable.
+- Exporting all four percentiles per series is intentional — exporting raw histogram buckets to Prometheus would be much heavier and rarely useful.
+
+## Where to next
+
+- [Admin Commands](admin-commands.md) — read percentiles directly via `SHOW POOLS_EXTENDED`.
+- [Prometheus reference](../reference/prometheus.md) — full metric list with labels.
+- [Pool Pressure](../tutorials/pool-pressure.md) — diagnostic recipes when percentiles look wrong.
+- [Benchmarks](../benchmarks.md) — reference percentile distributions under load.

--- a/documentation/en/src/operations/signals.md
+++ b/documentation/en/src/operations/signals.md
@@ -1,0 +1,118 @@
+# Signals and Reload
+
+PgDoorman responds to four POSIX signals: `SIGHUP`, `SIGINT`, `SIGUSR2`, and `SIGTERM`. Each does one specific thing.
+
+## Quick reference
+
+| Signal | Effect | Existing connections | When to use |
+| --- | --- | --- | --- |
+| `SIGHUP` | Reload config from disk. | Preserved. | Adjust pools, rotate server TLS certs, edit `pg_hba.conf`. |
+| `SIGTERM` | Graceful shutdown. | Drained until idle, then closed. | Stopping the service. |
+| `SIGUSR2` | Graceful binary upgrade. | Migrated to a new process. | Replacing the binary without downtime. |
+| `SIGINT` | Depends on TTY (see below). | Varies. | Ctrl+C in development; deprecated in production. |
+
+## Reload (`SIGHUP`)
+
+```bash
+kill -HUP $(pidof pg_doorman)
+```
+
+Re-reads the config file and applies changes. What reloads:
+
+- Pool definitions (added, removed, resized).
+- User lists, passwords, `auth_query` blocks.
+- `pg_hba.conf` rules (file or inline content).
+- Server-side TLS certificates and CA bundles (lock-free swap; existing TLS connections keep their original context).
+- Talos and JWT public keys.
+- Log level and format.
+
+What does **not** reload:
+
+- `general.host`, `general.port` — listening socket is fixed at startup.
+- Client-side TLS certificates — process restart required, or use binary upgrade.
+- Worker thread count and Tokio runtime parameters.
+
+After reload, `SHOW CONFIG` reflects the new values. Existing client connections are not re-evaluated against the new `pg_hba.conf` — only new connections.
+
+## Graceful shutdown (`SIGTERM`)
+
+```bash
+kill -TERM $(pidof pg_doorman)
+```
+
+PgDoorman:
+
+1. Stops accepting new connections.
+2. Closes idle backend connections.
+3. Logs how many clients are still in transactions.
+4. Waits up to `shutdown_timeout` (default 10s) for clients to finish.
+5. Exits.
+
+`shutdown_timeout` is a hard cap. Clients still in transactions when it fires receive a connection close.
+
+```yaml
+general:
+  shutdown_timeout: "30s"
+```
+
+For systemd, set `TimeoutStopSec` to a value larger than `shutdown_timeout` so systemd does not `SIGKILL` while PgDoorman is still draining.
+
+## Binary upgrade (`SIGUSR2`)
+
+```bash
+kill -USR2 $(pidof pg_doorman)
+```
+
+The recommended way to replace the binary without dropping clients:
+
+1. Replace the binary on disk with the new version.
+2. Send `SIGUSR2` to the running process.
+3. The current process spawns a child running the new binary, hands over the listening socket, and continues serving existing clients until they finish.
+4. New clients connect to the child immediately.
+5. The old process exits when the last client transaction completes (or on `shutdown_timeout`).
+
+The child sends `sd_notify MAINPID=<new_pid>` so systemd `Type=notify` units update their main PID seamlessly.
+
+For the full protocol, TLS migration, and rollback, see [Binary Upgrade](../tutorials/binary-upgrade.md).
+
+## `SIGINT` (Ctrl+C)
+
+`SIGINT` is context-sensitive:
+
+- **Foreground with a TTY** (development, `cargo run`): graceful shutdown only.
+- **Daemon mode or no TTY** (legacy production): triggers a binary upgrade + graceful shutdown, like `SIGUSR2`.
+
+The legacy `SIGINT` upgrade path exists for backward compatibility with deployments that send `SIGINT` from init scripts. New deployments should use `SIGUSR2` for upgrade and `SIGTERM` for shutdown explicitly.
+
+## systemd integration
+
+PgDoorman supports `Type=notify`. The shipped `pg_doorman.service` unit runs the binary in the foreground and notifies systemd via `sd_notify`:
+
+```ini
+[Service]
+Type=notify
+ExecStart=/usr/bin/pg_doorman /etc/pg_doorman/pg_doorman.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+TimeoutStopSec=60
+Restart=on-failure
+```
+
+`sd_notify READY=1` is sent after the listening socket is bound and pools are initialized. `sd_notify MAINPID=<child>` is sent during binary upgrade so systemd tracks the new process correctly.
+
+If you migrate from `Type=forking` + `--daemon`, drop `--daemon` and switch to `Type=notify` — fewer moving parts and proper readiness tracking. Older deployments using `--daemon` continue to work but do not benefit from `sd_notify`.
+
+## Daemon mode
+
+`pg_doorman --daemon` forks into the background and writes its PID to `daemon_pid_file` (default `/tmp/pg_doorman.pid`). For systemd users, prefer `Type=notify` over `--daemon`.
+
+```yaml
+general:
+  daemon_pid_file: "/var/run/pg_doorman.pid"
+```
+
+## Where to next
+
+- [Binary Upgrade](../tutorials/binary-upgrade.md) — full upgrade protocol with TLS migration.
+- [Troubleshooting](../tutorials/troubleshooting.md) — what to check when reload does not pick up changes.
+- [TLS](../guides/tls.md#hot-reload) — `SIGHUP` reload semantics for server-side certificates.


### PR DESCRIPTION
## What changed

The site at [ozontech.github.io/pg_doorman](https://ozontech.github.io/pg_doorman/) previously buried **Pool Coordinator**, **Patroni-assisted fallback**, and **graceful binary upgrade** among generic bullets. Most authentication methods lived only in the changelog or deep inside `pool-pressure.md`. Server-side TLS (added in 3.6.0) had no chapter at all.
