### PR TITLE
ci: speed up Ubicloud Benchmarks by computing percentiles on the VM

### DIFF
--- a/.github/workflows/bench-ubicloud.yml
+++ b/.github/workflows/bench-ubicloud.yml
@@ -217,6 +217,17 @@ jobs:
             echo "got_tarball=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Delete VM
+        if: always() && steps.create_vm.outputs.vm_name != ''
+        env:
+          VM_NAME: ${{ steps.create_vm.outputs.vm_name }}
+        run: |
+          # Tear down as soon as the tarball is on the runner — parse and
+          # upload-artifact run on the runner-local file and don't need the
+          # bench host alive. `ubi vm destroy` reads the VM name from stdin
+          # as a confirmation; no --yes flag exists in 1.1.0.
+          echo "$VM_NAME" | ubi vm "$UBI_LOCATION/$VM_NAME" destroy || true
+
       - name: Parse logs into benchmarks.md
         if: steps.download.outputs.got_tarball == 'true'
         run: |
@@ -234,16 +245,6 @@ jobs:
           name: ubicloud-bench-${{ github.run_number }}
           path: artifacts/
           retention-days: 30
-
-      - name: Delete VM
-        if: always() && steps.create_vm.outputs.vm_name != ''
-        env:
-          VM_NAME: ${{ steps.create_vm.outputs.vm_name }}
-        run: |
-          # `ubi vm destroy` reads the VM name from stdin as a confirmation.
-          # No --yes flag exists (1.1.0); piping the name in is the official
-          # non-interactive form.
-          echo "$VM_NAME" | ubi vm "$UBI_LOCATION/$VM_NAME" destroy || true
 
       - name: Create Pull Request with results
         if: steps.download.outputs.got_tarball == 'true' && inputs.create_pr

