### PR TITLE
docs(benchmarks): add SVG charts to the benchmarks page

### DIFF
--- a/.github/workflows/bench-ubicloud.yml
+++ b/.github/workflows/bench-ubicloud.yml
@@ -232,11 +232,16 @@ jobs:
         if: steps.download.outputs.got_tarball == 'true'
         run: |
           set -euo pipefail
-          mkdir -p documentation/en/src
+          mkdir -p documentation/en/src/images/benchmarks
+          # matplotlib/seaborn/numpy power benches/render_charts.py; install
+          # quietly so the runner output stays focused on the bench results.
+          pip install --quiet --user matplotlib seaborn numpy
           python3 benches/parse-bench-logs.py \
             artifacts/bench-results.tar.gz \
-            documentation/en/src/benchmarks.md
+            documentation/en/src/benchmarks.md \
+            --images-dir documentation/en/src/images/benchmarks
           head -60 documentation/en/src/benchmarks.md
+          ls -la documentation/en/src/images/benchmarks
 
       - name: Upload artifacts
         if: always()
@@ -256,6 +261,8 @@ jobs:
 
           # Save benchmark results to a temporary location before switching branches
           cp documentation/en/src/benchmarks.md /tmp/benchmarks.md.tmp
+          rm -rf /tmp/benchmark-images.tmp
+          cp -r documentation/en/src/images/benchmarks /tmp/benchmark-images.tmp
 
           # Create a unique branch name with timestamp
           BRANCH_NAME="ubicloud-benchmark-results-$(date +%Y%m%d-%H%M%S)"
@@ -266,9 +273,14 @@ jobs:
 
           # Restore benchmark results to the new branch
           mv /tmp/benchmarks.md.tmp documentation/en/src/benchmarks.md
+          mkdir -p documentation/en/src/images
+          rm -rf documentation/en/src/images/benchmarks
+          mv /tmp/benchmark-images.tmp documentation/en/src/images/benchmarks
 
-          # Check if there are any changes to commit
+          # Check if there are any changes to commit. `git add -A` so deletions
+          # of charts that no longer have data behind them also get staged.
           git add documentation/en/src/benchmarks.md
+          git add -A documentation/en/src/images/benchmarks
           if git diff --staged --quiet; then
             echo "No changes to benchmark results, skipping PR creation"
             exit 0

--- a/benches/parse-bench-logs.py
+++ b/benches/parse-bench-logs.py
@@ -8,12 +8,16 @@ p50/p95/p99 latency table) + caveats.
 Latency percentiles come from pgbench `--log` files (column 3 = µs) — same
 nearest-rank convention as tests/bdd/pgbench_helper.rs::compute_latency_percentiles.
 
-stdlib only (Python 3.10+).
+When called with ``--images-dir``, also renders SVG charts via
+``benches/render_charts.py`` (requires matplotlib/seaborn/numpy) and embeds
+them in the markdown output. Without ``--images-dir`` the script keeps its
+stdlib-only behaviour and emits markdown tables only.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import re
 import sys
@@ -22,6 +26,10 @@ import tempfile
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Allow `import render_charts` from the same directory regardless of how
+# parse-bench-logs.py is invoked (the hyphen rules out a package import).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 TPS_RE = re.compile(r"^tps = ([\d.]+)", re.MULTILINE)
 LAT_AVG_RE = re.compile(r"^latency average = ([\d.]+)", re.MULTILINE)
@@ -45,6 +53,12 @@ PROTO_ORDER = ("simple", "extended", "prepared")
 # (ssl, connect) tuples in the same row order as the existing benchmarks.md.
 MODE_ORDER = ((False, False), (False, True), (True, False), (True, True))
 CLIENT_ORDER = (1, 40, 120, 500, 10000)
+
+# Filenames render_charts.render_all may produce. Kept here so render() knows
+# which ![]() links to inject without importing render_charts (it is optional).
+TLDR_CHART = "tldr_tail_spread.svg"
+LATENCY_CHART = {p: f"{p}_latency.svg" for p in PROTO_ORDER}
+IMAGES_REL_DIR = "images/benchmarks"
 
 
 # ---------- pure helpers (covered by tests/test_parse_bench_logs.py) ----------
@@ -468,7 +482,12 @@ def _emit_latency_table(proto_groups: dict[tuple, dict]) -> list[str]:
     return out
 
 
-def render(results: dict[str, dict], meta: dict | None) -> str:
+def build_groups(results: dict[str, dict]) -> tuple[dict, list[str]]:
+    """Pivot {test_name: data} into {(proto, ssl, conn, clients): {pooler: data}}.
+
+    Returns the groups dict plus a list of test names that did not match the
+    expected naming convention (so the caller can surface a warning).
+    """
     groups: dict[tuple, dict[str, dict]] = defaultdict(dict)
     unmatched: list[str] = []
     for name, data in results.items():
@@ -478,6 +497,18 @@ def render(results: dict[str, dict], meta: dict | None) -> str:
             continue
         key = (n["proto"], n["ssl"], n["connect"], n["clients"])
         groups[key][n["pooler"]] = data
+    return dict(groups), unmatched
+
+
+def render(results: dict[str, dict], meta: dict | None,
+           chart_names: frozenset[str] = frozenset()) -> str:
+    """Build the markdown page.
+
+    ``chart_names`` lists SVG filenames that already exist under
+    ``IMAGES_REL_DIR`` next to the output. Each known name triggers a
+    matching ``![]()`` link in the right section; unknown names are ignored.
+    """
+    groups, unmatched = build_groups(results)
 
     if unmatched:
         print(f"warning: {len(unmatched)} unmatched test name(s) ignored: "
@@ -502,6 +533,12 @@ def render(results: dict[str, dict], meta: dict | None) -> str:
     tldr = compute_tldr(groups)
     if tldr:
         out += ["## TL;DR", ""] + tldr + [""]
+        if TLDR_CHART in chart_names:
+            out += [
+                f"![Tail spread at 10,000 simple-protocol clients]"
+                f"({IMAGES_REL_DIR}/{TLDR_CHART})",
+                "",
+            ]
 
     out += emit_metadata(meta)
     out += METHODOLOGY
@@ -521,6 +558,13 @@ def render(results: dict[str, dict], meta: dict | None) -> str:
             f"## {proto.capitalize()} protocol",
             "",
         ]
+        chart = LATENCY_CHART[proto]
+        if chart in chart_names:
+            out += [
+                f"![{proto.capitalize()} protocol: latency p50 (solid) and p99 (dashed)]"
+                f"({IMAGES_REL_DIR}/{chart})",
+                "",
+            ]
         out += _emit_throughput_table(proto_groups)
         out.append("")
         out += _emit_latency_table(proto_groups)
@@ -536,6 +580,9 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("tarball", help="bench-results.tar.gz")
     ap.add_argument("output", help="output markdown file")
+    ap.add_argument("--images-dir",
+                    help="If set, render SVG charts here and embed ![]() links "
+                         "in the markdown. Requires matplotlib/seaborn/numpy.")
     args = ap.parse_args()
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -559,7 +606,20 @@ def main() -> None:
                 continue
             results[name] = parse_test(name, src)
 
-        Path(args.output).write_text(render(results, meta))
+        chart_names: frozenset[str] = frozenset()
+        if args.images_dir:
+            try:
+                render_charts = importlib.import_module("render_charts")
+            except ImportError as exc:
+                sys.exit(f"--images-dir requires {exc.name} "
+                         f"(install matplotlib/seaborn/numpy)")
+            groups, _ = build_groups(results)
+            chart_names = frozenset(
+                render_charts.render_all(groups, Path(args.images_dir))
+            )
+            print(f"rendered {len(chart_names)} chart(s) into {args.images_dir}")
+
+        Path(args.output).write_text(render(results, meta, chart_names))
         print(f"wrote {args.output} with {len(results)} tests")
 
 

