### PR TITLE
Bump openssl to 0.10.78 (CVE-2026-41678, CVE-2026-41681), release 3.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,9 +1743,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ native-tls = { version = "0.2.14" }
 tokio-native-tls = { version = "0.3.1" }
 serde-toml-merge = { version = "0.3.8"}
 jwt = { version = "0.16.0", features = ["openssl"] }
-openssl = { version = "0.10.72" }
-openssl-sys = { version = "0.9" }
+openssl = { version = "0.10.78" }
+openssl-sys = { version = "0.9.114" }
 iota = { version = "0.2.3" }
 pin-project-lite = "0.2.16"
 pam-client = { version =  "0.5.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.6.1 <small>Apr 27, 2026</small>
+
+#### openssl 0.10.78 (CVE-2026-41678, CVE-2026-41681)
+
+`openssl` 0.10.72 is affected by CVE-2026-41678 and CVE-2026-41681; some registry mirrors refuse downloads on that basis. pg_doorman now depends on `openssl` 0.10.78 and `openssl-sys` 0.9.114. API-compatible — no source changes.
+
 ### 3.6.0 <small>Apr 24, 2026</small>
 
 #### Patroni-assisted fallback


### PR DESCRIPTION
## Summary

- Bumps `openssl` `0.10.72` → `0.10.78` and `openssl-sys` to `0.9.114`. The 0.10.72 release is blocked by CodeScoring policy (CVE-2026-41678, CVE-2026-41681), which prevents resolution from internal mirrors.
- Releases `3.6.1` with a changelog entry covering the bump.

API-compatible — no source changes.