### PR TITLE
ci: bench runner on VM's

### DIFF
--- a/.github/workflows/bench-ubicloud.yml
+++ b/.github/workflows/bench-ubicloud.yml
@@ -1,0 +1,240 @@
+name: Ubicloud Benchmarks
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      vm_size:
+        description: 'Ubicloud VM size (cores/RAM grow with the suffix)'
+        required: false
+        default: 'standard-30'
+        type: choice
+        options:
+          - standard-8
+          - standard-16
+          - standard-30
+          - standard-60
+      vm_location:
+        description: 'Ubicloud location'
+        required: false
+        default: 'eu-central-h1'
+        type: choice
+        options:
+          - eu-central-h1
+      bench_duration:
+        description: 'Seconds per pgbench run'
+        required: false
+        default: '30'
+      doorman_workers:
+        description: 'worker_threads for pg_doorman and odyssey'
+        required: false
+        default: '12'
+      pgbench_jobs:
+        description: 'pgbench -j for c40/c120/c500/c10000 (c1 stays at 1)'
+        required: false
+        default: '4'
+      storage_gib:
+        description: 'VM storage size (GiB)'
+        required: false
+        default: '80'
+
+env:
+  UBICLOUD_API: https://api.ubicloud.com
+
+jobs:
+  bench:
+    name: Bench on Ubicloud (${{ inputs.vm_size }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate ephemeral SSH key
+        run: |
+          set -euo pipefail
+          ssh-keygen -t ed25519 -f /tmp/bench_key -N '' -q -C "ubicloud-bench-${{ github.run_id }}"
+          chmod 600 /tmp/bench_key
+          {
+            echo 'PUBKEY<<KEYEOF'
+            cat /tmp/bench_key.pub
+            echo 'KEYEOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Create Ubicloud VM
+        id: create_vm
+        env:
+          TOKEN: ${{ secrets.UBICLOUD_API_TOKEN }}
+          PROJECT: ${{ secrets.UBICLOUD_PROJECT_ID }}
+          LOCATION: ${{ inputs.vm_location }}
+          SIZE: ${{ inputs.vm_size }}
+          STORAGE: ${{ inputs.storage_gib }}
+        run: |
+          set -euo pipefail
+          VM_NAME="bench-${{ github.run_id }}-${{ github.run_attempt }}"
+          BODY=$(jq -n \
+            --arg pk "$PUBKEY" \
+            --arg size "$SIZE" \
+            --argjson storage "$STORAGE" \
+            '{public_key:$pk, size:$size, unix_user:"ubuntu", enable_ip4:true, storage_size_gib:$storage}')
+          RESP=$(curl -fsS -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$VM_NAME")
+          VM_ID=$(echo "$RESP" | jq -r '.id')
+          echo "VM created: id=$VM_ID name=$VM_NAME"
+          echo "vm_name=$VM_NAME" >> "$GITHUB_OUTPUT"
+          echo "vm_id=$VM_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for VM running
+        id: wait_vm
+        env:
+          TOKEN: ${{ secrets.UBICLOUD_API_TOKEN }}
+          PROJECT: ${{ secrets.UBICLOUD_PROJECT_ID }}
+          LOCATION: ${{ inputs.vm_location }}
+          VM_NAME: ${{ steps.create_vm.outputs.vm_name }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            RESP=$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+              "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$VM_NAME")
+            STATE=$(echo "$RESP" | jq -r '.state')
+            IP=$(echo "$RESP" | jq -r '.ip4 // empty')
+            printf '[%s] state=%s ip=%s\n' "$i" "$STATE" "${IP:-none}"
+            if [[ "$STATE" == "running" && -n "$IP" ]]; then
+              echo "ip=$IP" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "VM did not become running in 5 minutes" >&2
+          exit 1
+
+      - name: Wait for SSH
+        env:
+          IP: ${{ steps.wait_vm.outputs.ip }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if ssh -i /tmp/bench_key \
+                  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                  -o ConnectTimeout=5 -o LogLevel=ERROR \
+                  ubuntu@"$IP" true 2>/dev/null; then
+              echo "ssh ready"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "ssh did not respond" >&2
+          exit 1
+
+      - name: Upload source to VM
+        env:
+          IP: ${{ steps.wait_vm.outputs.ip }}
+        run: |
+          set -euo pipefail
+          git archive --format=tar HEAD -o /tmp/source.tar
+          scp -i /tmp/bench_key \
+            -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            /tmp/source.tar ubuntu@"$IP":/tmp/source.tar
+          ssh -i /tmp/bench_key \
+            -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            ubuntu@"$IP" \
+            'sudo mkdir -p /workspace && sudo chown "$USER" /workspace && tar -C /workspace -xf /tmp/source.tar'
+
+      - name: Run setup-and-run-bench.sh on VM
+        env:
+          IP: ${{ steps.wait_vm.outputs.ip }}
+          BENCH_DURATION: ${{ inputs.bench_duration }}
+          WORKERS: ${{ inputs.doorman_workers }}
+          PGBENCH_JOBS: ${{ inputs.pgbench_jobs }}
+        run: |
+          set -euo pipefail
+          # The script requires root (apt, initdb, runuser).
+          ssh -i /tmp/bench_key \
+            -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=60 -o ServerAliveCountMax=30 \
+            ubuntu@"$IP" \
+            "sudo WORKSPACE=/workspace \
+                 BENCH_DURATION=$BENCH_DURATION \
+                 BENCH_DOORMAN_WORKERS=$WORKERS \
+                 BENCH_ODYSSEY_WORKERS=$WORKERS \
+                 BENCH_PGBENCH_JOBS_C40=$PGBENCH_JOBS \
+                 BENCH_PGBENCH_JOBS_C120=$PGBENCH_JOBS \
+                 BENCH_PGBENCH_JOBS_C500=$PGBENCH_JOBS \
+                 BENCH_PGBENCH_JOBS_C10000=$PGBENCH_JOBS \
+                 bash /workspace/benches/setup-and-run-bench.sh"
+
+      - name: Download bench-results.tar.gz
+        id: download
+        if: always() && steps.wait_vm.outputs.ip != ''
+        env:
+          IP: ${{ steps.wait_vm.outputs.ip }}
+        run: |
+          mkdir -p artifacts
+          if scp -i /tmp/bench_key \
+              -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              ubuntu@"$IP":/tmp/bench-results.tar.gz artifacts/bench-results.tar.gz; then
+            ls -lh artifacts/bench-results.tar.gz
+            echo "got_tarball=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no tarball produced"
+            echo "got_tarball=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Parse logs into benchmarks.md
+        if: steps.download.outputs.got_tarball == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p documentation/en/src
+          python3 benches/parse-bench-logs.py \
+            artifacts/bench-results.tar.gz \
+            documentation/en/src/benchmarks.md
+          head -60 documentation/en/src/benchmarks.md
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubicloud-bench-${{ github.run_number }}
+          path: artifacts/
+          retention-days: 30
+
+      - name: Delete VM
+        if: always() && steps.create_vm.outputs.vm_name != ''
+        env:
+          TOKEN: ${{ secrets.UBICLOUD_API_TOKEN }}
+          PROJECT: ${{ secrets.UBICLOUD_PROJECT_ID }}
+          LOCATION: ${{ inputs.vm_location }}
+          VM_NAME: ${{ steps.create_vm.outputs.vm_name }}
+        run: |
+          curl -sS -w 'HTTP:%{http_code}\n' -X DELETE \
+            -H "Authorization: Bearer $TOKEN" \
+            "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$VM_NAME" || true
+
+      - name: Create PR with benchmarks.md
+        if: steps.download.outputs.got_tarball == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          BRANCH="ubicloud-bench-results-$(date +%Y%m%d-%H%M%S)"
+          cp documentation/en/src/benchmarks.md /tmp/benchmarks.md.tmp
+          git fetch origin master
+          git checkout -b "$BRANCH" origin/master
+          mv /tmp/benchmarks.md.tmp documentation/en/src/benchmarks.md
+          git add documentation/en/src/benchmarks.md
+          if git diff --staged --quiet; then
+            echo "no changes to commit"; exit 0
+          fi
+          git commit -m "Update Ubicloud benchmark results [skip ci]"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Update Ubicloud benchmark results (${{ inputs.vm_size }})" \
+            --body "Automated benchmark on Ubicloud (${{ inputs.vm_size }}, ${{ inputs.vm_location }}, duration ${{ inputs.bench_duration }}s)." \
+            --base master --head "$BRANCH"

--- a/.github/workflows/bench-ubicloud.yml
+++ b/.github/workflows/bench-ubicloud.yml
@@ -40,6 +40,11 @@ on:
         description: 'VM storage size (GiB)'
         required: false
         default: '80'
+      create_pr:
+        description: 'Open a PR with the new benchmarks.md (uncheck for smoke runs)'
+        required: false
+        default: true
+        type: boolean
 
 env:
   UBICLOUD_API: https://api.ubicloud.com
@@ -145,7 +150,7 @@ jobs:
             ubuntu@"$IP" \
             'sudo mkdir -p /workspace && sudo chown "$USER" /workspace && tar -C /workspace -xf /tmp/source.tar'
 
-      - name: Run setup-and-run-bench.sh on VM
+      - name: Launch benchmark on VM (detached)
         env:
           IP: ${{ steps.wait_vm.outputs.ip }}
           BENCH_DURATION: ${{ inputs.bench_duration }}
@@ -153,20 +158,65 @@ jobs:
           PGBENCH_JOBS: ${{ inputs.pgbench_jobs }}
         run: |
           set -euo pipefail
-          # The script requires root (apt, initdb, runuser).
+          # The bench can run for hours, so we don't keep ssh open. The wrapper
+          # records its own exit code into /tmp/bench.rc and the next step polls
+          # for that file. If the runner crashes, the VM keeps going.
           ssh -i /tmp/bench_key \
             -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            -o ServerAliveInterval=60 -o ServerAliveCountMax=30 \
-            ubuntu@"$IP" \
-            "sudo WORKSPACE=/workspace \
-                 BENCH_DURATION=$BENCH_DURATION \
-                 BENCH_DOORMAN_WORKERS=$WORKERS \
-                 BENCH_ODYSSEY_WORKERS=$WORKERS \
-                 BENCH_PGBENCH_JOBS_C40=$PGBENCH_JOBS \
-                 BENCH_PGBENCH_JOBS_C120=$PGBENCH_JOBS \
-                 BENCH_PGBENCH_JOBS_C500=$PGBENCH_JOBS \
-                 BENCH_PGBENCH_JOBS_C10000=$PGBENCH_JOBS \
-                 bash /workspace/benches/setup-and-run-bench.sh"
+            -o ConnectTimeout=10 \
+            ubuntu@"$IP" "bash -s" <<EOF
+          set -euo pipefail
+          cat > /tmp/bench-wrap.sh <<'WRAP'
+          #!/bin/bash
+          sudo WORKSPACE=/workspace \\
+               BENCH_DURATION=$BENCH_DURATION \\
+               BENCH_DOORMAN_WORKERS=$WORKERS \\
+               BENCH_ODYSSEY_WORKERS=$WORKERS \\
+               BENCH_PGBENCH_JOBS_C40=$PGBENCH_JOBS \\
+               BENCH_PGBENCH_JOBS_C120=$PGBENCH_JOBS \\
+               BENCH_PGBENCH_JOBS_C500=$PGBENCH_JOBS \\
+               BENCH_PGBENCH_JOBS_C10000=$PGBENCH_JOBS \\
+               bash /workspace/benches/setup-and-run-bench.sh > /tmp/bench.out 2>&1
+          echo \$? > /tmp/bench.rc
+          WRAP
+          chmod +x /tmp/bench-wrap.sh
+          rm -f /tmp/bench.rc /tmp/bench.out
+          nohup /tmp/bench-wrap.sh < /dev/null > /tmp/bench-wrap.log 2>&1 &
+          disown
+          echo "launched bench-wrap.sh on \$(hostname), pid \$!"
+          EOF
+
+      - name: Wait for benchmark to finish
+        env:
+          IP: ${{ steps.wait_vm.outputs.ip }}
+        run: |
+          set -uo pipefail
+          # Poll once a minute for up to 5 hours. Each cycle prints the tail
+          # of bench.out so progress is visible in the Actions UI.
+          MAX_CYCLES=300
+          for i in $(seq 1 $MAX_CYCLES); do
+            echo "==== poll #$i (elapsed $((i-1)) min) ===="
+            OUT=$(ssh -i /tmp/bench_key \
+              -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=10 -o LogLevel=ERROR \
+              ubuntu@"$IP" "
+                if [ -f /tmp/bench.rc ]; then
+                  echo BENCH_DONE_RC=\$(cat /tmp/bench.rc)
+                fi
+                echo '--- tail bench.out ---'
+                tail -n 20 /tmp/bench.out 2>/dev/null || echo '(no bench.out yet)'
+              " 2>&1) || { echo "ssh poll failed; retrying"; sleep 60; continue; }
+            echo "$OUT"
+            if echo "$OUT" | grep -q '^BENCH_DONE_RC='; then
+              RC=$(echo "$OUT" | sed -nE 's/BENCH_DONE_RC=([0-9]+).*/\1/p' | head -1)
+              echo "benchmark finished with rc=$RC after $((i-1)) min"
+              [[ "$RC" == "0" ]] || exit 1
+              exit 0
+            fi
+            sleep 60
+          done
+          echo "benchmark did not finish in $MAX_CYCLES minutes"
+          exit 1
 
       - name: Download bench-results.tar.gz
         id: download
@@ -216,7 +266,7 @@ jobs:
             "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$VM_NAME" || true
 
       - name: Create PR with benchmarks.md
-        if: steps.download.outputs.got_tarball == 'true'
+        if: steps.download.outputs.got_tarball == 'true' && inputs.create_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/bench-ubicloud.yml
+++ b/.github/workflows/bench-ubicloud.yml
@@ -265,26 +265,41 @@ jobs:
             -H "Authorization: Bearer $TOKEN" \
             "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$VM_NAME" || true
 
-      - name: Create PR with benchmarks.md
+      - name: Create Pull Request with results
         if: steps.download.outputs.got_tarball == 'true' && inputs.create_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          BRANCH="ubicloud-bench-results-$(date +%Y%m%d-%H%M%S)"
+
+          # Save benchmark results to a temporary location before switching branches
           cp documentation/en/src/benchmarks.md /tmp/benchmarks.md.tmp
+
+          # Create a unique branch name with timestamp
+          BRANCH_NAME="ubicloud-benchmark-results-$(date +%Y%m%d-%H%M%S)"
+
+          # Fetch latest master and create new branch from it
           git fetch origin master
-          git checkout -b "$BRANCH" origin/master
+          git checkout -b "$BRANCH_NAME" origin/master
+
+          # Restore benchmark results to the new branch
           mv /tmp/benchmarks.md.tmp documentation/en/src/benchmarks.md
+
+          # Check if there are any changes to commit
           git add documentation/en/src/benchmarks.md
           if git diff --staged --quiet; then
-            echo "no changes to commit"; exit 0
+            echo "No changes to benchmark results, skipping PR creation"
+            exit 0
           fi
+
+          # Commit and push
           git commit -m "Update Ubicloud benchmark results [skip ci]"
-          git push origin "$BRANCH"
+          git push origin "$BRANCH_NAME"
+
+          # Create Pull Request to master
           gh pr create \
-            --title "Update Ubicloud benchmark results (${{ inputs.vm_size }})" \
-            --body "Automated benchmark on Ubicloud (${{ inputs.vm_size }}, ${{ inputs.vm_location }}, duration ${{ inputs.bench_duration }}s)." \
-            --base master --head "$BRANCH"
+            --title "Update Ubicloud benchmark results" \
+            --body "Automated benchmark results from Ubicloud (${{ inputs.vm_size }}, ${{ inputs.vm_location }}). This PR updates the benchmark comparison table in documentation/en/src/benchmarks.md." \
+            --base "master" \
+            --head "$BRANCH_NAME"

--- a/.github/workflows/ubicloud-cleanup.yml
+++ b/.github/workflows/ubicloud-cleanup.yml
@@ -1,0 +1,94 @@
+name: Ubicloud Cleanup
+
+permissions:
+  contents: read
+
+# Manual emergency cleanup. Lists every VM in the project whose name starts
+# with the given prefix and deletes them when confirm_delete=true. Useful when
+# a benchmark run leaves a VM behind (runner crash, cancelled job, etc.) so
+# nothing keeps billing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      vm_location:
+        description: 'Ubicloud location to scan'
+        required: false
+        default: 'eu-central-h1'
+        type: choice
+        options:
+          - eu-central-h1
+      name_prefix:
+        description: 'Only touch VMs whose name starts with this'
+        required: false
+        default: 'bench-'
+      confirm_delete:
+        description: 'Actually delete (false = dry-run, only list)'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  UBICLOUD_API: https://api.ubicloud.com
+
+jobs:
+  cleanup:
+    name: Cleanup Ubicloud VMs (${{ inputs.name_prefix }}*)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: List matching VMs
+        id: list
+        env:
+          TOKEN: ${{ secrets.UBICLOUD_API_TOKEN }}
+          PROJECT: ${{ secrets.UBICLOUD_PROJECT_ID }}
+          LOCATION: ${{ inputs.vm_location }}
+          PREFIX: ${{ inputs.name_prefix }}
+        run: |
+          set -euo pipefail
+          RESP=$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+            "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm")
+          echo "All VMs in $LOCATION:"
+          echo "$RESP" | jq -r '.items[] | "  \(.name)\t\(.state)\t\(.size)\tip4=\(.ip4 // "-")"'
+          echo
+          NAMES=$(echo "$RESP" | jq -r --arg p "$PREFIX" '.items[] | select(.name | startswith($p)) | .name')
+          if [ -z "$NAMES" ]; then
+            echo "No VMs match prefix '$PREFIX'."
+          else
+            echo "Matched (prefix '$PREFIX'):"
+            echo "$NAMES" | sed 's/^/  /'
+          fi
+          {
+            echo "names<<EOF"
+            echo "$NAMES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delete matching VMs
+        if: inputs.confirm_delete == true && steps.list.outputs.names != ''
+        env:
+          TOKEN: ${{ secrets.UBICLOUD_API_TOKEN }}
+          PROJECT: ${{ secrets.UBICLOUD_PROJECT_ID }}
+          LOCATION: ${{ inputs.vm_location }}
+          NAMES: ${{ steps.list.outputs.names }}
+        run: |
+          set -uo pipefail
+          fail=0
+          while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            CODE=$(curl -sS -o /tmp/del.body -w '%{http_code}' -X DELETE \
+              -H "Authorization: Bearer $TOKEN" \
+              "$UBICLOUD_API/project/$PROJECT/location/$LOCATION/vm/$name" || echo curl_err)
+            if [[ "$CODE" =~ ^2 ]]; then
+              echo "deleted: $name (HTTP $CODE)"
+            else
+              echo "FAILED: $name (HTTP $CODE) :: $(cat /tmp/del.body)"
+              fail=1
+            fi
+          done <<< "$NAMES"
+          exit "$fail"
+
+      - name: Dry-run notice
+        if: inputs.confirm_delete == false
+        run: |
+          echo "DRY-RUN — set 'confirm_delete' to true and re-run to actually delete."

--- a/benches/parse-bench-logs.py
+++ b/benches/parse-bench-logs.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Parse bench-results.tar.gz from setup-and-run-bench.sh and emit benchmarks.md.
+
+Same shape as documentation/en/src/benchmarks.md: per-protocol sections with a
+relative-throughput table (vs pgbouncer / vs odyssey) and an absolute-latency
+table (p50/p95/p99 in one cell per pooler).
+
+Latency percentiles come from pgbench `--log` files (column 3 = µs) — same
+convention as tests/bdd/pgbench_helper.rs::compute_latency_percentiles.
+
+stdlib only (Python 3.10+).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tarfile
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+TPS_RE = re.compile(r"^tps = ([\d.]+)", re.MULTILINE)
+LAT_AVG_RE = re.compile(r"^latency average = ([\d.]+)", re.MULTILINE)
+NAME_RE = re.compile(
+    r"^(?P<pooler>pg_doorman|odyssey|pgbouncer)"
+    r"(?:_(?P<ssl>ssl))?"
+    # bench.feature names SSL+connect cases without an explicit proto segment
+    # (they all use --protocol=simple), so proto is optional and we default it
+    # to "simple" in parse_test_name.
+    r"(?:_(?P<proto>simple|extended|prepared))?"
+    r"(?:_(?P<connect>connect))?"
+    r"_c(?P<clients>\d+)$"
+)
+SERVICE_LOG_NAMES = {"doorman", "odyssey", "pgbouncer", "pg"}
+
+PROTO_ORDER = ("simple", "extended", "prepared")
+# (ssl, connect) tuples in the same row order as the existing benchmarks.md.
+MODE_ORDER = ((False, False), (False, True), (True, False), (True, True))
+CLIENT_ORDER = (1, 40, 120, 500, 10000)
+
+
+# ---------- pure helpers (covered by tests/test_parse_bench_logs.py) ----------
+
+
+def parse_pgbench_stdout(text: str) -> dict:
+    tps = TPS_RE.search(text)
+    lat = LAT_AVG_RE.search(text)
+    return {
+        "tps": float(tps.group(1)) if tps else None,
+        "lat_avg_ms": float(lat.group(1)) if lat else None,
+    }
+
+
+def percentile_ms(sorted_us: list[float], frac: float) -> float | None:
+    if not sorted_us:
+        return None
+    n = len(sorted_us)
+    # nearest-rank, matches tests/bdd/pgbench_helper.rs::percentile_index
+    idx = max(0, min(n - 1, int(n * frac + 0.999999) - 1))
+    return sorted_us[idx] / 1000.0
+
+
+def parse_test_name(name: str) -> dict | None:
+    m = NAME_RE.match(name)
+    if not m:
+        return None
+    d = m.groupdict()
+    return {
+        "pooler": d["pooler"],
+        "ssl": bool(d["ssl"]),
+        "proto": d["proto"] or "simple",
+        "connect": bool(d["connect"]),
+        "clients": int(d["clients"]),
+    }
+
+
+def mode_label(ssl: bool, connect: bool) -> str:
+    parts = []
+    if ssl:
+        parts.append("SSL")
+    if connect:
+        parts.append("Reconnect")
+    return " + ".join(parts)
+
+
+def row_label(clients: int, mode: str) -> str:
+    word = "client" if clients == 1 else "clients"
+    label = f"{clients:,} {word}"
+    if mode:
+        label += f" + {mode}"
+    return label
+
+
+def format_throughput(self_tps: float | None, other_tps: float | None) -> str:
+    """Relative throughput cell: '+N%', '-N%', '≈0%', 'xN.N', '∞', 'N/A', '-'."""
+    if self_tps is None and other_tps is None:
+        return "-"
+    if self_tps is None or other_tps is None:
+        return "N/A"
+    if other_tps == 0:
+        return "∞" if self_tps > 0 else "-"
+    ratio = self_tps / other_tps
+    pct = (ratio - 1) * 100
+    if abs(pct) < 3:
+        return "≈0%"
+    if ratio >= 1.5:
+        return f"x{ratio:.1f}"
+    sign = "+" if pct > 0 else ""
+    return f"{sign}{pct:.0f}%"
+
+
+def format_latency_triplet(rec: dict | None) -> str:
+    """`p50 / p95 / p99` (ms, two decimals) or '-' when any percentile missing."""
+    if not rec:
+        return "-"
+    p50 = rec.get("p50_ms")
+    p95 = rec.get("p95_ms")
+    p99 = rec.get("p99_ms")
+    if any(v is None for v in (p50, p95, p99)):
+        return "-"
+    return f"{p50:.2f} / {p95:.2f} / {p99:.2f}"
+
+
+# ---------- I/O ----------
+
+
+def parse_test(name: str, src: Path) -> dict:
+    rec = parse_pgbench_stdout((src / f"{name}.log").read_text(errors="replace"))
+    latencies_us: list[float] = []
+    for f in src.glob(f"{name}_pgbenchlog.*"):
+        for line in f.read_text(errors="replace").splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            try:
+                latencies_us.append(float(parts[2]))
+            except ValueError:
+                pass
+    latencies_us.sort()
+    rec["p50_ms"] = percentile_ms(latencies_us, 0.50)
+    rec["p95_ms"] = percentile_ms(latencies_us, 0.95)
+    rec["p99_ms"] = percentile_ms(latencies_us, 0.99)
+    rec["samples"] = len(latencies_us)
+    return rec
+
+
+# ---------- rendering ----------
+
+
+def emit_metadata(meta: dict | None) -> list[str]:
+    if not meta:
+        return []
+    mem_kb = meta.get("memory_kb")
+    mem_gb = f"{mem_kb / 1024 / 1024:.1f}" if mem_kb else "?"
+    return [
+        "### Environment",
+        "",
+        f"- **Host**: {meta.get('host', '?')}",
+        f"- **Resources**: {meta.get('vcpus', '?')} vCPU / {mem_gb} GB",
+        f"- **Workers**: pg_doorman: {meta.get('doorman_workers', '?')}, "
+        f"odyssey: {meta.get('odyssey_workers', '?')}",
+        f"- **Duration per pgbench run**: {meta.get('duration_per_run_sec', '?')}s",
+        f"- **Started**: {meta.get('started_at', '?')}",
+        f"- **Commit**: `{meta.get('git_sha', '?')}`",
+        "",
+    ]
+
+
+LEGEND = [
+    "### Reading the tables",
+    "",
+    "**Throughput** — pg_doorman TPS relative to each competitor:",
+    "",
+    "| Value | Meaning |",
+    "|-------|---------|",
+    "| +N% | Faster by N% |",
+    "| -N% | Slower by N% |",
+    "| ≈0% | Within 3% |",
+    "| xN | N times faster or slower |",
+    "| ∞ | Competitor got 0 TPS |",
+    "| N/A | Unsupported |",
+    "| - | Not tested |",
+    "",
+    "**Latency** — per-transaction latency in ms. Each cell: `p50 / p95 / p99`. Lower is better.",
+    "",
+]
+
+NOTES = [
+    "### Notes",
+    "",
+    "- Throughput values are relative ratios — comparable across runs on identical hardware",
+    "- Latency values are absolute, measured per-transaction",
+]
+
+
+def _emit_throughput_table(proto_groups: dict[tuple, dict]) -> list[str]:
+    out = [
+        "### Throughput",
+        "",
+        "| Test | vs pgbouncer | vs odyssey |",
+        "|------|--------------|------------|",
+    ]
+    for ssl, conn in MODE_ORDER:
+        for c in CLIENT_ORDER:
+            key = (ssl, conn, c)
+            if key not in proto_groups:
+                continue
+            row = proto_groups[key]
+            d = row.get("pg_doorman", {})
+            b = row.get("pgbouncer", {})
+            o = row.get("odyssey", {})
+            label = row_label(c, mode_label(ssl, conn))
+            out.append(
+                f"| {label} | "
+                f"{format_throughput(d.get('tps'), b.get('tps'))} | "
+                f"{format_throughput(d.get('tps'), o.get('tps'))} |"
+            )
+    return out
+
+
+def _emit_latency_table(proto_groups: dict[tuple, dict]) -> list[str]:
+    out = [
+        "### Latency — p50 / p95 / p99 (ms)",
+        "",
+        "| Test | pg_doorman (ms) | pgbouncer (ms) | odyssey (ms) |",
+        "|------|----------------|----------------|--------------|",
+    ]
+    for ssl, conn in MODE_ORDER:
+        for c in CLIENT_ORDER:
+            key = (ssl, conn, c)
+            if key not in proto_groups:
+                continue
+            row = proto_groups[key]
+            label = row_label(c, mode_label(ssl, conn))
+            out.append(
+                f"| {label} | "
+                f"{format_latency_triplet(row.get('pg_doorman'))} | "
+                f"{format_latency_triplet(row.get('pgbouncer'))} | "
+                f"{format_latency_triplet(row.get('odyssey'))} |"
+            )
+    return out
+
+
+def render(results: dict[str, dict], meta: dict | None) -> str:
+    groups: dict[tuple, dict[str, dict]] = defaultdict(dict)
+    unmatched: list[str] = []
+    for name, data in results.items():
+        n = parse_test_name(name)
+        if n is None:
+            unmatched.append(name)
+            continue
+        key = (n["proto"], n["ssl"], n["connect"], n["clients"])
+        groups[key][n["pooler"]] = data
+
+    duration = (meta or {}).get("duration_per_run_sec", "?")
+    out: list[str] = [
+        "---",
+        "title: Benchmarks",
+        "---",
+        "",
+        "# Benchmarks",
+        "",
+        f"pg_doorman vs pgbouncer vs odyssey. Each test runs `pgbench` for {duration} seconds through a 40-connection pool.",
+        "",
+        f"Last updated: {datetime.now(timezone.utc):%Y-%m-%d %H:%M UTC}",
+        "",
+    ]
+    out += emit_metadata(meta)
+    out += LEGEND
+
+    for proto in PROTO_ORDER:
+        proto_groups = {
+            (ssl, conn, c): data
+            for (p, ssl, conn, c), data in groups.items()
+            if p == proto
+        }
+        if not proto_groups:
+            continue
+        out += [
+            "---",
+            "",
+            f"## {proto.capitalize()} protocol",
+            "",
+        ]
+        out += _emit_throughput_table(proto_groups)
+        out.append("")
+        out += _emit_latency_table(proto_groups)
+        out.append("")
+
+    out += ["---", ""]
+    out += NOTES
+
+    if unmatched:
+        out += ["", "### Unparsed test names", ""]
+        out += [f"- {n}" for n in sorted(unmatched)]
+
+    out.append("")
+    return "\n".join(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("tarball", help="bench-results.tar.gz")
+    ap.add_argument("output", help="output markdown file")
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with tarfile.open(args.tarball, "r:gz") as tf:
+            # filter="data" rejects path-traversal entries; tarball is local so
+            # this is mostly future-proofing for Python 3.14's default change.
+            tf.extractall(tmp, filter="data")
+        src = Path(tmp) / "bench-results"
+        if not src.is_dir():
+            sys.exit("tarball missing 'bench-results/' dir")
+
+        meta = None
+        meta_file = src / "metadata.json"
+        if meta_file.exists():
+            meta = json.loads(meta_file.read_text())
+
+        results: dict[str, dict] = {}
+        for log_file in sorted(src.glob("*.log")):
+            name = log_file.stem
+            if name in SERVICE_LOG_NAMES:
+                continue
+            results[name] = parse_test(name, src)
+
+        Path(args.output).write_text(render(results, meta))
+        print(f"wrote {args.output} with {len(results)} tests")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/setup-and-run-bench.sh
+++ b/benches/setup-and-run-bench.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# Run me as root on a fresh Ubuntu 22.04 host. Internet plus the repo source
+# under $WORKSPACE (default /workspace) is enough.
+#
+# Layout: postgres, pg_doorman, odyssey and pgbouncer all live as runit
+# services under /etc/service/. runsvdir supervises them; chpst handles the
+# chuid and RLIMIT_NOFILE per service. The script's only jobs are install,
+# build, write configs, hand control to runit, then drive pgbench.
+#
+# Output: /tmp/bench-results.tar.gz with raw pgbench stdout, per-transaction
+# pgbench --log files, and the four service logs. Parsing happens elsewhere
+# (see benches/parse-bench-logs.py).
+#
+# Tunables (env): BENCH_DOORMAN_WORKERS, BENCH_ODYSSEY_WORKERS, BENCH_DURATION,
+#                 BENCH_PGBENCH_JOBS_C{1,40,120,500,10000}, WORKSPACE,
+#                 CARGO_TARGET_DIR.
+
+set -euo pipefail
+
+[[ $EUID -eq 0 ]] || { echo "Run me as root (e.g. sudo bash $0)"; exit 1; }
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+FEATURE_FILE="$WORKSPACE/tests/bdd/features/bench.feature"
+RESULTS_DIR=/tmp/bench-results
+RESULTS_TARBALL=/tmp/bench-results.tar.gz
+
+PG_VERSION=14
+PG_PORT=5433
+DOORMAN_PORT=6432
+ODYSSEY_PORT=6433
+PGBOUNCER_PORT=6434
+
+BENCH_DURATION="${BENCH_DURATION:-30}"
+DOORMAN_WORKERS="${BENCH_DOORMAN_WORKERS:-12}"
+ODYSSEY_WORKERS="${BENCH_ODYSSEY_WORKERS:-12}"
+PGBENCH_JOBS_C1="${BENCH_PGBENCH_JOBS_C1:-1}"
+PGBENCH_JOBS_C40="${BENCH_PGBENCH_JOBS_C40:-4}"
+PGBENCH_JOBS_C120="${BENCH_PGBENCH_JOBS_C120:-4}"
+PGBENCH_JOBS_C500="${BENCH_PGBENCH_JOBS_C500:-4}"
+PGBENCH_JOBS_C10000="${BENCH_PGBENCH_JOBS_C10000:-4}"
+
+PGBIN="/usr/lib/postgresql/$PG_VERSION/bin"
+PGDATA=/tmp/pgdata
+SSL_KEY=/tmp/bench-key.pem
+SSL_CERT=/tmp/bench-cert.pem
+PGBENCH_FILE=/tmp/pgbench.sql
+SVDIR=/etc/service
+SERVICES=(postgres pg_doorman odyssey pgbouncer)
+
+log() { printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+install_packages() {
+  log "Installing system packages"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg lsb-release gettext-base
+  install -d /usr/share/postgresql-common/pgdg
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+  local codename
+  codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-jammy}")
+  cat > /etc/apt/sources.list.d/pgdg.list <<EOF
+deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $codename-pgdg main
+EOF
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+    "postgresql-$PG_VERSION" "postgresql-contrib-$PG_VERSION" \
+    pgbouncer postgresql-client \
+    build-essential pkg-config libssl-dev libpq-dev cmake git \
+    netcat-openbsd openssl jq runit
+}
+
+install_rust() {
+  if command -v cargo >/dev/null; then
+    log "Rust already present: $(cargo --version)"
+    return
+  fi
+  log "Installing rustup 1.87.0"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.87.0 --profile minimal
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+}
+
+build_pg_doorman() {
+  log "Building pg_doorman (cargo build --release)"
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env" 2>/dev/null || true
+  cd "$WORKSPACE"
+  local target_dir="${CARGO_TARGET_DIR:-$WORKSPACE/target}"
+  CARGO_TARGET_DIR="$target_dir" cargo build --release
+  install -m 0755 "$target_dir/release/pg_doorman" /usr/local/bin/
+  /usr/local/bin/pg_doorman --version || true
+}
+
+build_odyssey() {
+  if [[ -x /usr/local/bin/odyssey ]]; then
+    log "odyssey already installed"
+    return
+  fi
+  log "Building odyssey 1.4.1"
+  rm -rf /tmp/odyssey-src /tmp/odyssey-build
+  git clone --depth 1 -b v1.4.1 https://github.com/yandex/odyssey.git /tmp/odyssey-src
+  cmake -S /tmp/odyssey-src -B /tmp/odyssey-build \
+    -DBUILD_COMPRESSION=OFF -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-Wno-error=implicit-int -Wno-error=incompatible-pointer-types"
+  cmake --build /tmp/odyssey-build -j"$(nproc)"
+  local bin
+  bin=$(find /tmp/odyssey-build -name odyssey -type f -executable | head -1)
+  [[ -z "$bin" ]] && { echo "odyssey binary not found" >&2; find /tmp/odyssey-build -name 'odyssey*'; exit 1; }
+  install -m 0755 "$bin" /usr/local/bin/odyssey
+}
+
+init_postgres_datadir() {
+  log "Initializing postgres data directory at $PGDATA"
+  rm -rf "$PGDATA"
+  install -d -o postgres -g postgres "$PGDATA"
+  chpst -u postgres:postgres -- \
+    "$PGBIN/initdb" -D "$PGDATA" --auth-host=trust --auth-local=trust >/dev/null
+  cat > /tmp/pg_hba.conf <<EOF
+local   all all trust
+host    all all 127.0.0.1/32 trust
+host    all all ::1/128       trust
+EOF
+  install -m 0600 -o postgres -g postgres /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
+}
+
+generate_ssl() {
+  log "Generating self-signed SSL cert"
+  openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+    -subj "/CN=bench" -keyout "$SSL_KEY" -out "$SSL_CERT" >/dev/null 2>&1
+  # All four services need to read the cert; ephemeral, world-readable is fine.
+  chmod 644 "$SSL_KEY" "$SSL_CERT"
+}
+
+write_pgbench_script() {
+  cat > "$PGBENCH_FILE" <<'EOF'
+\set aid random(1, 100000)
+select :aid;
+EOF
+}
+
+write_configs() {
+  cat > /tmp/doorman.hba <<EOF
+host all all 0.0.0.0/0 trust
+hostssl all all 0.0.0.0/0 trust
+EOF
+  cat > /tmp/doorman.toml <<EOF
+[general]
+host = "127.0.0.1"
+port = $DOORMAN_PORT
+worker_threads = $DOORMAN_WORKERS
+pg_hba = {path = "/tmp/doorman.hba"}
+admin_username = "admin"
+admin_password = "admin"
+tls_private_key = "$SSL_KEY"
+tls_certificate = "$SSL_CERT"
+max_connections = 11000
+
+[pools.postgres]
+server_host = "127.0.0.1"
+server_port = $PG_PORT
+pool_mode = "transaction"
+
+[[pools.postgres.users]]
+username = "postgres"
+password = ""
+pool_size = 40
+EOF
+
+  cat > /tmp/odyssey.conf <<EOF
+workers $ODYSSEY_WORKERS
+log_to_stdout no
+log_file "/dev/null"
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_debug no
+log_config no
+log_session no
+log_query no
+log_stats no
+
+storage "postgres_server" {
+  type "remote"
+  host "127.0.0.1"
+  port $PG_PORT
+}
+
+database "postgres" {
+  user "postgres" {
+    authentication "none"
+    storage "postgres_server"
+    pool "transaction"
+    pool_size 40
+    pool_discard no
+    pool_reserve_prepared_statement yes
+  }
+}
+
+listen {
+  host "127.0.0.1"
+  port $ODYSSEY_PORT
+  tls "allow"
+  tls_cert_file "$SSL_CERT"
+  tls_key_file "$SSL_KEY"
+}
+EOF
+
+  cat > /tmp/pgbouncer.users <<'EOF'
+"postgres" ""
+EOF
+  cat > /tmp/pgbouncer.ini <<EOF
+[databases]
+postgres = host=127.0.0.1 port=$PG_PORT dbname=postgres
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = $PGBOUNCER_PORT
+unix_socket_dir =
+auth_type = trust
+auth_file = /tmp/pgbouncer.users
+pool_mode = transaction
+max_client_conn = 11000
+default_pool_size = 40
+admin_users = postgres
+client_tls_sslmode = allow
+client_tls_key_file = $SSL_KEY
+client_tls_cert_file = $SSL_CERT
+client_tls_ca_file = $SSL_CERT
+log_pooler_errors = 0
+verbose = 0
+log_connections = 0
+log_disconnections = 0
+logfile = /dev/null
+EOF
+  chown postgres /tmp/pgbouncer.ini /tmp/pgbouncer.users
+}
+
+write_runit_service() {
+  local name=$1 logfile=$2
+  local dir="$SVDIR/$name"
+  shift 2
+  install -d -m 0755 "$dir"
+  # 'down' marker keeps the service from auto-starting until we 'sv up' it.
+  touch "$dir/down"
+  {
+    echo '#!/bin/sh'
+    printf 'exec >>%s 2>&1\n' "$logfile"
+    printf 'exec '
+    printf '%q ' "$@"
+    echo
+  } > "$dir/run"
+  chmod 0755 "$dir/run"
+}
+
+create_runit_services() {
+  log "Creating runit service definitions under $SVDIR"
+  rm -rf "$SVDIR"
+  install -d -m 0755 "$SVDIR"
+
+  write_runit_service postgres /tmp/pg.log \
+    chpst -u postgres:postgres -- \
+    "$PGBIN/postgres" -D "$PGDATA" \
+    -c max_connections=500 -p "$PG_PORT" \
+    -c listen_addresses=127.0.0.1 \
+    -c unix_socket_directories=/tmp
+
+  write_runit_service pg_doorman /tmp/doorman.log \
+    chpst -o 1048576 -- \
+    /usr/local/bin/pg_doorman /tmp/doorman.toml
+
+  write_runit_service odyssey /tmp/odyssey.log \
+    chpst -o 1048576 -- \
+    /usr/local/bin/odyssey /tmp/odyssey.conf
+
+  write_runit_service pgbouncer /tmp/pgbouncer.log \
+    chpst -u postgres:postgres -o 1048576 -- \
+    /usr/sbin/pgbouncer /tmp/pgbouncer.ini
+}
+
+start_runsvdir() {
+  log "Starting runsvdir"
+  mkdir -p /var/log/runit
+  nohup runsvdir "$SVDIR" >/var/log/runit/runsvdir.log 2>&1 &
+  RUNSVDIR_PID=$!
+  # runsvdir scans the dir every ~5s; give it a moment to spawn the runsv's.
+  for i in $(seq 1 20); do
+    local missing=0
+    for s in "${SERVICES[@]}"; do
+      [[ -d "$SVDIR/$s/supervise" ]] || missing=1
+    done
+    [[ $missing -eq 0 ]] && return
+    sleep 1
+  done
+  log "runsvdir failed to set up supervise dirs in 20s"
+  return 1
+}
+
+bring_up() {
+  local name=$1 port=$2
+  log "Bringing up $name"
+  sv up "$SVDIR/$name"
+  for i in $(seq 1 30); do
+    if nc -z 127.0.0.1 "$port" 2>/dev/null; then
+      log "  $name ready on $port"
+      return
+    fi
+    sleep 1
+  done
+  log "  $name did not open port $port; tail of log:"
+  case $name in
+    postgres)   tail -n 50 /tmp/pg.log 2>&1 || true ;;
+    pg_doorman) tail -n 50 /tmp/doorman.log 2>&1 || true ;;
+    odyssey)    tail -n 50 /tmp/odyssey.log 2>&1 || true ;;
+    pgbouncer)  tail -n 50 /tmp/pgbouncer.log 2>&1 || true ;;
+  esac
+  return 1
+}
+
+cleanup() {
+  log "Cleanup: stopping services"
+  for s in "${SERVICES[@]}"; do
+    sv -w 5 force-stop "$SVDIR/$s" 2>/dev/null || true
+  done
+  if [[ -n "${RUNSVDIR_PID:-}" ]]; then
+    kill "$RUNSVDIR_PID" 2>/dev/null || true
+    wait "$RUNSVDIR_PID" 2>/dev/null || true
+  fi
+  # Always copy service logs into the results dir so even a failed run gives
+  # us something to debug.
+  mkdir -p "$RESULTS_DIR"
+  for f in /tmp/doorman.log /tmp/odyssey.log /tmp/pgbouncer.log /tmp/pg.log; do
+    [[ -f "$f" ]] && cp -f "$f" "$RESULTS_DIR/" 2>/dev/null || true
+  done
+  if [[ -d "$RESULTS_DIR" ]]; then
+    tar czf "$RESULTS_TARBALL" -C /tmp bench-results 2>/dev/null || true
+  fi
+}
+
+run_all_pgbench() {
+  mkdir -p "$RESULTS_DIR"
+  export DOORMAN_PORT ODYSSEY_PORT PGBOUNCER_PORT PGBENCH_FILE
+  export PGBENCH_JOBS_C1 PGBENCH_JOBS_C40 PGBENCH_JOBS_C120 PGBENCH_JOBS_C500 PGBENCH_JOBS_C10000
+
+  local total=0
+  local failed=0
+  while IFS=$'\t' read -r name args env_str; do
+    [[ -z "$name" ]] && continue
+    total=$((total+1))
+    local args_subst
+    args_subst=$(printf '%s' "$args" | envsubst)
+    args_subst="${args_subst// -T 30 / -T $BENCH_DURATION }"
+    # Hard wall-clock cap: BENCH_DURATION plus a generous buffer for the
+    # connect/warmup phase (10k-client scenarios spend tens of seconds opening
+    # sockets before the timed window even starts).
+    local pgbench_timeout=$((BENCH_DURATION + 180))
+    local log_prefix="$RESULTS_DIR/${name}_pgbenchlog"
+    log "[$total] $name :: $env_str pgbench -l --log-prefix=$log_prefix $args_subst (timeout=${pgbench_timeout}s)"
+    if env "$env_str" timeout "$pgbench_timeout" \
+        pgbench -l --log-prefix="$log_prefix" $args_subst \
+        > "$RESULTS_DIR/$name.log" 2>&1; then
+      :
+    else
+      local rc=$?
+      failed=$((failed+1))
+      echo "EXIT_CODE=$rc" >> "$RESULTS_DIR/$name.log"
+      log "  ! exited rc=$rc"
+    fi
+  done < <(sed -nE 's/.*pgbench for "([^"]+)" with "([^"]+)" and env "([^"]+)".*/\1\t\2\t\3/p' "$FEATURE_FILE")
+
+  log "pgbench rounds: $total total, $failed failed"
+}
+
+write_metadata() {
+  cat > "$RESULTS_DIR/metadata.json" <<EOF
+{
+  "host": "$(hostname)",
+  "kernel": "$(uname -srm)",
+  "vcpus": $(nproc),
+  "memory_kb": $(awk '/MemTotal/ {print $2}' /proc/meminfo),
+  "started_at": "$(date -u +%FT%TZ)",
+  "doorman_workers": $DOORMAN_WORKERS,
+  "odyssey_workers": $ODYSSEY_WORKERS,
+  "duration_per_run_sec": $BENCH_DURATION,
+  "pgbench_jobs": {
+    "c1": $PGBENCH_JOBS_C1,
+    "c40": $PGBENCH_JOBS_C40,
+    "c120": $PGBENCH_JOBS_C120,
+    "c500": $PGBENCH_JOBS_C500,
+    "c10000": $PGBENCH_JOBS_C10000
+  },
+  "git_sha": "$(cd "$WORKSPACE" && git rev-parse HEAD 2>/dev/null || echo unknown)"
+}
+EOF
+}
+
+main() {
+  trap cleanup EXIT
+
+  # The pgbench/parent shell only needs enough FDs to open log files and
+  # spawn timeout/pgbench; per-service limits are set by chpst -o in the run
+  # scripts.
+  ulimit -n 1048576 2>/dev/null || ulimit -n 65536 2>/dev/null || true
+
+  install_packages
+  install_rust
+  build_pg_doorman
+  build_odyssey
+
+  init_postgres_datadir
+  generate_ssl
+  write_pgbench_script
+  write_configs
+  create_runit_services
+  start_runsvdir
+
+  bring_up postgres   "$PG_PORT"
+  bring_up pg_doorman "$DOORMAN_PORT"
+  bring_up odyssey    "$ODYSSEY_PORT"
+  bring_up pgbouncer  "$PGBOUNCER_PORT"
+
+  run_all_pgbench
+  write_metadata
+
+  log "Packing $RESULTS_TARBALL"
+  tar czf "$RESULTS_TARBALL" -C /tmp bench-results
+  ls -lh "$RESULTS_TARBALL"
+  log "DONE"
+}
+
+main "$@"

--- a/benches/test_parse_bench_logs.py
+++ b/benches/test_parse_bench_logs.py
@@ -1,0 +1,187 @@
+"""Unit tests for benches/parse-bench-logs.py.
+
+Run: python3 -m unittest benches.test_parse_bench_logs -v
+or: python3 benches/test_parse_bench_logs.py
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+# parse-bench-logs.py uses a hyphen so we can't `import` it directly; load by path.
+_SPEC = importlib.util.spec_from_file_location(
+    "parse_bench_logs", Path(__file__).parent / "parse-bench-logs.py"
+)
+P = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(P)
+
+
+class PercentileMs(unittest.TestCase):
+    def test_empty_returns_none(self):
+        self.assertIsNone(P.percentile_ms([], 0.5))
+
+    def test_single_value(self):
+        self.assertEqual(P.percentile_ms([1000.0], 0.5), 1.0)
+        self.assertEqual(P.percentile_ms([1000.0], 0.99), 1.0)
+
+    def test_two_values(self):
+        # n=2, p50: idx = ceil(2*0.5)-1 = 0 → first
+        self.assertEqual(P.percentile_ms([1000.0, 2000.0], 0.5), 1.0)
+        # n=2, p95: idx = ceil(2*0.95)-1 = 1 → second
+        self.assertEqual(P.percentile_ms([1000.0, 2000.0], 0.95), 2.0)
+
+    def test_full_range(self):
+        # 1..100 µs → 0.001..0.100 ms
+        data = [float(i) for i in range(1, 101)]
+        # p50: idx = ceil(100*0.5)-1 = 49 → 50 µs → 0.050 ms
+        self.assertAlmostEqual(P.percentile_ms(data, 0.50), 0.050)
+        # p99: idx = ceil(100*0.99)-1 = 98 → 99 µs → 0.099 ms
+        self.assertAlmostEqual(P.percentile_ms(data, 0.99), 0.099)
+        # p95: idx = ceil(100*0.95)-1 = 94 → 95 µs → 0.095 ms
+        self.assertAlmostEqual(P.percentile_ms(data, 0.95), 0.095)
+
+    def test_index_clamped_at_top(self):
+        # very small input, very high frac — idx may overshoot before clamp.
+        self.assertEqual(P.percentile_ms([10.0], 0.999), 0.010)
+
+
+class ParseTestName(unittest.TestCase):
+    def test_simple_no_modifiers(self):
+        self.assertEqual(
+            P.parse_test_name("pg_doorman_simple_c1"),
+            {"pooler": "pg_doorman", "ssl": False, "proto": "simple",
+             "connect": False, "clients": 1},
+        )
+
+    def test_simple_with_connect(self):
+        self.assertEqual(
+            P.parse_test_name("odyssey_simple_connect_c40"),
+            {"pooler": "odyssey", "ssl": False, "proto": "simple",
+             "connect": True, "clients": 40},
+        )
+
+    def test_ssl_with_proto(self):
+        self.assertEqual(
+            P.parse_test_name("pgbouncer_ssl_extended_c500"),
+            {"pooler": "pgbouncer", "ssl": True, "proto": "extended",
+             "connect": False, "clients": 500},
+        )
+
+    def test_ssl_connect_no_explicit_proto_defaults_to_simple(self):
+        # bench.feature emits these for SSL+--connect (always --protocol=simple).
+        self.assertEqual(
+            P.parse_test_name("pg_doorman_ssl_connect_c1"),
+            {"pooler": "pg_doorman", "ssl": True, "proto": "simple",
+             "connect": True, "clients": 1},
+        )
+
+    def test_prepared(self):
+        self.assertEqual(
+            P.parse_test_name("pg_doorman_prepared_c10000")["proto"],
+            "prepared",
+        )
+
+    def test_garbage_returns_none(self):
+        self.assertIsNone(P.parse_test_name("garbage"))
+        self.assertIsNone(P.parse_test_name("doorman"))  # service log stem
+        self.assertIsNone(P.parse_test_name("pg_doorman_unknown_c1"))
+
+
+class ParsePgbenchStdout(unittest.TestCase):
+    def test_full_output(self):
+        text = (
+            "transaction type: /tmp/pgbench.sql\n"
+            "scaling factor: 1\n"
+            "tps = 1234.567 (without initial connection time)\n"
+            "latency average = 5.6 ms\n"
+        )
+        self.assertEqual(
+            P.parse_pgbench_stdout(text),
+            {"tps": 1234.567, "lat_avg_ms": 5.6},
+        )
+
+    def test_empty(self):
+        self.assertEqual(
+            P.parse_pgbench_stdout(""),
+            {"tps": None, "lat_avg_ms": None},
+        )
+
+    def test_only_tps(self):
+        self.assertEqual(
+            P.parse_pgbench_stdout("tps = 100"),
+            {"tps": 100.0, "lat_avg_ms": None},
+        )
+
+
+class FormatThroughput(unittest.TestCase):
+    def test_within_three_percent(self):
+        self.assertEqual(P.format_throughput(102, 100), "≈0%")
+        self.assertEqual(P.format_throughput(98, 100), "≈0%")
+
+    def test_positive_percent(self):
+        self.assertEqual(P.format_throughput(110, 100), "+10%")
+        self.assertEqual(P.format_throughput(149, 100), "+49%")
+
+    def test_negative_percent(self):
+        self.assertEqual(P.format_throughput(90, 100), "-10%")
+
+    def test_ratio_at_threshold(self):
+        # ratio == 1.5 switches to xN.N form
+        self.assertEqual(P.format_throughput(150, 100), "x1.5")
+        self.assertEqual(P.format_throughput(260, 100), "x2.6")
+        self.assertEqual(P.format_throughput(900, 100), "x9.0")
+
+    def test_competitor_zero_tps(self):
+        self.assertEqual(P.format_throughput(100, 0), "∞")
+        self.assertEqual(P.format_throughput(0, 0), "-")
+
+    def test_missing_data(self):
+        self.assertEqual(P.format_throughput(None, None), "-")
+        self.assertEqual(P.format_throughput(100, None), "N/A")
+        self.assertEqual(P.format_throughput(None, 100), "N/A")
+
+
+class FormatLatencyTriplet(unittest.TestCase):
+    def test_full(self):
+        rec = {"p50_ms": 0.07, "p95_ms": 0.07, "p99_ms": 0.08}
+        self.assertEqual(P.format_latency_triplet(rec), "0.07 / 0.07 / 0.08")
+
+    def test_two_decimal_rounding(self):
+        rec = {"p50_ms": 1.234, "p95_ms": 5.678, "p99_ms": 10.0}
+        self.assertEqual(P.format_latency_triplet(rec), "1.23 / 5.68 / 10.00")
+
+    def test_missing_percentile_returns_dash(self):
+        self.assertEqual(
+            P.format_latency_triplet({"p50_ms": 1.0, "p95_ms": None, "p99_ms": 3.0}),
+            "-",
+        )
+
+    def test_empty_dict(self):
+        self.assertEqual(P.format_latency_triplet({}), "-")
+        self.assertEqual(P.format_latency_triplet(None), "-")
+
+
+class ModeAndRowLabels(unittest.TestCase):
+    def test_mode_label(self):
+        self.assertEqual(P.mode_label(False, False), "")
+        self.assertEqual(P.mode_label(True, False), "SSL")
+        self.assertEqual(P.mode_label(False, True), "Reconnect")
+        self.assertEqual(P.mode_label(True, True), "SSL + Reconnect")
+
+    def test_row_label_singular_and_plural(self):
+        self.assertEqual(P.row_label(1, ""), "1 client")
+        self.assertEqual(P.row_label(40, ""), "40 clients")
+
+    def test_row_label_thousands_grouping(self):
+        self.assertEqual(P.row_label(10000, ""), "10,000 clients")
+
+    def test_row_label_with_mode(self):
+        self.assertEqual(P.row_label(120, "Reconnect"), "120 clients + Reconnect")
+        self.assertEqual(
+            P.row_label(500, "SSL + Reconnect"),
+            "500 clients + SSL + Reconnect",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- New `workflow_dispatch` workflow runs the pgbench scenarios from `tests/bdd/features/bench.feature` on a rented Ubicloud VM up to 60 vCPU / 240 GB — sizes the existing AWS Fargate workflow cannot reach (Fargate caps a task at 16 vCPU), at roughly half the per-hour price.
- The setup script and parser are independent of CI: anyone can reproduce a run locally with `sudo bash benches/setup-and-run-bench.sh` on a clean Ubuntu 22.04 host (or inside `docker run ubuntu:22.04`). The result tarball is the contract — the workflow consumes the same artifact.
- The Fargate workflow stays in place; this is an additional runner.