--- a/benches/render_charts.py
+++ b/benches/render_charts.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Render benchmark visualisations as SVG.
+
+Produces 4 charts for the steady-state (no SSL, no Reconnect) workloads:
+  * tldr_tail_spread.svg   - p99 / p50 at 10k simple-protocol clients
+  * <proto>_latency.svg    - p50 (solid) and p99 (dashed) vs concurrency
+
+Style follows tvhahn/matplotlib-skill conventions: whitegrid + despined,
+DejaVu Sans, dimgrey ticks/annotations, lightgrey legend frames. Categorical
+palette taken from the diverging-colorblind ColorBrewer set so the three
+poolers stay distinguishable both in colour and in marker shape.
+
+Inputs/outputs live in plain dicts so unit tests can drive the pure helpers
+without touching matplotlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+POOLER_ORDER = ("pg_doorman", "pgbouncer", "odyssey")
+COLOR = {
+    "pg_doorman": "#4575b4",
+    "pgbouncer":  "#d73027",
+    "odyssey":    "#fc8d59",
+}
+MARKER = {"pg_doorman": "o", "pgbouncer": "s", "odyssey": "^"}
+ACCENT_RED = "#bd0c0c"
+CLIENT_TICKS = (1, 40, 120, 500, 10_000)
+PROTOCOLS = ("simple", "extended", "prepared")
+
+LEGEND_KW = dict(
+    frameon=True, facecolor="white", framealpha=0.8,
+    edgecolor="lightgrey", labelcolor="dimgrey",
+)
+
+
+# ---------- pure helpers (covered by tests) -------------------------------
+
+
+def steady_state_series(groups: dict, proto: str, key: str) -> dict[str, list[tuple[int, float]]]:
+    """For each pooler return [(clients, value)] for ssl=False, conn=False."""
+    out: dict[str, list[tuple[int, float]]] = {p: [] for p in POOLER_ORDER}
+    for (p, ssl, conn, clients), poolers in groups.items():
+        if p != proto or ssl or conn:
+            continue
+        for pooler in POOLER_ORDER:
+            v = (poolers.get(pooler) or {}).get(key)
+            if v is not None:
+                out[pooler].append((clients, v))
+    for pooler in POOLER_ORDER:
+        out[pooler].sort()
+    return out
+
+
+def tail_spread(groups: dict, proto: str, ssl: bool, conn: bool, clients: int) -> dict[str, float]:
+    """Return {pooler: p99/p50} ratio at the requested cell."""
+    cell = groups.get((proto, ssl, conn, clients)) or {}
+    out: dict[str, float] = {}
+    for pooler, vals in cell.items():
+        p50 = (vals or {}).get("p50_ms")
+        p99 = (vals or {}).get("p99_ms")
+        if p50 and p99 and p50 > 0:
+            out[pooler] = p99 / p50
+    return out
+
+
+def format_spread_label(ratio: float) -> str:
+    return f"{ratio:.1f}×" if ratio < 10 else f"{ratio:.0f}×"
+
+
+# ---------- shared style setup --------------------------------------------
+
+
+def _setup_style() -> None:
+    sns.set_theme(font_scale=1.0, style="whitegrid", font="DejaVu Sans")
+    plt.rcParams["svg.fonttype"] = "none"
+    plt.rcParams["pdf.fonttype"] = 42
+
+
+def _finalise_axes(ax) -> None:
+    sns.despine(ax=ax, left=True, bottom=True)
+    ax.tick_params(axis="both", which="both", length=0, labelcolor="dimgrey")
+
+
+def _save(fig, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, format="svg", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------- chart functions -----------------------------------------------
+
+
+def chart_tldr_tail_spread(groups: dict, out_path: Path) -> None:
+    """Bar chart: p99/p50 at 10 000 simple-protocol clients."""
+    _setup_style()
+    spreads = tail_spread(groups, "simple", ssl=False, conn=False, clients=10_000)
+    poolers = [p for p in POOLER_ORDER if p in spreads]
+    values = [spreads[p] for p in poolers]
+    if not poolers:
+        return
+
+    winner = min(poolers, key=lambda p: spreads[p])
+    colors = [ACCENT_RED if p == winner else "lightgrey" for p in poolers]
+
+    fig, ax = plt.subplots(figsize=(7, 4.5), dpi=150)
+    bars = ax.bar(poolers, values, color=colors,
+                  edgecolor="dimgrey", linewidth=0.6, width=0.55)
+    ax.axhline(1.0, color="lightgrey", linestyle=":", linewidth=1, zorder=0)
+
+    ymax = max(values)
+    for bar, v in zip(bars, values):
+        ax.text(bar.get_x() + bar.get_width() / 2, v + ymax * 0.025,
+                format_spread_label(v),
+                ha="center", va="bottom",
+                color="dimgrey", weight="semibold", fontsize=12)
+
+    ax.set_ylim(0, ymax * 1.18)
+    ax.set_ylabel("p99 / p50  (lower = more predictable)",
+                  fontsize=11, labelpad=8, color="dimgrey")
+    ax.set_xlabel("")
+    ax.set_title("Tail spread at 10,000 simple-protocol clients",
+                 loc="left", pad=8, fontsize=14, color="dimgrey")
+
+    others = [p for p in poolers if p != winner]
+    if others:
+        gaps = ", ".join(
+            f"{p} {format_spread_label(spreads[p])}" for p in others
+        )
+        ax.text(0.98, 0.98,
+                f"{winner} holds the median ({format_spread_label(spreads[winner])}); "
+                f"competitors drift to {gaps}",
+                transform=ax.transAxes, ha="right", va="top",
+                fontsize=9, color="dimgrey", style="italic")
+
+    ax.grid(False, axis="x")
+    ax.grid(axis="y", alpha=0.3, linewidth=0.6)
+    _finalise_axes(ax)
+    _save(fig, out_path)
+
+
+def chart_latency_per_protocol(groups: dict, proto: str, out_path: Path) -> None:
+    """Log-log line chart: p50 (solid) and p99 (dashed) per pooler."""
+    _setup_style()
+    p50 = steady_state_series(groups, proto, "p50_ms")
+    p99 = steady_state_series(groups, proto, "p99_ms")
+
+    if not any(p50.values()):
+        return
+
+    fig, ax = plt.subplots(figsize=(9, 5.2), dpi=150)
+
+    for pooler in POOLER_ORDER:
+        pts50 = p50.get(pooler) or []
+        pts99 = p99.get(pooler) or []
+        if pts50:
+            xs, ys = zip(*pts50)
+            ax.plot(xs, ys, color=COLOR[pooler], marker=MARKER[pooler],
+                    linestyle="-", linewidth=2.2, markersize=7,
+                    label=f"{pooler} p50")
+        if pts99:
+            xs, ys = zip(*pts99)
+            ax.plot(xs, ys, color=COLOR[pooler], marker=MARKER[pooler],
+                    linestyle="--", linewidth=1.6, markersize=5,
+                    alpha=0.75, label=f"{pooler} p99")
+        if pts50 and pts99 and [x for x, _ in pts50] == [x for x, _ in pts99]:
+            xs = [x for x, _ in pts50]
+            ax.fill_between(xs,
+                            [y for _, y in pts50],
+                            [y for _, y in pts99],
+                            color=COLOR[pooler], alpha=0.08, linewidth=0)
+
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xticks(CLIENT_TICKS)
+    ax.set_xticklabels([f"{c:,}" for c in CLIENT_TICKS])
+    ax.set_xlabel("Concurrent pgbench clients (log scale)",
+                  fontsize=11, labelpad=8, color="dimgrey")
+    ax.set_ylabel("Per-transaction latency, ms (log scale)",
+                  fontsize=11, labelpad=8, color="dimgrey")
+    ax.set_title(f"{proto.capitalize()} protocol: latency p50 (solid) and p99 (dashed)",
+                 loc="left", pad=8, fontsize=14, color="dimgrey")
+
+    headline = _latency_headline(p50, p99)
+    if headline:
+        ax.text(0.98, 0.02, headline,
+                transform=ax.transAxes, ha="right", va="bottom",
+                fontsize=9, color="dimgrey", style="italic")
+
+    ax.legend(loc="upper left", ncol=2, fontsize=9, **LEGEND_KW)
+    ax.grid(True, which="major", alpha=0.35, linewidth=0.6)
+    ax.grid(True, which="minor", alpha=0.15, linewidth=0.4)
+    _finalise_axes(ax)
+    _save(fig, out_path)
+
+
+def _latency_headline(p50_series: dict, p99_series: dict) -> str | None:
+    """One-line takeaway built from the 10k-client column when available."""
+    target = 10_000
+    cells: list[tuple[str, float, float]] = []
+    for pooler in POOLER_ORDER:
+        s50 = dict(p50_series.get(pooler) or [])
+        s99 = dict(p99_series.get(pooler) or [])
+        if target in s50 and target in s99:
+            cells.append((pooler, s50[target], s99[target]))
+    if not cells:
+        return None
+    pieces = [
+        f"{pooler} {p50:.0f}/{p99:.0f}ms"
+        if p50 >= 1 else f"{pooler} {p50:.2f}/{p99:.2f}ms"
+        for pooler, p50, p99 in cells
+    ]
+    return f"At {target:,} clients (p50/p99): " + ", ".join(pieces)
+
+
+# ---------- top-level orchestration ---------------------------------------
+
+
+def render_all(groups: dict, images_dir: Path) -> list[str]:
+    """Generate every chart we currently know how to draw. Returns the list of
+    relative filenames produced (so the markdown step can build ![]() links)."""
+    rendered: list[str] = []
+
+    name = "tldr_tail_spread.svg"
+    chart_tldr_tail_spread(groups, images_dir / name)
+    if (images_dir / name).exists():
+        rendered.append(name)
+
+    for proto in PROTOCOLS:
+        name = f"{proto}_latency.svg"
+        chart_latency_per_protocol(groups, proto, images_dir / name)
+        if (images_dir / name).exists():
+            rendered.append(name)
+
+    return rendered
+
+
+def _decode_groups(raw: dict) -> dict:
+    """JSON keys arrive as strings ('simple|False|False|10000'); rebuild tuples."""
+    out: dict = {}
+    for k, v in raw.items():
+        proto, ssl, conn, clients = k.split("|")
+        out[(proto, ssl == "True", conn == "True", int(clients))] = v
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("groups_json",
+                    help="JSON file with {'<proto>|<ssl>|<conn>|<clients>': {<pooler>: {p50_ms, p99_ms, ...}}}")
+    ap.add_argument("images_dir", help="Output directory for SVG files")
+    args = ap.parse_args()
+
+    groups = _decode_groups(json.loads(Path(args.groups_json).read_text()))
+    rendered = render_all(groups, Path(args.images_dir))
+    for name in rendered:
+        print(f"wrote {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/render_charts.py
+++ b/benches/render_charts.py
@@ -224,7 +224,16 @@ def _latency_headline(p50_series: dict, p99_series: dict) -> str | None:
 
 def render_all(groups: dict, images_dir: Path) -> list[str]:
     """Generate every chart we currently know how to draw. Returns the list of
-    relative filenames produced (so the markdown step can build ![]() links)."""
+    relative filenames produced (so the markdown step can build ![]() links).
+
+    Existing .svg files in ``images_dir`` are removed before rendering so a
+    chart that no longer has data behind it disappears from the docs instead
+    of silently going stale.
+    """
+    images_dir.mkdir(parents=True, exist_ok=True)
+    for stale in images_dir.glob("*.svg"):
+        stale.unlink()
+
     rendered: list[str] = []
 
     name = "tldr_tail_spread.svg"

--- a/benches/test_parse_bench_logs.py
+++ b/benches/test_parse_bench_logs.py
@@ -342,5 +342,77 @@ class ParseTestPercentilesSource(unittest.TestCase):
             self.assertEqual(rec["samples"], 0)
 
 
+class BuildGroups(unittest.TestCase):
+    def test_pivots_test_names_into_tuple_keys(self):
+        results = {
+            "pg_doorman_simple_c40":   {"tps": 100},
+            "pgbouncer_simple_c40":    {"tps": 50},
+            "pg_doorman_ssl_extended_c500": {"tps": 200},
+        }
+        groups, unmatched = P.build_groups(results)
+        self.assertEqual(unmatched, [])
+        self.assertEqual(groups[("simple",   False, False, 40)],
+                         {"pg_doorman": {"tps": 100}, "pgbouncer": {"tps": 50}})
+        self.assertEqual(groups[("extended", True,  False, 500)],
+                         {"pg_doorman": {"tps": 200}})
+
+    def test_reports_unmatched_names(self):
+        results = {
+            "pg_doorman_simple_c1": {"tps": 1},
+            "garbage":              {"tps": 0},
+            "doorman":              {"tps": 0},  # service log stem
+        }
+        _, unmatched = P.build_groups(results)
+        self.assertEqual(sorted(unmatched), ["doorman", "garbage"])
+
+    def test_empty_input(self):
+        self.assertEqual(P.build_groups({}), ({}, []))
+
+
+class RenderChartLinkInjection(unittest.TestCase):
+    """render() embeds ![]() lines for the SVGs whose names are passed in."""
+
+    @staticmethod
+    def _results_with_one_cell():
+        # Minimum input that makes render() emit a TL;DR bullet (`>= 40
+        # clients`, no SSL, no Reconnect) and at least one protocol section.
+        return {
+            "pg_doorman_simple_c40": {"tps": 200, "p50_ms": 1, "p95_ms": 2, "p99_ms": 3},
+            "pgbouncer_simple_c40":  {"tps": 100, "p50_ms": 2, "p95_ms": 4, "p99_ms": 6},
+            "odyssey_simple_c40":    {"tps": 180, "p50_ms": 1, "p95_ms": 2, "p99_ms": 4},
+        }
+
+    def test_no_charts_means_no_image_lines(self):
+        md = P.render(self._results_with_one_cell(), meta=None, chart_names=frozenset())
+        self.assertNotIn("![", md)
+
+    def test_tldr_chart_lands_after_bullets(self):
+        md = P.render(
+            self._results_with_one_cell(), meta=None,
+            chart_names=frozenset({P.TLDR_CHART}),
+        )
+        # Image line must appear inside the TL;DR block, before the next
+        # heading (Environment / Methodology).
+        self.assertIn(f"({P.IMAGES_REL_DIR}/{P.TLDR_CHART})", md)
+        head, _, _ = md.partition("### Environment")
+        self.assertIn(P.TLDR_CHART, head)
+
+    def test_per_protocol_chart_lands_under_its_section(self):
+        md = P.render(
+            self._results_with_one_cell(), meta=None,
+            chart_names=frozenset({P.LATENCY_CHART["simple"]}),
+        )
+        section, _, _ = md.partition("### Throughput")
+        self.assertIn(f"## Simple protocol", section)
+        self.assertIn(P.LATENCY_CHART["simple"], section)
+
+    def test_unknown_chart_name_is_ignored(self):
+        md = P.render(
+            self._results_with_one_cell(), meta=None,
+            chart_names=frozenset({"unknown.svg"}),
+        )
+        self.assertNotIn("![", md)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/benches/test_render_charts.py
+++ b/benches/test_render_charts.py
@@ -168,6 +168,48 @@ class LatencyHeadline(unittest.TestCase):
 
 
 @unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class RenderAllCleanup(unittest.TestCase):
+    """render_all() purges stale SVGs so charts that lost their data go away."""
+
+    def test_existing_svg_files_are_removed_before_render(self):
+        import tempfile
+        groups = {
+            ("simple", False, False, 10000): {
+                "pg_doorman": _cell(60.0, 65.0),
+                "pgbouncer":  _cell(280.0, 390.0),
+                "odyssey":    _cell(18.0, 200.0),
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "ghost.svg").write_text("<svg/>")
+            (d / "another_ghost.svg").write_text("<svg/>")
+            (d / "keep.txt").write_text("not an svg, must survive")
+            R.render_all(groups, d)
+            survivors = sorted(p.name for p in d.iterdir())
+        self.assertNotIn("ghost.svg", survivors)
+        self.assertNotIn("another_ghost.svg", survivors)
+        self.assertIn("keep.txt", survivors)
+        # tldr_tail_spread is the only chart we produced (no per-protocol
+        # data passed in), so the live output is exactly that one file.
+        self.assertIn("tldr_tail_spread.svg", survivors)
+
+    def test_creates_images_dir_if_missing(self):
+        import tempfile
+        groups = {
+            ("simple", False, False, 10000): {
+                "pg_doorman": _cell(1.0, 2.0),
+                "pgbouncer":  _cell(2.0, 4.0),
+            },
+        }
+        with tempfile.TemporaryDirectory() as parent:
+            d = Path(parent) / "nested" / "images"
+            self.assertFalse(d.exists())
+            R.render_all(groups, d)
+            self.assertTrue(d.exists())
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
 class DecodeGroups(unittest.TestCase):
     def test_round_trip(self):
         raw = {

--- a/benches/test_render_charts.py
+++ b/benches/test_render_charts.py
@@ -1,0 +1,195 @@
+"""Unit tests for benches/render_charts.py pure helpers.
+
+Run: python3 -m unittest benches.test_render_charts -v
+or:  python3 benches/test_render_charts.py
+
+The render functions themselves call matplotlib and are exercised end-to-end
+when the bench workflow runs. These tests cover only the pure data-massaging
+helpers so the suite stays runnable without a matplotlib install.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "render_charts", Path(__file__).parent / "render_charts.py"
+)
+# render_charts imports matplotlib at module top, so skip the whole module if
+# matplotlib is not available. The pure helpers don't need matplotlib at call
+# time, but the import does.
+try:
+    R = importlib.util.module_from_spec(_SPEC)
+    _SPEC.loader.exec_module(R)
+    HAVE_RENDER = True
+except ModuleNotFoundError as exc:
+    HAVE_RENDER = False
+    SKIP_REASON = f"render_charts unavailable: {exc.name}"
+
+
+def _cell(p50, p99):
+    return {"p50_ms": p50, "p99_ms": p99}
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class SteadyStateSeries(unittest.TestCase):
+    def test_empty_groups_returns_empty_lists_per_pooler(self):
+        out = R.steady_state_series({}, "simple", "p50_ms")
+        self.assertEqual(out, {"pg_doorman": [], "pgbouncer": [], "odyssey": []})
+
+    def test_filters_out_ssl_and_reconnect_rows(self):
+        groups = {
+            ("simple", False, False, 40):  {"pg_doorman": _cell(0.3, 0.5)},
+            ("simple", True,  False, 40):  {"pg_doorman": _cell(9.9, 9.9)},
+            ("simple", False, True,  40):  {"pg_doorman": _cell(9.9, 9.9)},
+            ("simple", True,  True,  40):  {"pg_doorman": _cell(9.9, 9.9)},
+        }
+        out = R.steady_state_series(groups, "simple", "p50_ms")
+        self.assertEqual(out["pg_doorman"], [(40, 0.3)])
+
+    def test_filters_out_other_protocols(self):
+        groups = {
+            ("simple",   False, False, 40): {"pg_doorman": _cell(0.3, 0.5)},
+            ("extended", False, False, 40): {"pg_doorman": _cell(9.9, 9.9)},
+        }
+        out = R.steady_state_series(groups, "simple", "p50_ms")
+        self.assertEqual(out["pg_doorman"], [(40, 0.3)])
+
+    def test_sorts_by_client_count_ascending(self):
+        groups = {
+            ("simple", False, False, c): {"pg_doorman": _cell(c * 0.01, c * 0.02)}
+            for c in (10000, 1, 500, 40, 120)
+        }
+        out = R.steady_state_series(groups, "simple", "p50_ms")
+        clients = [c for c, _ in out["pg_doorman"]]
+        self.assertEqual(clients, [1, 40, 120, 500, 10000])
+
+    def test_skips_pooler_with_missing_metric(self):
+        groups = {
+            ("simple", False, False, 40): {
+                "pg_doorman": _cell(0.3, 0.5),
+                "pgbouncer":  {"p99_ms": 1.9},  # no p50
+                "odyssey":    None,
+            },
+        }
+        out = R.steady_state_series(groups, "simple", "p50_ms")
+        self.assertEqual(out["pg_doorman"], [(40, 0.3)])
+        self.assertEqual(out["pgbouncer"], [])
+        self.assertEqual(out["odyssey"], [])
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class TailSpread(unittest.TestCase):
+    def test_returns_p99_over_p50(self):
+        groups = {
+            ("simple", False, False, 10000): {
+                "pg_doorman": _cell(60.0, 65.0),
+                "pgbouncer":  _cell(280.0, 390.0),
+            },
+        }
+        out = R.tail_spread(groups, "simple", False, False, 10000)
+        self.assertAlmostEqual(out["pg_doorman"], 65.0 / 60.0)
+        self.assertAlmostEqual(out["pgbouncer"],  390.0 / 280.0)
+
+    def test_missing_cell_returns_empty(self):
+        self.assertEqual(R.tail_spread({}, "simple", False, False, 10000), {})
+
+    def test_skips_pooler_with_zero_p50(self):
+        groups = {
+            ("simple", False, False, 1): {
+                "pg_doorman": _cell(0.0, 0.1),  # division guard must trigger
+                "pgbouncer":  _cell(0.07, 0.10),
+            },
+        }
+        out = R.tail_spread(groups, "simple", False, False, 1)
+        self.assertNotIn("pg_doorman", out)
+        self.assertIn("pgbouncer", out)
+
+    def test_skips_pooler_missing_either_percentile(self):
+        groups = {
+            ("simple", False, False, 1): {
+                "a": {"p50_ms": 0.07},
+                "b": {"p99_ms": 0.10},
+                "c": _cell(0.07, 0.10),
+            },
+        }
+        out = R.tail_spread(groups, "simple", False, False, 1)
+        self.assertEqual(set(out.keys()), {"c"})
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class FormatSpreadLabel(unittest.TestCase):
+    def test_below_ten_one_decimal(self):
+        self.assertEqual(R.format_spread_label(1.083), "1.1×")
+        self.assertEqual(R.format_spread_label(1.4),   "1.4×")
+        self.assertEqual(R.format_spread_label(9.94),  "9.9×")
+
+    def test_at_and_above_ten_no_decimals(self):
+        self.assertEqual(R.format_spread_label(10.0),  "10×")
+        self.assertEqual(R.format_spread_label(11.39), "11×")
+        self.assertEqual(R.format_spread_label(305.0), "305×")
+
+    def test_boundary_just_under_ten_uses_decimal_form(self):
+        # 9.95 stays in the decimal branch (`< 10`); float-repr makes
+        # `.1f` emit 9.9 rather than 10.0 due to IEEE 754 rounding-down.
+        self.assertEqual(R.format_spread_label(9.95), "9.9×")
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class LatencyHeadline(unittest.TestCase):
+    def test_returns_none_when_no_pooler_has_10k_data(self):
+        p50 = {"pg_doorman": [(40, 0.3)], "pgbouncer": [], "odyssey": []}
+        p99 = {"pg_doorman": [(40, 0.5)], "pgbouncer": [], "odyssey": []}
+        self.assertIsNone(R._latency_headline(p50, p99))
+
+    def test_renders_only_poolers_present_at_10k(self):
+        p50 = {
+            "pg_doorman": [(10000, 60.0)],
+            "pgbouncer":  [(10000, 280.0)],
+            "odyssey":    [(40, 0.3)],          # no 10k row
+        }
+        p99 = {
+            "pg_doorman": [(10000, 65.0)],
+            "pgbouncer":  [(10000, 390.0)],
+            "odyssey":    [(40, 0.5)],
+        }
+        out = R._latency_headline(p50, p99)
+        self.assertIn("pg_doorman 60/65ms", out)
+        self.assertIn("pgbouncer 280/390ms", out)
+        self.assertNotIn("odyssey", out)
+
+    def test_sub_one_ms_uses_two_decimal_places(self):
+        # Edge case: at 1 client all three poolers are well under 1ms; format
+        # must switch to high-precision so the digits don't round to 0.
+        p50 = {"pg_doorman": [(10000, 0.07)], "pgbouncer": [], "odyssey": []}
+        p99 = {"pg_doorman": [(10000, 0.10)], "pgbouncer": [], "odyssey": []}
+        out = R._latency_headline(p50, p99)
+        self.assertIn("0.07/0.10ms", out)
+
+
+@unittest.skipUnless(HAVE_RENDER, "matplotlib/seaborn not installed")
+class DecodeGroups(unittest.TestCase):
+    def test_round_trip(self):
+        raw = {
+            "simple|False|False|40":   {"pg_doorman": {"p50_ms": 0.3}},
+            "simple|True|False|10000": {"pg_doorman": {"p50_ms": 26.9}},
+            "extended|False|True|120": {"pg_doorman": {"p50_ms": 3.8}},
+        }
+        out = R._decode_groups(raw)
+        self.assertEqual(out[("simple",   False, False, 40)],    raw["simple|False|False|40"])
+        self.assertEqual(out[("simple",   True,  False, 10000)], raw["simple|True|False|10000"])
+        self.assertEqual(out[("extended", False, True,  120)],   raw["extended|False|True|120"])
+
+    def test_only_literal_True_string_decodes_to_true(self):
+        # Documented contract: keys come from json.dumps of the bench-host
+        # dict, so values are exactly "True" / "False". Anything else is
+        # interpreted as False rather than raising; keep the renderer
+        # tolerant of mangled metadata.
+        raw = {"simple|true|FALSE|40": {"pg_doorman": {"p50_ms": 0.3}}}
+        out = R._decode_groups(raw)
+        # "true" lowercase is not "True" → ssl=False, "FALSE" → conn=False
+        self.assertIn(("simple", False, False, 40), out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/documentation/en/src/benchmarks.md
+++ b/documentation/en/src/benchmarks.md
@@ -17,6 +17,8 @@ _Last updated: 2026-04-27 12:00 UTC._
 - **vs odyssey** — pg_doorman wins by **+40%** at most (extended protocol, 120 clients).
 - **Tail spread at 10 000 simple-protocol clients** (`p99/p50`, lower = more predictable) — pg_doorman 1.1× (59.9→64.5ms), pgbouncer 1.4× (276→387ms), odyssey 11× (17.9→204ms).
 
+![Tail spread at 10,000 simple-protocol clients](images/benchmarks/tldr_tail_spread.svg)
+
 ### Environment
 
 - **Provider**: Ubicloud `standard-60` (eu-central-h1)
@@ -75,6 +77,8 @@ the client count grows. Full p95 series ships in the raw
 
 ## Simple protocol
 
+![Simple protocol: latency p50 (solid) and p99 (dashed)](images/benchmarks/simple_latency.svg)
+
 ### Throughput
 
 | Test | vs pgbouncer | vs odyssey |
@@ -129,6 +133,8 @@ the client count grows. Full p95 series ships in the raw
 
 ## Extended protocol
 
+![Extended protocol: latency p50 (solid) and p99 (dashed)](images/benchmarks/extended_latency.svg)
+
 ### Throughput
 
 | Test | vs pgbouncer | vs odyssey |
@@ -172,6 +178,8 @@ the client count grows. Full p95 series ships in the raw
 ---
 
 ## Prepared protocol
+
+![Prepared protocol: latency p50 (solid) and p99 (dashed)](images/benchmarks/prepared_latency.svg)
 
 ### Throughput
 

--- a/documentation/en/src/images/benchmarks/extended_latency.svg
+++ b/documentation/en/src/images/benchmarks/extended_latency.svg
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.595937pt" height="354.117687pt" viewBox="0 0 564.595937 354.117687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-01T12:17:20.557240</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 354.117687 
+L 564.595937 354.117687 
+L 564.595937 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 55.195938 314.125812 
+L 557.395938 314.125812 
+L 557.395938 25.837812 
+L 55.195938 25.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 78.02321 314.125812 
+L 78.02321 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="78.02321" y="325.984094" transform="rotate(-0 78.02321 325.984094)">1</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <path d="M 260.876512 314.125812 
+L 260.876512 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="260.876512" y="325.984094" transform="rotate(-0 260.876512 325.984094)">40</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <path d="M 315.333397 314.125812 
+L 315.333397 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="315.333397" y="325.984094" transform="rotate(-0 315.333397 325.984094)">120</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <path d="M 386.073832 314.125812 
+L 386.073832 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="386.073832" y="325.984094" transform="rotate(-0 386.073832 325.984094)">500</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <path d="M 534.568665 314.125812 
+L 534.568665 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="534.568665" y="325.984094" transform="rotate(-0 534.568665 325.984094)">10,000</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <path d="M 60.343264 314.125812 
+L 60.343264 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <path d="M 66.962254 314.125812 
+L 66.962254 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <path d="M 72.800617 314.125812 
+L 72.800617 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <path d="M 112.381679 314.125812 
+L 112.381679 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <path d="M 132.480095 314.125812 
+L 132.480095 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <path d="M 146.740148 314.125812 
+L 146.740148 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <path d="M 157.801105 314.125812 
+L 157.801105 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <path d="M 166.838564 314.125812 
+L 166.838564 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <path d="M 174.479627 314.125812 
+L 174.479627 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <path d="M 181.098617 314.125812 
+L 181.098617 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <path d="M 186.93698 314.125812 
+L 186.93698 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <path d="M 226.518043 314.125812 
+L 226.518043 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_18">
+      <path d="M 246.616459 314.125812 
+L 246.616459 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_19">
+      <path d="M 271.937468 314.125812 
+L 271.937468 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_20">
+      <path d="M 280.974928 314.125812 
+L 280.974928 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_21">
+      <path d="M 288.615991 314.125812 
+L 288.615991 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_22">
+      <path d="M 295.234981 314.125812 
+L 295.234981 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_23">
+      <path d="M 301.073344 314.125812 
+L 301.073344 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_24">
+      <path d="M 340.654407 314.125812 
+L 340.654407 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_25">
+      <path d="M 360.752823 314.125812 
+L 360.752823 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_26">
+      <path d="M 375.012876 314.125812 
+L 375.012876 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_27">
+      <path d="M 395.111292 314.125812 
+L 395.111292 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_28">
+      <path d="M 402.752355 314.125812 
+L 402.752355 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_29">
+      <path d="M 409.371345 314.125812 
+L 409.371345 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_30">
+      <path d="M 415.209708 314.125812 
+L 415.209708 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_31">
+      <path d="M 454.79077 314.125812 
+L 454.79077 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_32">
+      <path d="M 474.889186 314.125812 
+L 474.889186 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_33">
+      <path d="M 489.149239 314.125812 
+L 489.149239 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_34">
+      <path d="M 500.210196 314.125812 
+L 500.210196 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_35">
+      <path d="M 509.247655 314.125812 
+L 509.247655 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_36">
+      <path d="M 516.888718 314.125812 
+L 516.888718 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_37">
+      <path d="M 523.507708 314.125812 
+L 523.507708 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_38">
+      <path d="M 529.346071 314.125812 
+L 529.346071 25.837812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="306.295938" y="344.630031" transform="rotate(-0 306.295938 344.630031)">Concurrent pgbench clients (log scale)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_39">
+      <path d="M 55.195938 290.174657 
+L 557.395938 290.174657 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g style="fill: #696969" transform="translate(25.845938 294.353797)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">−</tspan>
+        <tspan x="20.554102" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_40">
+      <path d="M 55.195938 220.148713 
+L 557.395938 220.148713 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 224.327854)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_41">
+      <path d="M 55.195938 150.12277 
+L 557.395938 150.12277 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 154.301911)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_42">
+      <path d="M 55.195938 80.096827 
+L 557.395938 80.096827 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 84.275968)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">2</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_43">
+      <path d="M 55.195938 311.254566 
+L 557.395938 311.254566 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_44">
+      <path d="M 55.195938 305.709825 
+L 557.395938 305.709825 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_45">
+      <path d="M 55.195938 301.021812 
+L 557.395938 301.021812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_46">
+      <path d="M 55.195938 296.960872 
+L 557.395938 296.960872 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_47">
+      <path d="M 55.195938 293.378868 
+L 557.395938 293.378868 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_48">
+      <path d="M 55.195938 269.094747 
+L 557.395938 269.094747 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_49">
+      <path d="M 55.195938 256.763791 
+L 557.395938 256.763791 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_50">
+      <path d="M 55.195938 248.014838 
+L 557.395938 248.014838 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_51">
+      <path d="M 55.195938 241.228623 
+L 557.395938 241.228623 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_52">
+      <path d="M 55.195938 235.683881 
+L 557.395938 235.683881 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_53">
+      <path d="M 55.195938 230.995869 
+L 557.395938 230.995869 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_54">
+      <path d="M 55.195938 226.934929 
+L 557.395938 226.934929 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_55">
+      <path d="M 55.195938 223.352925 
+L 557.395938 223.352925 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_56">
+      <path d="M 55.195938 199.068804 
+L 557.395938 199.068804 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_57">
+      <path d="M 55.195938 186.737848 
+L 557.395938 186.737848 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_58">
+      <path d="M 55.195938 177.988895 
+L 557.395938 177.988895 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_59">
+      <path d="M 55.195938 171.20268 
+L 557.395938 171.20268 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_60">
+      <path d="M 55.195938 165.657938 
+L 557.395938 165.657938 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_61">
+      <path d="M 55.195938 160.969926 
+L 557.395938 160.969926 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_62">
+      <path d="M 55.195938 156.908985 
+L 557.395938 156.908985 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_63">
+      <path d="M 55.195938 153.326982 
+L 557.395938 153.326982 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_64">
+      <path d="M 55.195938 129.042861 
+L 557.395938 129.042861 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_65">
+      <path d="M 55.195938 116.711904 
+L 557.395938 116.711904 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_66">
+      <path d="M 55.195938 107.962952 
+L 557.395938 107.962952 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_67">
+      <path d="M 55.195938 101.176737 
+L 557.395938 101.176737 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_68">
+      <path d="M 55.195938 95.631995 
+L 557.395938 95.631995 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_69">
+      <path d="M 55.195938 90.943983 
+L 557.395938 90.943983 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_70">
+      <path d="M 55.195938 86.883042 
+L 557.395938 86.883042 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_71">
+      <path d="M 55.195938 83.301039 
+L 557.395938 83.301039 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_72">
+      <path d="M 55.195938 59.016918 
+L 557.395938 59.016918 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_73">
+      <path d="M 55.195938 46.685961 
+L 557.395938 46.685961 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_74">
+      <path d="M 55.195938 37.937008 
+L 557.395938 37.937008 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_75">
+      <path d="M 55.195938 31.150793 
+L 557.395938 31.150793 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="15.558281" y="169.981812" transform="rotate(-90 15.558281 169.981812)">Per-transaction latency, ms (log scale)</text>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <defs>
+     <path id="m884eb8e298" d="M 78.02321 -66.841593 
+L 78.02321 -53.095875 
+L 260.876512 -94.149685 
+L 315.333397 -95.255694 
+L 386.073832 -156.241659 
+L 534.568665 -256.05989 
+L 534.568665 -258.637373 
+L 534.568665 -258.637373 
+L 386.073832 -175.976352 
+L 315.333397 -130.424962 
+L 260.876512 -111.647591 
+L 78.02321 -66.841593 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m884eb8e298" x="0" y="354.117687" style="fill: #4575b4; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_2">
+    <defs>
+     <path id="mb293c5cbb0" d="M 78.02321 -63.943031 
+L 78.02321 -53.095875 
+L 260.876512 -125.622833 
+L 315.333397 -167.982075 
+L 386.073832 -211.502396 
+L 534.568665 -306.190253 
+L 534.568665 -315.175875 
+L 534.568665 -315.175875 
+L 386.073832 -234.97998 
+L 315.333397 -192.577659 
+L 260.876512 -153.488958 
+L 78.02321 -63.943031 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#mb293c5cbb0" x="0" y="354.117687" style="fill: #d73027; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_3">
+    <defs>
+     <path id="m57e714cafc" d="M 78.02321 -81.818729 
+L 78.02321 -66.841593 
+L 260.876512 -81.818729 
+L 315.333397 -102.041909 
+L 386.073832 -147.297131 
+L 534.568665 -254.250471 
+L 534.568665 -309.959407 
+L 534.568665 -309.959407 
+L 386.073832 -212.43822 
+L 315.333397 -172.24114 
+L 260.876512 -111.647591 
+L 78.02321 -81.818729 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m57e714cafc" x="0" y="354.117687" style="fill: #fc8d59; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="line2d_76">
+    <path d="M 78.02321 301.021812 
+L 260.876512 259.968002 
+L 315.333397 258.861994 
+L 386.073832 197.876028 
+L 534.568665 98.057798 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m467a629bb3" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #4575b4"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m467a629bb3" x="78.02321" y="301.021812" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m467a629bb3" x="260.876512" y="259.968002" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m467a629bb3" x="315.333397" y="258.861994" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m467a629bb3" x="386.073832" y="197.876028" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m467a629bb3" x="534.568665" y="98.057798" style="fill: #4575b4; stroke: #4575b4"/>
+    </g>
+   </g>
+   <g id="line2d_77">
+    <path d="M 78.02321 287.276095 
+L 260.876512 242.470096 
+L 315.333397 223.692726 
+L 386.073832 178.141336 
+L 534.568665 95.480315 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m1bfc96d0e6" d="M 0 2.5 
+C 0.663008 2.5 1.29895 2.236584 1.767767 1.767767 
+C 2.236584 1.29895 2.5 0.663008 2.5 0 
+C 2.5 -0.663008 2.236584 -1.29895 1.767767 -1.767767 
+C 1.29895 -2.236584 0.663008 -2.5 0 -2.5 
+C -0.663008 -2.5 -1.29895 -2.236584 -1.767767 -1.767767 
+C -2.236584 -1.29895 -2.5 -0.663008 -2.5 0 
+C -2.5 0.663008 -2.236584 1.29895 -1.767767 1.767767 
+C -1.29895 2.236584 -0.663008 2.5 0 2.5 
+z
+" style="stroke: #4575b4; stroke-opacity: 0.75"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m1bfc96d0e6" x="78.02321" y="287.276095" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m1bfc96d0e6" x="260.876512" y="242.470096" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m1bfc96d0e6" x="315.333397" y="223.692726" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m1bfc96d0e6" x="386.073832" y="178.141336" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m1bfc96d0e6" x="534.568665" y="95.480315" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+    </g>
+   </g>
+   <g id="line2d_78">
+    <path d="M 78.02321 301.021812 
+L 260.876512 228.494854 
+L 315.333397 186.135612 
+L 386.073832 142.615291 
+L 534.568665 47.927435 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="mee41da02bd" d="M -3.5 3.5 
+L 3.5 3.5 
+L 3.5 -3.5 
+L -3.5 -3.5 
+z
+" style="stroke: #d73027; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#mee41da02bd" x="78.02321" y="301.021812" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#mee41da02bd" x="260.876512" y="228.494854" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#mee41da02bd" x="315.333397" y="186.135612" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#mee41da02bd" x="386.073832" y="142.615291" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#mee41da02bd" x="534.568665" y="47.927435" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_79">
+    <path d="M 78.02321 290.174657 
+L 260.876512 200.62873 
+L 315.333397 161.540029 
+L 386.073832 119.137707 
+L 534.568665 38.941812 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m8db14dbfdf" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m8db14dbfdf" x="78.02321" y="290.174657" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db14dbfdf" x="260.876512" y="200.62873" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db14dbfdf" x="315.333397" y="161.540029" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db14dbfdf" x="386.073832" y="119.137707" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db14dbfdf" x="534.568665" y="38.941812" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_80">
+    <path d="M 78.02321 287.276095 
+L 260.876512 272.298959 
+L 315.333397 252.075779 
+L 386.073832 206.820557 
+L 534.568665 99.867216 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m714fa12a42" d="M 0 -3.5 
+L -3.5 3.5 
+L 3.5 3.5 
+z
+" style="stroke: #fc8d59; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m714fa12a42" x="78.02321" y="287.276095" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fa12a42" x="260.876512" y="272.298959" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fa12a42" x="315.333397" y="252.075779" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fa12a42" x="386.073832" y="206.820557" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fa12a42" x="534.568665" y="99.867216" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_81">
+    <path d="M 78.02321 272.298959 
+L 260.876512 242.470096 
+L 315.333397 181.876548 
+L 386.073832 141.679467 
+L 534.568665 44.158281 
+" clip-path="url(#p4ef3b9ea15)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m1aa5ba0841" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p4ef3b9ea15)">
+     <use xlink:href="#m1aa5ba0841" x="78.02321" y="272.298959" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m1aa5ba0841" x="260.876512" y="242.470096" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m1aa5ba0841" x="315.333397" y="181.876548" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m1aa5ba0841" x="386.073832" y="141.679467" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m1aa5ba0841" x="534.568665" y="44.158281" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <text style="font-style: italic; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="547.351938" y="306.238021" transform="rotate(-0 547.351938 306.238021)">At 10,000 clients (p50/p99): pg_doorman 55/60ms, pgbouncer 288/387ms, odyssey 52/326ms</text>
+   </g>
+   <g id="text_13">
+    <text style="font-size: 14px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="55.195938" y="17.837812" transform="rotate(-0 55.195938 17.837812)">Extended protocol: latency p50 (solid) and p99 (dashed)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_3">
+     <path d="M 61.495938 73.169375 
+L 277.972656 73.169375 
+Q 279.772656 73.169375 279.772656 71.369375 
+L 279.772656 32.137812 
+Q 279.772656 30.337812 277.972656 30.337812 
+L 61.495938 30.337812 
+Q 59.695938 30.337812 59.695938 32.137812 
+L 59.695938 71.369375 
+Q 59.695938 73.169375 61.495938 73.169375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #d3d3d3; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_82">
+     <path d="M 63.295938 37.626406 
+L 72.295938 37.626406 
+L 81.295938 37.626406 
+" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m467a629bb3" x="72.295938" y="37.626406" style="fill: #4575b4; stroke: #4575b4"/>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="40.776406" transform="rotate(-0 88.495938 40.776406)">pg_doorman p50</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 63.295938 51.087031 
+L 72.295938 51.087031 
+L 81.295938 51.087031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m1bfc96d0e6" x="72.295938" y="51.087031" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="54.237031" transform="rotate(-0 88.495938 54.237031)">pg_doorman p99</text>
+    </g>
+    <g id="line2d_84">
+     <path d="M 63.295938 64.547656 
+L 72.295938 64.547656 
+L 81.295938 64.547656 
+" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#mee41da02bd" x="72.295938" y="64.547656" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="67.697656" transform="rotate(-0 88.495938 67.697656)">pgbouncer p50</text>
+    </g>
+    <g id="line2d_85">
+     <path d="M 182.704844 37.626406 
+L 191.704844 37.626406 
+L 200.704844 37.626406 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m8db14dbfdf" x="191.704844" y="37.626406" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="40.776406" transform="rotate(-0 207.904844 40.776406)">pgbouncer p99</text>
+    </g>
+    <g id="line2d_86">
+     <path d="M 182.704844 50.836719 
+L 191.704844 50.836719 
+L 200.704844 50.836719 
+" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m714fa12a42" x="191.704844" y="50.836719" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="53.986719" transform="rotate(-0 207.904844 53.986719)">odyssey p50</text>
+    </g>
+    <g id="line2d_87">
+     <path d="M 182.704844 64.047031 
+L 191.704844 64.047031 
+L 200.704844 64.047031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m1aa5ba0841" x="191.704844" y="64.047031" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="67.197031" transform="rotate(-0 207.904844 67.197031)">odyssey p99</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4ef3b9ea15">
+   <rect x="55.195938" y="25.837812" width="502.2" height="288.288"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/documentation/en/src/images/benchmarks/prepared_latency.svg
+++ b/documentation/en/src/images/benchmarks/prepared_latency.svg
@@ -1,0 +1,954 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.595937pt" height="354.117687pt" viewBox="0 0 564.595937 354.117687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-01T12:17:20.759636</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 354.117687 
+L 564.595937 354.117687 
+L 564.595937 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 55.195938 314.125812 
+L 557.395938 314.125812 
+L 557.395938 25.837812 
+L 55.195938 25.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 78.02321 314.125812 
+L 78.02321 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="78.02321" y="325.984094" transform="rotate(-0 78.02321 325.984094)">1</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <path d="M 260.876512 314.125812 
+L 260.876512 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="260.876512" y="325.984094" transform="rotate(-0 260.876512 325.984094)">40</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <path d="M 315.333397 314.125812 
+L 315.333397 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="315.333397" y="325.984094" transform="rotate(-0 315.333397 325.984094)">120</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <path d="M 386.073832 314.125812 
+L 386.073832 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="386.073832" y="325.984094" transform="rotate(-0 386.073832 325.984094)">500</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <path d="M 534.568665 314.125812 
+L 534.568665 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="534.568665" y="325.984094" transform="rotate(-0 534.568665 325.984094)">10,000</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <path d="M 60.343264 314.125812 
+L 60.343264 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <path d="M 66.962254 314.125812 
+L 66.962254 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <path d="M 72.800617 314.125812 
+L 72.800617 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <path d="M 112.381679 314.125812 
+L 112.381679 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <path d="M 132.480095 314.125812 
+L 132.480095 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <path d="M 146.740148 314.125812 
+L 146.740148 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <path d="M 157.801105 314.125812 
+L 157.801105 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <path d="M 166.838564 314.125812 
+L 166.838564 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <path d="M 174.479627 314.125812 
+L 174.479627 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <path d="M 181.098617 314.125812 
+L 181.098617 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <path d="M 186.93698 314.125812 
+L 186.93698 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <path d="M 226.518043 314.125812 
+L 226.518043 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_18">
+      <path d="M 246.616459 314.125812 
+L 246.616459 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_19">
+      <path d="M 271.937468 314.125812 
+L 271.937468 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_20">
+      <path d="M 280.974928 314.125812 
+L 280.974928 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_21">
+      <path d="M 288.615991 314.125812 
+L 288.615991 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_22">
+      <path d="M 295.234981 314.125812 
+L 295.234981 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_23">
+      <path d="M 301.073344 314.125812 
+L 301.073344 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_24">
+      <path d="M 340.654407 314.125812 
+L 340.654407 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_25">
+      <path d="M 360.752823 314.125812 
+L 360.752823 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_26">
+      <path d="M 375.012876 314.125812 
+L 375.012876 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_27">
+      <path d="M 395.111292 314.125812 
+L 395.111292 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_28">
+      <path d="M 402.752355 314.125812 
+L 402.752355 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_29">
+      <path d="M 409.371345 314.125812 
+L 409.371345 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_30">
+      <path d="M 415.209708 314.125812 
+L 415.209708 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_31">
+      <path d="M 454.79077 314.125812 
+L 454.79077 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_32">
+      <path d="M 474.889186 314.125812 
+L 474.889186 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_33">
+      <path d="M 489.149239 314.125812 
+L 489.149239 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_34">
+      <path d="M 500.210196 314.125812 
+L 500.210196 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_35">
+      <path d="M 509.247655 314.125812 
+L 509.247655 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_36">
+      <path d="M 516.888718 314.125812 
+L 516.888718 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_37">
+      <path d="M 523.507708 314.125812 
+L 523.507708 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_38">
+      <path d="M 529.346071 314.125812 
+L 529.346071 25.837812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="306.295938" y="344.630031" transform="rotate(-0 306.295938 344.630031)">Concurrent pgbench clients (log scale)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_39">
+      <path d="M 55.195938 290.40095 
+L 557.395938 290.40095 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g style="fill: #696969" transform="translate(25.845938 294.580091)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">−</tspan>
+        <tspan x="20.554102" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_40">
+      <path d="M 55.195938 221.835888 
+L 557.395938 221.835888 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 226.015029)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_41">
+      <path d="M 55.195938 153.270827 
+L 557.395938 153.270827 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 157.449968)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_42">
+      <path d="M 55.195938 84.705765 
+L 557.395938 84.705765 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 88.884906)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">2</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_43">
+      <path d="M 55.195938 311.04109 
+L 557.395938 311.04109 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_44">
+      <path d="M 55.195938 305.612023 
+L 557.395938 305.612023 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_45">
+      <path d="M 55.195938 301.021812 
+L 557.395938 301.021812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_46">
+      <path d="M 55.195938 297.045591 
+L 557.395938 297.045591 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_47">
+      <path d="M 55.195938 293.538315 
+L 557.395938 293.538315 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_48">
+      <path d="M 55.195938 269.76081 
+L 557.395938 269.76081 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_49">
+      <path d="M 55.195938 257.687102 
+L 557.395938 257.687102 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_50">
+      <path d="M 55.195938 249.12067 
+L 557.395938 249.12067 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_51">
+      <path d="M 55.195938 242.476029 
+L 557.395938 242.476029 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_52">
+      <path d="M 55.195938 237.046962 
+L 557.395938 237.046962 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_53">
+      <path d="M 55.195938 232.456751 
+L 557.395938 232.456751 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_54">
+      <path d="M 55.195938 228.480529 
+L 557.395938 228.480529 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_55">
+      <path d="M 55.195938 224.973254 
+L 557.395938 224.973254 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_56">
+      <path d="M 55.195938 201.195748 
+L 557.395938 201.195748 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_57">
+      <path d="M 55.195938 189.12204 
+L 557.395938 189.12204 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_58">
+      <path d="M 55.195938 180.555608 
+L 557.395938 180.555608 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_59">
+      <path d="M 55.195938 173.910967 
+L 557.395938 173.910967 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_60">
+      <path d="M 55.195938 168.4819 
+L 557.395938 168.4819 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_61">
+      <path d="M 55.195938 163.891689 
+L 557.395938 163.891689 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_62">
+      <path d="M 55.195938 159.915468 
+L 557.395938 159.915468 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_63">
+      <path d="M 55.195938 156.408192 
+L 557.395938 156.408192 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_64">
+      <path d="M 55.195938 132.630687 
+L 557.395938 132.630687 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_65">
+      <path d="M 55.195938 120.556979 
+L 557.395938 120.556979 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_66">
+      <path d="M 55.195938 111.990547 
+L 557.395938 111.990547 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_67">
+      <path d="M 55.195938 105.345906 
+L 557.395938 105.345906 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_68">
+      <path d="M 55.195938 99.916838 
+L 557.395938 99.916838 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_69">
+      <path d="M 55.195938 95.326628 
+L 557.395938 95.326628 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_70">
+      <path d="M 55.195938 91.350406 
+L 557.395938 91.350406 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_71">
+      <path d="M 55.195938 87.84313 
+L 557.395938 87.84313 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_72">
+      <path d="M 55.195938 64.065625 
+L 557.395938 64.065625 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_73">
+      <path d="M 55.195938 51.991917 
+L 557.395938 51.991917 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_74">
+      <path d="M 55.195938 43.425485 
+L 557.395938 43.425485 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_75">
+      <path d="M 55.195938 36.780844 
+L 557.395938 36.780844 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_76">
+      <path d="M 55.195938 31.351777 
+L 557.395938 31.351777 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_77">
+      <path d="M 55.195938 26.761566 
+L 557.395938 26.761566 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="15.558281" y="169.981812" transform="rotate(-90 15.558281 169.981812)">Per-transaction latency, ms (log scale)</text>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <defs>
+     <path id="mcf8e8b7426" d="M 78.02321 -63.716737 
+L 78.02321 -53.095875 
+L 260.876512 -93.29322 
+L 315.333397 -96.430586 
+L 386.073832 -155.895076 
+L 534.568665 -252.933533 
+L 534.568665 -255.606391 
+L 534.568665 -255.606391 
+L 386.073832 -175.226865 
+L 315.333397 -130.439309 
+L 260.876512 -111.040074 
+L 78.02321 -63.716737 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#mcf8e8b7426" x="0" y="354.117687" style="fill: #4575b4; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_2">
+    <defs>
+     <path id="mc7d600615c" d="M 78.02321 -63.716737 
+L 78.02321 -53.095875 
+L 260.876512 -129.144434 
+L 315.333397 -172.191009 
+L 386.073832 -215.758661 
+L 534.568665 -306.970129 
+L 534.568665 -315.175875 
+L 534.568665 -315.175875 
+L 386.073832 -236.398801 
+L 315.333397 -194.937502 
+L 260.876512 -156.163343 
+L 78.02321 -63.716737 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#mc7d600615c" x="0" y="354.117687" style="fill: #d73027; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_3">
+    <defs>
+     <path id="m4052eaca13" d="M 78.02321 -66.554829 
+L 78.02321 -53.095875 
+L 260.876512 -69.145804 
+L 315.333397 -88.518629 
+L 386.073832 -126.007069 
+L 534.568665 -217.510779 
+L 534.568665 -290.787345 
+L 534.568665 -290.787345 
+L 386.073832 -189.926725 
+L 315.333397 -143.955804 
+L 260.876512 -92.169411 
+L 78.02321 -66.554829 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m4052eaca13" x="0" y="354.117687" style="fill: #fc8d59; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="line2d_78">
+    <path d="M 78.02321 301.021812 
+L 260.876512 260.824467 
+L 315.333397 257.687102 
+L 386.073832 198.222611 
+L 534.568665 101.184154 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m17a8075331" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #4575b4"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m17a8075331" x="78.02321" y="301.021812" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m17a8075331" x="260.876512" y="260.824467" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m17a8075331" x="315.333397" y="257.687102" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m17a8075331" x="386.073832" y="198.222611" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m17a8075331" x="534.568665" y="101.184154" style="fill: #4575b4; stroke: #4575b4"/>
+    </g>
+   </g>
+   <g id="line2d_79">
+    <path d="M 78.02321 290.40095 
+L 260.876512 243.077613 
+L 315.333397 223.678379 
+L 386.073832 178.890823 
+L 534.568665 98.511296 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m4b014a11de" d="M 0 2.5 
+C 0.663008 2.5 1.29895 2.236584 1.767767 1.767767 
+C 2.236584 1.29895 2.5 0.663008 2.5 0 
+C 2.5 -0.663008 2.236584 -1.29895 1.767767 -1.767767 
+C 1.29895 -2.236584 0.663008 -2.5 0 -2.5 
+C -0.663008 -2.5 -1.29895 -2.236584 -1.767767 -1.767767 
+C -2.236584 -1.29895 -2.5 -0.663008 -2.5 0 
+C -2.5 0.663008 -2.236584 1.29895 -1.767767 1.767767 
+C -1.29895 2.236584 -0.663008 2.5 0 2.5 
+z
+" style="stroke: #4575b4; stroke-opacity: 0.75"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m4b014a11de" x="78.02321" y="290.40095" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m4b014a11de" x="260.876512" y="243.077613" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m4b014a11de" x="315.333397" y="223.678379" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m4b014a11de" x="386.073832" y="178.890823" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m4b014a11de" x="534.568665" y="98.511296" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+    </g>
+   </g>
+   <g id="line2d_80">
+    <path d="M 78.02321 301.021812 
+L 260.876512 224.973254 
+L 315.333397 181.926678 
+L 386.073832 138.359027 
+L 534.568665 47.147559 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m8bf9e64c3c" d="M -3.5 3.5 
+L 3.5 3.5 
+L 3.5 -3.5 
+L -3.5 -3.5 
+z
+" style="stroke: #d73027; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m8bf9e64c3c" x="78.02321" y="301.021812" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bf9e64c3c" x="260.876512" y="224.973254" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bf9e64c3c" x="315.333397" y="181.926678" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bf9e64c3c" x="386.073832" y="138.359027" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bf9e64c3c" x="534.568665" y="47.147559" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_81">
+    <path d="M 78.02321 290.40095 
+L 260.876512 197.954344 
+L 315.333397 159.180185 
+L 386.073832 117.718887 
+L 534.568665 38.941812 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m8fc7264ffd" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m8fc7264ffd" x="78.02321" y="290.40095" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8fc7264ffd" x="260.876512" y="197.954344" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8fc7264ffd" x="315.333397" y="159.180185" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8fc7264ffd" x="386.073832" y="117.718887" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m8fc7264ffd" x="534.568665" y="38.941812" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_82">
+    <path d="M 78.02321 301.021812 
+L 260.876512 284.971883 
+L 315.333397 265.599059 
+L 386.073832 228.110619 
+L 534.568665 136.606908 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m8d0b934f88" d="M 0 -3.5 
+L -3.5 3.5 
+L 3.5 3.5 
+z
+" style="stroke: #fc8d59; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m8d0b934f88" x="78.02321" y="301.021812" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d0b934f88" x="260.876512" y="284.971883" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d0b934f88" x="315.333397" y="265.599059" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d0b934f88" x="386.073832" y="228.110619" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d0b934f88" x="534.568665" y="136.606908" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_83">
+    <path d="M 78.02321 287.562858 
+L 260.876512 261.948277 
+L 315.333397 210.161883 
+L 386.073832 164.190962 
+L 534.568665 63.330343 
+" clip-path="url(#p43d5aa5fb9)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m80d55c1e00" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p43d5aa5fb9)">
+     <use xlink:href="#m80d55c1e00" x="78.02321" y="287.562858" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m80d55c1e00" x="260.876512" y="261.948277" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m80d55c1e00" x="315.333397" y="210.161883" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m80d55c1e00" x="386.073832" y="164.190962" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m80d55c1e00" x="534.568665" y="63.330343" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <text style="font-style: italic; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="547.351938" y="306.238021" transform="rotate(-0 547.351938 306.238021)">At 10,000 clients (p50/p99): pg_doorman 58/63ms, pgbouncer 353/465ms, odyssey 18/205ms</text>
+   </g>
+   <g id="text_13">
+    <text style="font-size: 14px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="55.195938" y="17.837812" transform="rotate(-0 55.195938 17.837812)">Prepared protocol: latency p50 (solid) and p99 (dashed)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_3">
+     <path d="M 61.495938 73.169375 
+L 277.972656 73.169375 
+Q 279.772656 73.169375 279.772656 71.369375 
+L 279.772656 32.137812 
+Q 279.772656 30.337812 277.972656 30.337812 
+L 61.495938 30.337812 
+Q 59.695938 30.337812 59.695938 32.137812 
+L 59.695938 71.369375 
+Q 59.695938 73.169375 61.495938 73.169375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #d3d3d3; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_84">
+     <path d="M 63.295938 37.626406 
+L 72.295938 37.626406 
+L 81.295938 37.626406 
+" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m17a8075331" x="72.295938" y="37.626406" style="fill: #4575b4; stroke: #4575b4"/>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="40.776406" transform="rotate(-0 88.495938 40.776406)">pg_doorman p50</text>
+    </g>
+    <g id="line2d_85">
+     <path d="M 63.295938 51.087031 
+L 72.295938 51.087031 
+L 81.295938 51.087031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m4b014a11de" x="72.295938" y="51.087031" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="54.237031" transform="rotate(-0 88.495938 54.237031)">pg_doorman p99</text>
+    </g>
+    <g id="line2d_86">
+     <path d="M 63.295938 64.547656 
+L 72.295938 64.547656 
+L 81.295938 64.547656 
+" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m8bf9e64c3c" x="72.295938" y="64.547656" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="67.697656" transform="rotate(-0 88.495938 67.697656)">pgbouncer p50</text>
+    </g>
+    <g id="line2d_87">
+     <path d="M 182.704844 37.626406 
+L 191.704844 37.626406 
+L 200.704844 37.626406 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m8fc7264ffd" x="191.704844" y="37.626406" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="40.776406" transform="rotate(-0 207.904844 40.776406)">pgbouncer p99</text>
+    </g>
+    <g id="line2d_88">
+     <path d="M 182.704844 50.836719 
+L 191.704844 50.836719 
+L 200.704844 50.836719 
+" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m8d0b934f88" x="191.704844" y="50.836719" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="53.986719" transform="rotate(-0 207.904844 53.986719)">odyssey p50</text>
+    </g>
+    <g id="line2d_89">
+     <path d="M 182.704844 64.047031 
+L 191.704844 64.047031 
+L 200.704844 64.047031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m80d55c1e00" x="191.704844" y="64.047031" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="67.197031" transform="rotate(-0 207.904844 67.197031)">odyssey p99</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p43d5aa5fb9">
+   <rect x="55.195938" y="25.837812" width="502.2" height="288.288"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/documentation/en/src/images/benchmarks/simple_latency.svg
+++ b/documentation/en/src/images/benchmarks/simple_latency.svg
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.595937pt" height="354.117687pt" viewBox="0 0 564.595937 354.117687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-01T12:17:20.399015</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 354.117687 
+L 564.595937 354.117687 
+L 564.595937 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 55.195938 314.125812 
+L 557.395938 314.125812 
+L 557.395938 25.837812 
+L 55.195938 25.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 78.02321 314.125812 
+L 78.02321 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="78.02321" y="325.984094" transform="rotate(-0 78.02321 325.984094)">1</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <path d="M 260.876512 314.125812 
+L 260.876512 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="260.876512" y="325.984094" transform="rotate(-0 260.876512 325.984094)">40</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <path d="M 315.333397 314.125812 
+L 315.333397 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="315.333397" y="325.984094" transform="rotate(-0 315.333397 325.984094)">120</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <path d="M 386.073832 314.125812 
+L 386.073832 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="386.073832" y="325.984094" transform="rotate(-0 386.073832 325.984094)">500</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <path d="M 534.568665 314.125812 
+L 534.568665 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="534.568665" y="325.984094" transform="rotate(-0 534.568665 325.984094)">10,000</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <path d="M 60.343264 314.125812 
+L 60.343264 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <path d="M 66.962254 314.125812 
+L 66.962254 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <path d="M 72.800617 314.125812 
+L 72.800617 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <path d="M 112.381679 314.125812 
+L 112.381679 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <path d="M 132.480095 314.125812 
+L 132.480095 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <path d="M 146.740148 314.125812 
+L 146.740148 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <path d="M 157.801105 314.125812 
+L 157.801105 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <path d="M 166.838564 314.125812 
+L 166.838564 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <path d="M 174.479627 314.125812 
+L 174.479627 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <path d="M 181.098617 314.125812 
+L 181.098617 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <path d="M 186.93698 314.125812 
+L 186.93698 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <path d="M 226.518043 314.125812 
+L 226.518043 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_18">
+      <path d="M 246.616459 314.125812 
+L 246.616459 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_19">
+      <path d="M 271.937468 314.125812 
+L 271.937468 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_20">
+      <path d="M 280.974928 314.125812 
+L 280.974928 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_21">
+      <path d="M 288.615991 314.125812 
+L 288.615991 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_22">
+      <path d="M 295.234981 314.125812 
+L 295.234981 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_23">
+      <path d="M 301.073344 314.125812 
+L 301.073344 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_24">
+      <path d="M 340.654407 314.125812 
+L 340.654407 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_25">
+      <path d="M 360.752823 314.125812 
+L 360.752823 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_26">
+      <path d="M 375.012876 314.125812 
+L 375.012876 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_27">
+      <path d="M 395.111292 314.125812 
+L 395.111292 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_28">
+      <path d="M 402.752355 314.125812 
+L 402.752355 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_29">
+      <path d="M 409.371345 314.125812 
+L 409.371345 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_30">
+      <path d="M 415.209708 314.125812 
+L 415.209708 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_31">
+      <path d="M 454.79077 314.125812 
+L 454.79077 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_32">
+      <path d="M 474.889186 314.125812 
+L 474.889186 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_33">
+      <path d="M 489.149239 314.125812 
+L 489.149239 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_34">
+      <path d="M 500.210196 314.125812 
+L 500.210196 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_35">
+      <path d="M 509.247655 314.125812 
+L 509.247655 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_36">
+      <path d="M 516.888718 314.125812 
+L 516.888718 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_37">
+      <path d="M 523.507708 314.125812 
+L 523.507708 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_38">
+      <path d="M 529.346071 314.125812 
+L 529.346071 25.837812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="306.295938" y="344.630031" transform="rotate(-0 306.295938 344.630031)">Concurrent pgbench clients (log scale)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_39">
+      <path d="M 55.195938 290.174657 
+L 557.395938 290.174657 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g style="fill: #696969" transform="translate(25.845938 294.353797)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">−</tspan>
+        <tspan x="20.554102" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_40">
+      <path d="M 55.195938 220.148713 
+L 557.395938 220.148713 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 224.327854)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_41">
+      <path d="M 55.195938 150.12277 
+L 557.395938 150.12277 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 154.301911)">
+       <text>
+        <tspan x="0" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.178125" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.389063" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_42">
+      <path d="M 55.195938 80.096827 
+L 557.395938 80.096827 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.35; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g style="fill: #696969" transform="translate(32.335938 84.275968)">
+       <text>
+        <tspan x="0" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">1</tspan>
+        <tspan x="6.998535" y="-0.06875" style="font-size: 11px; font-family: 'DejaVu Sans'; fill: #696969">0</tspan>
+        <tspan x="14.102344" y="-4.279688" style="font-size: 7.7px; font-family: 'DejaVu Sans'; fill: #696969">2</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_43">
+      <path d="M 55.195938 311.254566 
+L 557.395938 311.254566 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_44">
+      <path d="M 55.195938 305.709825 
+L 557.395938 305.709825 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_45">
+      <path d="M 55.195938 301.021812 
+L 557.395938 301.021812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_46">
+      <path d="M 55.195938 296.960872 
+L 557.395938 296.960872 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_47">
+      <path d="M 55.195938 293.378868 
+L 557.395938 293.378868 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_48">
+      <path d="M 55.195938 269.094747 
+L 557.395938 269.094747 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_49">
+      <path d="M 55.195938 256.763791 
+L 557.395938 256.763791 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_50">
+      <path d="M 55.195938 248.014838 
+L 557.395938 248.014838 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_51">
+      <path d="M 55.195938 241.228623 
+L 557.395938 241.228623 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_52">
+      <path d="M 55.195938 235.683881 
+L 557.395938 235.683881 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_53">
+      <path d="M 55.195938 230.995869 
+L 557.395938 230.995869 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_54">
+      <path d="M 55.195938 226.934929 
+L 557.395938 226.934929 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_55">
+      <path d="M 55.195938 223.352925 
+L 557.395938 223.352925 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_56">
+      <path d="M 55.195938 199.068804 
+L 557.395938 199.068804 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_57">
+      <path d="M 55.195938 186.737848 
+L 557.395938 186.737848 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_58">
+      <path d="M 55.195938 177.988895 
+L 557.395938 177.988895 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_59">
+      <path d="M 55.195938 171.20268 
+L 557.395938 171.20268 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_60">
+      <path d="M 55.195938 165.657938 
+L 557.395938 165.657938 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_61">
+      <path d="M 55.195938 160.969926 
+L 557.395938 160.969926 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_62">
+      <path d="M 55.195938 156.908985 
+L 557.395938 156.908985 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_63">
+      <path d="M 55.195938 153.326982 
+L 557.395938 153.326982 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_64">
+      <path d="M 55.195938 129.042861 
+L 557.395938 129.042861 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_65">
+      <path d="M 55.195938 116.711904 
+L 557.395938 116.711904 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_66">
+      <path d="M 55.195938 107.962952 
+L 557.395938 107.962952 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_67">
+      <path d="M 55.195938 101.176737 
+L 557.395938 101.176737 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_68">
+      <path d="M 55.195938 95.631995 
+L 557.395938 95.631995 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_69">
+      <path d="M 55.195938 90.943983 
+L 557.395938 90.943983 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_70">
+      <path d="M 55.195938 86.883042 
+L 557.395938 86.883042 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_71">
+      <path d="M 55.195938 83.301039 
+L 557.395938 83.301039 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_72">
+      <path d="M 55.195938 59.016918 
+L 557.395938 59.016918 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_73">
+      <path d="M 55.195938 46.685961 
+L 557.395938 46.685961 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_74">
+      <path d="M 55.195938 37.937008 
+L 557.395938 37.937008 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_75">
+      <path d="M 55.195938 31.150793 
+L 557.395938 31.150793 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.15; stroke-width: 0.4; stroke-linecap: round"/>
+     </g>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="15.558281" y="169.981812" transform="rotate(-90 15.558281 169.981812)">Per-transaction latency, ms (log scale)</text>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <defs>
+     <path id="m2c5f3fe568" d="M 78.02321 -63.943031 
+L 78.02321 -57.156816 
+L 260.876512 -94.149685 
+L 315.333397 -96.322887 
+L 386.073832 -159.299307 
+L 534.568665 -258.434964 
+L 534.568665 -260.6851 
+L 534.568665 -260.6851 
+L 386.073832 -178.888804 
+L 315.333397 -131.100809 
+L 260.876512 -112.889065 
+L 78.02321 -63.943031 
+z
+"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m2c5f3fe568" x="0" y="354.117687" style="fill: #4575b4; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_2">
+    <defs>
+     <path id="m598310204f" d="M 78.02321 -63.943031 
+L 78.02321 -53.095875 
+L 260.876512 -124.811802 
+L 315.333397 -165.926436 
+L 386.073832 -211.023459 
+L 534.568665 -304.895935 
+L 534.568665 -315.175875 
+L 534.568665 -315.175875 
+L 386.073832 -234.869992 
+L 315.333397 -192.131729 
+L 260.876512 -153.488958 
+L 78.02321 -63.943031 
+z
+"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m598310204f" x="0" y="354.117687" style="fill: #d73027; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_3">
+    <defs>
+     <path id="m658da9d559" d="M 78.02321 -69.487772 
+L 78.02321 -53.095875 
+L 260.876512 -69.487772 
+L 315.333397 -90.567682 
+L 386.073832 -127.933708 
+L 534.568665 -221.701189 
+L 534.568665 -295.703005 
+L 534.568665 -295.703005 
+L 386.073832 -196.71045 
+L 315.333397 -156.095095 
+L 260.876512 -97.353897 
+L 78.02321 -69.487772 
+z
+"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m658da9d559" x="0" y="354.117687" style="fill: #fc8d59; fill-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="line2d_76">
+    <path d="M 78.02321 296.960872 
+L 260.876512 259.968002 
+L 315.333397 257.794801 
+L 386.073832 194.818381 
+L 534.568665 95.682724 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m1742fed79e" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #4575b4"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m1742fed79e" x="78.02321" y="296.960872" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m1742fed79e" x="260.876512" y="259.968002" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m1742fed79e" x="315.333397" y="257.794801" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m1742fed79e" x="386.073832" y="194.818381" style="fill: #4575b4; stroke: #4575b4"/>
+     <use xlink:href="#m1742fed79e" x="534.568665" y="95.682724" style="fill: #4575b4; stroke: #4575b4"/>
+    </g>
+   </g>
+   <g id="line2d_77">
+    <path d="M 78.02321 290.174657 
+L 260.876512 241.228623 
+L 315.333397 223.016879 
+L 386.073832 175.228884 
+L 534.568665 93.432588 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="m13ba2a23ab" d="M 0 2.5 
+C 0.663008 2.5 1.29895 2.236584 1.767767 1.767767 
+C 2.236584 1.29895 2.5 0.663008 2.5 0 
+C 2.5 -0.663008 2.236584 -1.29895 1.767767 -1.767767 
+C 1.29895 -2.236584 0.663008 -2.5 0 -2.5 
+C -0.663008 -2.5 -1.29895 -2.236584 -1.767767 -1.767767 
+C -2.236584 -1.29895 -2.5 -0.663008 -2.5 0 
+C -2.5 0.663008 -2.236584 1.29895 -1.767767 1.767767 
+C -1.29895 2.236584 -0.663008 2.5 0 2.5 
+z
+" style="stroke: #4575b4; stroke-opacity: 0.75"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m13ba2a23ab" x="78.02321" y="290.174657" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m13ba2a23ab" x="260.876512" y="241.228623" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m13ba2a23ab" x="315.333397" y="223.016879" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m13ba2a23ab" x="386.073832" y="175.228884" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     <use xlink:href="#m13ba2a23ab" x="534.568665" y="93.432588" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+    </g>
+   </g>
+   <g id="line2d_78">
+    <path d="M 78.02321 301.021812 
+L 260.876512 229.305886 
+L 315.333397 188.191252 
+L 386.073832 143.094228 
+L 534.568665 49.221753 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m275ec5b739" d="M -3.5 3.5 
+L 3.5 3.5 
+L 3.5 -3.5 
+L -3.5 -3.5 
+z
+" style="stroke: #d73027; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m275ec5b739" x="78.02321" y="301.021812" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m275ec5b739" x="260.876512" y="229.305886" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m275ec5b739" x="315.333397" y="188.191252" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m275ec5b739" x="386.073832" y="143.094228" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     <use xlink:href="#m275ec5b739" x="534.568665" y="49.221753" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_79">
+    <path d="M 78.02321 290.174657 
+L 260.876512 200.62873 
+L 315.333397 161.985959 
+L 386.073832 119.247696 
+L 534.568665 38.941812 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="meff9d869c9" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#meff9d869c9" x="78.02321" y="290.174657" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#meff9d869c9" x="260.876512" y="200.62873" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#meff9d869c9" x="315.333397" y="161.985959" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#meff9d869c9" x="386.073832" y="119.247696" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#meff9d869c9" x="534.568665" y="38.941812" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_80">
+    <path d="M 78.02321 301.021812 
+L 260.876512 284.629915 
+L 315.333397 263.550006 
+L 386.073832 226.18398 
+L 534.568665 132.416498 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+    <defs>
+     <path id="m8e9e12dbaf" d="M 0 -3.5 
+L -3.5 3.5 
+L 3.5 3.5 
+z
+" style="stroke: #fc8d59; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#m8e9e12dbaf" x="78.02321" y="301.021812" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e9e12dbaf" x="260.876512" y="284.629915" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e9e12dbaf" x="315.333397" y="263.550006" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e9e12dbaf" x="386.073832" y="226.18398" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e9e12dbaf" x="534.568665" y="132.416498" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_81">
+    <path d="M 78.02321 284.629915 
+L 260.876512 256.763791 
+L 315.333397 198.022592 
+L 386.073832 157.407238 
+L 534.568665 58.414683 
+" clip-path="url(#pdfc717d678)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+    <defs>
+     <path id="mf401439188" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pdfc717d678)">
+     <use xlink:href="#mf401439188" x="78.02321" y="284.629915" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#mf401439188" x="260.876512" y="256.763791" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#mf401439188" x="315.333397" y="198.022592" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#mf401439188" x="386.073832" y="157.407238" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#mf401439188" x="534.568665" y="58.414683" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <text style="font-style: italic; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="547.351938" y="306.238021" transform="rotate(-0 547.351938 306.238021)">At 10,000 clients (p50/p99): pg_doorman 60/64ms, pgbouncer 276/387ms, odyssey 18/204ms</text>
+   </g>
+   <g id="text_13">
+    <text style="font-size: 14px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="55.195938" y="17.837812" transform="rotate(-0 55.195938 17.837812)">Simple protocol: latency p50 (solid) and p99 (dashed)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_3">
+     <path d="M 61.495938 73.169375 
+L 277.972656 73.169375 
+Q 279.772656 73.169375 279.772656 71.369375 
+L 279.772656 32.137812 
+Q 279.772656 30.337812 277.972656 30.337812 
+L 61.495938 30.337812 
+Q 59.695938 30.337812 59.695938 32.137812 
+L 59.695938 71.369375 
+Q 59.695938 73.169375 61.495938 73.169375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #d3d3d3; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_82">
+     <path d="M 63.295938 37.626406 
+L 72.295938 37.626406 
+L 81.295938 37.626406 
+" style="fill: none; stroke: #4575b4; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m1742fed79e" x="72.295938" y="37.626406" style="fill: #4575b4; stroke: #4575b4"/>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="40.776406" transform="rotate(-0 88.495938 40.776406)">pg_doorman p50</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 63.295938 51.087031 
+L 72.295938 51.087031 
+L 81.295938 51.087031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #4575b4; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m13ba2a23ab" x="72.295938" y="51.087031" style="fill: #4575b4; fill-opacity: 0.75; stroke: #4575b4; stroke-opacity: 0.75"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="54.237031" transform="rotate(-0 88.495938 54.237031)">pg_doorman p99</text>
+    </g>
+    <g id="line2d_84">
+     <path d="M 63.295938 64.547656 
+L 72.295938 64.547656 
+L 81.295938 64.547656 
+" style="fill: none; stroke: #d73027; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m275ec5b739" x="72.295938" y="64.547656" style="fill: #d73027; stroke: #d73027; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="88.495938" y="67.697656" transform="rotate(-0 88.495938 67.697656)">pgbouncer p50</text>
+    </g>
+    <g id="line2d_85">
+     <path d="M 182.704844 37.626406 
+L 191.704844 37.626406 
+L 200.704844 37.626406 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d73027; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#meff9d869c9" x="191.704844" y="37.626406" style="fill: #d73027; fill-opacity: 0.75; stroke: #d73027; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="40.776406" transform="rotate(-0 207.904844 40.776406)">pgbouncer p99</text>
+    </g>
+    <g id="line2d_86">
+     <path d="M 182.704844 50.836719 
+L 191.704844 50.836719 
+L 200.704844 50.836719 
+" style="fill: none; stroke: #fc8d59; stroke-width: 2.2; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m8e9e12dbaf" x="191.704844" y="50.836719" style="fill: #fc8d59; stroke: #fc8d59; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="53.986719" transform="rotate(-0 207.904844 53.986719)">odyssey p50</text>
+    </g>
+    <g id="line2d_87">
+     <path d="M 182.704844 64.047031 
+L 191.704844 64.047031 
+L 200.704844 64.047031 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #fc8d59; stroke-opacity: 0.75; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#mf401439188" x="191.704844" y="64.047031" style="fill: #fc8d59; fill-opacity: 0.75; stroke: #fc8d59; stroke-opacity: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="207.904844" y="67.197031" transform="rotate(-0 207.904844 67.197031)">odyssey p99</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pdfc717d678">
+   <rect x="55.195938" y="25.837812" width="502.2" height="288.288"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/documentation/en/src/images/benchmarks/tldr_tail_spread.svg
+++ b/documentation/en/src/images/benchmarks/tldr_tail_spread.svg
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="441.143438pt" height="296.969688pt" viewBox="0 0 441.143438 296.969688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-01T12:17:20.251761</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 296.969688 
+L 441.143438 296.969688 
+L 441.143438 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.343438 275.317813 
+L 433.943438 275.317813 
+L 433.943438 25.837812 
+L 43.343438 25.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="line2d_1">
+    <path d="M 43.343438 256.766417 
+L 433.943438 256.766417 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #d3d3d3"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="99.392101" y="287.176094" transform="rotate(-0 99.392101 287.176094)">pg_doorman</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="238.643438" y="287.176094" transform="rotate(-0 238.643438 287.176094)">pgbouncer</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="377.894774" y="287.176094" transform="rotate(-0 377.894774 287.176094)">odyssey</text>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_2">
+      <path d="M 43.343438 275.317813 
+L 433.943438 275.317813 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="279.496953" transform="rotate(-0 39.843438 279.496953)">0</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_3">
+      <path d="M 43.343438 238.215021 
+L 433.943438 238.215021 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="242.394161" transform="rotate(-0 39.843438 242.394161)">2</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_4">
+      <path d="M 43.343438 201.112229 
+L 433.943438 201.112229 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="205.29137" transform="rotate(-0 39.843438 205.29137)">4</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_5">
+      <path d="M 43.343438 164.009438 
+L 433.943438 164.009438 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="168.188578" transform="rotate(-0 39.843438 168.188578)">6</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_6">
+      <path d="M 43.343438 126.906646 
+L 433.943438 126.906646 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_8">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="131.085787" transform="rotate(-0 39.843438 131.085787)">8</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_7">
+      <path d="M 43.343438 89.803854 
+L 433.943438 89.803854 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="93.982995" transform="rotate(-0 39.843438 93.982995)">10</text>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_8">
+      <path d="M 43.343438 52.701063 
+L 433.943438 52.701063 
+" clip-path="url(#p91574f2417)" style="fill: none; stroke: #cccccc; stroke-opacity: 0.3; stroke-width: 0.6; stroke-linecap: round"/>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="39.843438" y="56.880203" transform="rotate(-0 39.843438 56.880203)">12</text>
+     </g>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="15.558281" y="150.577812" transform="rotate(-90 15.558281 150.577812)">p99 / p50  (lower = more predictable)</text>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 61.097983 275.317813 
+L 137.686218 275.317813 
+L 137.686218 255.341769 
+L 61.097983 255.341769 
+z
+" clip-path="url(#p91574f2417)" style="fill: #bd0c0c; stroke: #696969; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 200.34932 275.317813 
+L 276.937555 275.317813 
+L 276.937555 249.305529 
+L 200.34932 249.305529 
+z
+" clip-path="url(#p91574f2417)" style="fill: #d3d3d3; stroke: #696969; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 339.600657 275.317813 
+L 416.188892 275.317813 
+L 416.188892 63.894084 
+L 339.600657 63.894084 
+z
+" clip-path="url(#p91574f2417)" style="fill: #d3d3d3; stroke: #696969; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_12">
+    <text style="font-weight: 600; font-size: 12px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="99.392101" y="247.56055" transform="rotate(-0 99.392101 247.56055)">1.1×</text>
+   </g>
+   <g id="text_13">
+    <text style="font-weight: 600; font-size: 12px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="238.643438" y="241.524311" transform="rotate(-0 238.643438 241.524311)">1.4×</text>
+   </g>
+   <g id="text_14">
+    <text style="font-weight: 600; font-size: 12px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #696969" x="377.894774" y="56.112865" transform="rotate(-0 377.894774 56.112865)">11×</text>
+   </g>
+   <g id="text_15">
+    <text style="font-style: italic; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: end; fill: #696969" x="426.131438" y="37.666006" transform="rotate(-0 426.131438 37.666006)">pg_doorman holds the median (1.1×); competitors drift to pgbouncer 1.4×, odyssey 11×</text>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 14px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #696969" x="43.343438" y="17.837812" transform="rotate(-0 43.343438 17.837812)">Tail spread at 10,000 simple-protocol clients</text>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p91574f2417">
+   <rect x="43.343438" y="25.837812" width="390.6" height="249.48"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/documentation/ru/src/images
+++ b/documentation/ru/src/images
@@ -1,0 +1,1 @@
+../../en/src/images


### PR DESCRIPTION
## Summary

Adds 4 SVG charts to the benchmarks page so the data is readable at a glance instead of forcing readers through six 20-row tables:

- **TL;DR bar** of p99/p50 spread at 10,000 simple-protocol clients (the headline tail-latency story).
- **Three log-log line charts** (one per protocol: simple / extended / prepared) with p50 (solid) and p99 (dashed) per pooler, plus a faint p50–p99 corridor.

Charts are rendered from the steady-state cells (no SSL, no Reconnect) of the most recent benchmark run.