--- a/benches/compute_percentiles.py
+++ b/benches/compute_percentiles.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Compute pgbench latency percentiles on the bench host before tarring results.
+
+For every <test>.log produced by setup-and-run-bench.sh, walk the matching
+<test>_pgbenchlog.* per-transaction files, sort the third column (latency in
+microseconds — see pgbench --log docs), pick nearest-rank p50/p95/p99 and
+write <test>_percentiles.json next to the .log file.
+
+Doing this on the VM keeps the raw pgbench --log files (multi-gigabyte ASCII,
+one row per transaction) off the wire: parse-bench-logs.py only needs the
+percentiles, so the post-bench tarball drops from gigabytes to megabytes.
+
+Nearest-rank semantics match parse-bench-logs.py::percentile_ms and
+tests/bdd/pgbench_helper.rs::percentile_index — keep them in sync.
+
+stdlib only (Python 3.10+).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Stems setup-and-run-bench.sh leaves in the results dir for debugging.
+# Mirrors parse-bench-logs.py::SERVICE_LOG_NAMES.
+SERVICE_LOG_NAMES = {
+    "doorman", "odyssey", "pgbouncer", "pg",
+    "bench-wrap",
+}
+
+
+def percentile_ms(sorted_us: list[float], frac: float) -> float | None:
+    """Nearest-rank percentile, microseconds → milliseconds."""
+    if not sorted_us:
+        return None
+    n = len(sorted_us)
+    idx = max(0, min(n - 1, int(n * frac + 0.999999) - 1))
+    return sorted_us[idx] / 1000.0
+
+
+def collect_latencies_us(results_dir: Path, name: str) -> list[float]:
+    """Return latency samples (µs) from every <name>_pgbenchlog.* file."""
+    samples: list[float] = []
+    for f in sorted(results_dir.glob(f"{name}_pgbenchlog.*")):
+        for line in f.read_text(errors="replace").splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            try:
+                samples.append(float(parts[2]))
+            except ValueError:
+                pass
+    return samples
+
+
+def summarize(latencies_us: list[float]) -> dict:
+    """Sort in place and return the {samples, p50_ms, p95_ms, p99_ms} payload."""
+    latencies_us.sort()
+    return {
+        "samples": len(latencies_us),
+        "p50_ms": percentile_ms(latencies_us, 0.50),
+        "p95_ms": percentile_ms(latencies_us, 0.95),
+        "p99_ms": percentile_ms(latencies_us, 0.99),
+    }
+
+
+def write_percentiles_for_results_dir(results_dir: Path) -> int:
+    """Emit <name>_percentiles.json for every pgbench test log. Returns count."""
+    count = 0
+    for log_file in sorted(results_dir.glob("*.log")):
+        name = log_file.stem
+        if name in SERVICE_LOG_NAMES:
+            continue
+        payload = summarize(collect_latencies_us(results_dir, name))
+        (results_dir / f"{name}_percentiles.json").write_text(json.dumps(payload))
+        count += 1
+    return count
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("results_dir", help="path to bench-results directory")
+    args = ap.parse_args()
+    results_dir = Path(args.results_dir)
+    if not results_dir.is_dir():
+        sys.exit(f"not a directory: {results_dir}")
+    count = write_percentiles_for_results_dir(results_dir)
+    print(f"wrote percentiles for {count} test(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/parse-bench-logs.py
+++ b/benches/parse-bench-logs.py
@@ -271,6 +271,14 @@ def compute_tldr(groups: dict[tuple, dict[str, dict]]) -> list[str]:
 
 def parse_test(name: str, src: Path) -> dict:
     rec = parse_pgbench_stdout((src / f"{name}.log").read_text(errors="replace"))
+    # Prefer the JSON summary written by compute_percentiles.py on the bench
+    # host — it lets the workflow ship a tiny tarball instead of gigabytes of
+    # raw pgbench --log ASCII. Fall back to scanning the raw files so older
+    # tarballs (or runs where compute_percentiles.py failed) still parse.
+    pct_file = src / f"{name}_percentiles.json"
+    if pct_file.exists():
+        rec.update(json.loads(pct_file.read_text()))
+        return rec
     latencies_us: list[float] = []
     for f in src.glob(f"{name}_pgbenchlog.*"):
         for line in f.read_text(errors="replace").splitlines():

--- a/benches/setup-and-run-bench.sh
+++ b/benches/setup-and-run-bench.sh
@@ -168,6 +168,10 @@ EOF
 host = "127.0.0.1"
 port = $DOORMAN_PORT
 worker_threads = $DOORMAN_WORKERS
+# Pin every tokio worker to its own CPU starting from core 1 (core 0 is left
+# for postgres + pgbench + the system). Skipped at runtime when the host has
+# fewer than three cores; Ubicloud standard-* always have enough.
+worker_cpu_affinity_pinning = true
 pg_hba = {path = "/tmp/doorman.hba"}
 admin_username = "admin"
 admin_password = "admin"

--- a/benches/setup-and-run-bench.sh
+++ b/benches/setup-and-run-bench.sh
@@ -79,7 +79,7 @@ EOF
     "postgresql-$PG_VERSION" "postgresql-contrib-$PG_VERSION" \
     pgbouncer postgresql-client \
     build-essential pkg-config libssl-dev libpq-dev cmake git \
-    netcat-openbsd openssl jq runit
+    netcat-openbsd openssl jq runit pigz
   # The Ubuntu/PGDG packages auto-start postgres on 5432 and pgbouncer on
   # 6432 — exactly the ports our runit instances want to claim. Without
   # disabling them, our pg_doorman silently loses 6432 to the system
@@ -351,7 +351,10 @@ cleanup() {
     [[ -f "$f" ]] && cp -f "$f" "$RESULTS_DIR/" 2>/dev/null || true
   done
   if [[ -d "$RESULTS_DIR" ]]; then
-    tar czf "$RESULTS_TARBALL" -C /tmp bench-results 2>/dev/null || true
+    # On the failure path raw pgbench --log files are still here; pigz keeps
+    # the postmortem tarball from blocking wrap-up for tens of minutes.
+    tar -I "pigz -p $(nproc) -1" -cf "$RESULTS_TARBALL" \
+      -C /tmp bench-results 2>/dev/null || true
   fi
 }
 
@@ -493,8 +496,15 @@ main() {
   run_all_pgbench
   write_metadata
 
+  # Summarize per-transaction latencies on the VM so the workflow only ships
+  # tens of KB of JSON instead of gigabytes of raw pgbench --log ASCII.
+  log "Computing latency percentiles from raw pgbench logs"
+  python3 "$WORKSPACE/benches/compute_percentiles.py" "$RESULTS_DIR"
+  log "Dropping raw pgbench --log files (percentiles already computed)"
+  rm -f "$RESULTS_DIR"/*_pgbenchlog.*
+
   log "Packing $RESULTS_TARBALL"
-  tar czf "$RESULTS_TARBALL" -C /tmp bench-results
+  tar -I "pigz -p $(nproc) -1" -cf "$RESULTS_TARBALL" -C /tmp bench-results
   ls -lh "$RESULTS_TARBALL"
   log "DONE"
 }

--- a/benches/test_compute_percentiles.py
+++ b/benches/test_compute_percentiles.py
@@ -1,0 +1,141 @@
+"""Unit tests for benches/compute_percentiles.py.
+
+Run: python3 -m unittest benches.test_compute_percentiles -v
+or:  python3 benches/test_compute_percentiles.py
+"""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "compute_percentiles", Path(__file__).parent / "compute_percentiles.py"
+)
+C = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(C)
+
+
+class PercentileMs(unittest.TestCase):
+    def test_empty_returns_none(self):
+        self.assertIsNone(C.percentile_ms([], 0.5))
+
+    def test_full_range_matches_parse_bench_logs(self):
+        # 1..100 µs → 0.001..0.100 ms. Same indices as
+        # parse-bench-logs.py and pgbench_helper.rs::percentile_index.
+        data = [float(i) for i in range(1, 101)]
+        self.assertAlmostEqual(C.percentile_ms(data, 0.50), 0.050)
+        self.assertAlmostEqual(C.percentile_ms(data, 0.95), 0.095)
+        self.assertAlmostEqual(C.percentile_ms(data, 0.99), 0.099)
+
+    def test_index_clamped_at_top(self):
+        self.assertEqual(C.percentile_ms([10.0], 0.999), 0.010)
+
+
+class CollectLatenciesUs(unittest.TestCase):
+    def test_no_files_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(C.collect_latencies_us(Path(tmp), "missing"), [])
+
+    def test_extracts_third_column(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "test_pgbenchlog.1").write_text(
+                "0 1 1500 0 1700000000 0\n"
+                "0 2 2500 0 1700000001 0\n"
+            )
+            self.assertEqual(
+                sorted(C.collect_latencies_us(d, "test")),
+                [1500.0, 2500.0],
+            )
+
+    def test_concatenates_across_per_thread_files(self):
+        # pgbench writes one log per thread (-l --log-prefix=foo → foo.<pid>).
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "test_pgbenchlog.1").write_text("0 1 1000\n")
+            (d / "test_pgbenchlog.2").write_text("0 1 2000\n")
+            self.assertEqual(
+                sorted(C.collect_latencies_us(d, "test")),
+                [1000.0, 2000.0],
+            )
+
+    def test_skips_malformed_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "test_pgbenchlog.1").write_text(
+                "\n"                       # blank line
+                "0 1\n"                    # too few columns
+                "0 1 not_a_number\n"       # column 3 unparseable
+                "0 1 500\n"                # valid
+            )
+            self.assertEqual(C.collect_latencies_us(d, "test"), [500.0])
+
+    def test_does_not_match_other_test_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "alpha_pgbenchlog.1").write_text("0 1 100\n")
+            (d / "beta_pgbenchlog.1").write_text("0 1 200\n")
+            self.assertEqual(C.collect_latencies_us(d, "alpha"), [100.0])
+
+
+class Summarize(unittest.TestCase):
+    def test_three_samples(self):
+        # Unsorted input, summarize should sort in place.
+        result = C.summarize([2000.0, 1000.0, 3000.0])
+        self.assertEqual(result["samples"], 3)
+        # n=3, p50: idx = ceil(3*0.5)-1 = 1 → 2000 µs → 2.0 ms
+        self.assertEqual(result["p50_ms"], 2.0)
+        self.assertEqual(result["p99_ms"], 3.0)
+
+    def test_empty_yields_none_percentiles(self):
+        self.assertEqual(
+            C.summarize([]),
+            {"samples": 0, "p50_ms": None, "p95_ms": None, "p99_ms": None},
+        )
+
+
+class WritePercentilesForResultsDir(unittest.TestCase):
+    def test_writes_one_json_per_test_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "alpha.log").write_text("tps = 100\nlatency average = 5.0\n")
+            (d / "alpha_pgbenchlog.1").write_text("0 1 1000\n0 2 2000\n")
+            (d / "beta.log").write_text("tps = 200\n")
+            (d / "beta_pgbenchlog.1").write_text("0 1 500\n")
+            count = C.write_percentiles_for_results_dir(d)
+            self.assertEqual(count, 2)
+            alpha = json.loads((d / "alpha_percentiles.json").read_text())
+            self.assertEqual(alpha["samples"], 2)
+            self.assertEqual(alpha["p99_ms"], 2.0)
+            beta = json.loads((d / "beta_percentiles.json").read_text())
+            self.assertEqual(beta["samples"], 1)
+
+    def test_skips_service_logs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            for stem in ("doorman", "odyssey", "pgbouncer", "pg", "bench-wrap"):
+                (d / f"{stem}.log").write_text("noise")
+            count = C.write_percentiles_for_results_dir(d)
+            self.assertEqual(count, 0)
+            self.assertFalse((d / "doorman_percentiles.json").exists())
+            self.assertFalse((d / "bench-wrap_percentiles.json").exists())
+
+    def test_test_with_no_pgbenchlog_emits_zero_sample_summary(self):
+        # A pgbench round that timed out/exited still has its .log; record an
+        # empty summary so the parser sees samples=0 instead of falling back
+        # to scanning raw files that won't exist on the runner.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "failed_test.log").write_text("EXIT_CODE=124\n")
+            self.assertEqual(C.write_percentiles_for_results_dir(d), 1)
+            payload = json.loads((d / "failed_test_percentiles.json").read_text())
+            self.assertEqual(
+                payload,
+                {"samples": 0, "p50_ms": None, "p95_ms": None, "p99_ms": None},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/benches/test_parse_bench_logs.py
+++ b/benches/test_parse_bench_logs.py
@@ -5,6 +5,8 @@ or: python3 benches/test_parse_bench_logs.py
 """
 
 import importlib.util
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -296,6 +298,48 @@ class ServiceLogFiltering(unittest.TestCase):
     def test_pooler_logs_in_blocklist(self):
         for name in ("doorman", "odyssey", "pgbouncer", "pg"):
             self.assertIn(name, P.SERVICE_LOG_NAMES)
+
+
+class ParseTestPercentilesSource(unittest.TestCase):
+    """parse_test prefers <name>_percentiles.json (written on the bench host
+    by compute_percentiles.py) over raw pgbench --log files."""
+
+    def test_uses_percentiles_json_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "alpha.log").write_text(
+                "tps = 1000\nlatency average = 5.0\n"
+            )
+            (d / "alpha_percentiles.json").write_text(json.dumps({
+                "samples": 42, "p50_ms": 1.5, "p95_ms": 4.0, "p99_ms": 8.0,
+            }))
+            # A stale raw log next to the JSON must not influence the result.
+            (d / "alpha_pgbenchlog.1").write_text("0 1 999999\n")
+            rec = P.parse_test("alpha", d)
+            self.assertEqual(rec["tps"], 1000.0)
+            self.assertEqual(rec["lat_avg_ms"], 5.0)
+            self.assertEqual(rec["samples"], 42)
+            self.assertEqual(rec["p50_ms"], 1.5)
+            self.assertEqual(rec["p95_ms"], 4.0)
+            self.assertEqual(rec["p99_ms"], 8.0)
+
+    def test_falls_back_to_raw_logs_when_json_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "alpha.log").write_text("tps = 100\n")
+            (d / "alpha_pgbenchlog.1").write_text("0 1 1000\n0 2 2000\n")
+            rec = P.parse_test("alpha", d)
+            self.assertEqual(rec["samples"], 2)
+            # n=2, p99: idx = ceil(2*0.99)-1 = 1 → 2000 µs → 2.0 ms
+            self.assertEqual(rec["p99_ms"], 2.0)
+
+    def test_no_data_at_all_yields_none_percentiles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "alpha.log").write_text("tps = 0\n")
+            rec = P.parse_test("alpha", d)
+            self.assertIsNone(rec["p50_ms"])
+            self.assertEqual(rec["samples"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `Ubicloud Benchmarks` workflow spent ~20 minutes per run shipping a 5.2 GB `bench-results.tar.gz` from VM → runner → GitHub artifacts only to read one column for p50/p95/p99, and held the Ubicloud VM alive through the parse + upload window. Two commits address both:

- **bench: compute pgbench latency percentiles on the VM** — `setup-and-run-bench.sh` now summarizes per-transaction latencies into `<test>_percentiles.json` on the bench host before tarring, drops the raw `pgbench --log` files, and uses `pigz` so the final pack runs across all VM cores instead of one. `parse-bench-logs.py` prefers the JSON; raw-scan fallback stays for older tarballs.
- **ci(bench-ubicloud): tear down the VM right after fetching results** — `Delete VM` was the last step; move it right after `Download bench-results.tar.gz` so a stuck artifact upload no longer keeps the bench host billing.
