### PR TITLE
ci(docker): smoke-test pushed image end-to-end and verify arm64 manifest

### DIFF
--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -274,6 +274,69 @@ jobs:
           push: true
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: | 
+          tags: |
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}
+
+  docker-image-smoke:
+    name: Smoke-test pushed docker image (amd64 E2E + arm64 --version)
+    needs: [verify-version, docker-image]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU for arm64 execution
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.TOKEN }}
+
+      - name: Resolve image reference
+        id: image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}"
+          echo "ref=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "Smoking ${IMAGE}"
+
+      - name: Pull pushed image (amd64)
+        run: docker pull --platform linux/amd64 "${{ steps.image.outputs.ref }}"
+
+      - name: End-to-end smoke (amd64)
+        # Runs the same script developers run locally via `make docker-smoke`.
+        # Brings up a postgres:17 sidecar, drives `pg_doorman generate`,
+        # starts pg_doorman on the generated config, and routes SELECT 1
+        # through it via psql.
+        run: scripts/docker-smoke.sh "${{ steps.image.outputs.ref }}"
+
+      - name: Pull pushed image (arm64)
+        run: docker pull --platform linux/arm64 "${{ steps.image.outputs.ref }}"
+
+      - name: 'arm64: pg_doorman --version matches tag'
+        # Full E2E under QEMU is slow; --version is enough to catch a
+        # broken arm64 build (linker mismatch, missing dynamic library,
+        # wrong target triple). Without this check the arm64 manifest
+        # entry can exist with a broken binary inside.
+        run: |
+          EXPECTED=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
+          ACTUAL=$(docker run --rm --platform linux/arm64 \
+            "${{ steps.image.outputs.ref }}" pg_doorman --version | awk '{print $NF}')
+          echo "Cargo.toml: ${EXPECTED}"
+          echo "arm64 bin:  ${ACTUAL}"
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "::error::arm64 pg_doorman version (${ACTUAL}) does not match Cargo.toml (${EXPECTED})"
+            exit 1
+          fi
+
+      - name: 'arm64: patroni_proxy --version'
+        run: |
+          docker run --rm --platform linux/arm64 \
+            "${{ steps.image.outputs.ref }}" patroni_proxy --version

--- a/.github/workflows/dashboard-validation.yml
+++ b/.github/workflows/dashboard-validation.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/dashboard-*"
       - "src/web/metrics/**"
       - "Makefile"
+      - "Dockerfile"
       - ".github/workflows/dashboard-validation.yml"
   pull_request:
     paths:
@@ -15,6 +16,7 @@ on:
       - "scripts/dashboard-*"
       - "src/web/metrics/**"
       - "Makefile"
+      - "Dockerfile"
       - ".github/workflows/dashboard-validation.yml"
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ generate:
 flamegraph: ## Generate CPU flamegraph (perf + pgbench load)
 	./scripts/flamegraph.sh
 
+# Default to the local demo image so `make docker-smoke` runs after a
+# `dashboard-up` build. Override with `make docker-smoke IMAGE=...`
+# when validating a freshly built or pulled image.
+IMAGE ?= pg_doorman:demo
+
+docker-smoke: ## End-to-end smoke (postgres sidecar + generate + SELECT 1) against $(IMAGE)
+	./scripts/docker-smoke.sh $(IMAGE)
+
 dashboard-up: ## Bring up grafana/demo and wait until pg_doorman emits enough scrape points
 	cd grafana/demo && docker compose up -d --wait
 	# Wait until Prometheus has at least 12 scrape points for a counter

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# End-to-end smoke for a pg_doorman docker image:
+#   1. pg_doorman --version inside image matches Cargo.toml
+#   2. patroni_proxy --version inside image runs
+#   3. pg_doorman generate produces a config against a real postgres
+#   4. pg_doorman starts on the generated config
+#   5. psql SELECT 1 routed through pg_doorman returns 1
+#
+# Both CI (build-packages.yaml docker-image-smoke job) and developers
+# (make docker-smoke) call this script, so CI and local stay in sync.
+#
+# Usage:
+#   scripts/docker-smoke.sh <image-ref>
+#
+# Requires: docker, internet access to pull postgres:17 once.
+set -euo pipefail
+
+IMAGE="${1:?usage: $0 <image-ref>}"
+
+# Repo root so the Cargo.toml lookup works regardless of cwd.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Unique resource names so parallel runs (or stale containers) don't collide.
+RUN_ID="docker-smoke-$$-$RANDOM"
+NET_NAME="net-${RUN_ID}"
+PG_NAME="pg-${RUN_ID}"
+DOORMAN_NAME="doorman-${RUN_ID}"
+CONFIG_DIR="$(mktemp -d -t pg-doorman-smoke.XXXXXX)"
+
+# Postgres credentials used both for the sidecar and for pg_doorman generate.
+PG_USER="postgres"
+PG_PASSWORD="postgres"
+PG_DB="postgres"
+
+cleanup() {
+  local rc=$?
+  set +e
+  if [ "$rc" -ne 0 ]; then
+    echo
+    echo "=== smoke failed, dumping recent logs ==="
+    echo "--- postgres ($PG_NAME) ---"
+    docker logs --tail 60 "$PG_NAME" 2>&1 || true
+    echo "--- pg_doorman ($DOORMAN_NAME) ---"
+    docker logs --tail 100 "$DOORMAN_NAME" 2>&1 || true
+    echo "--- generated config ---"
+    cat "$CONFIG_DIR/pg_doorman.toml" 2>/dev/null || echo "(no config generated)"
+  fi
+  docker rm -f "$DOORMAN_NAME" "$PG_NAME" >/dev/null 2>&1 || true
+  docker network rm "$NET_NAME" >/dev/null 2>&1 || true
+  rm -rf "$CONFIG_DIR"
+  return "$rc"
+}
+trap cleanup EXIT
+
+echo "=== smoke: image = $IMAGE ==="
+echo
+
+# 1. Version inside the image matches Cargo.toml.
+echo "--- pg_doorman --version vs Cargo.toml ---"
+EXPECTED_VERSION=$(grep -m1 '^version = ' "$REPO_ROOT/Cargo.toml" | cut -d'"' -f2)
+# `pg_doorman --version` emits "pg_doorman <version>".
+ACTUAL_VERSION=$(docker run --rm "$IMAGE" pg_doorman --version | awk '{print $NF}')
+echo "Cargo.toml: $EXPECTED_VERSION"
+echo "image:      $ACTUAL_VERSION"
+if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "::error::pg_doorman version in image ($ACTUAL_VERSION) does not match Cargo.toml ($EXPECTED_VERSION)"
+  exit 1
+fi
+
+echo
+echo "--- patroni_proxy --version ---"
+docker run --rm "$IMAGE" patroni_proxy --version
+
+# 2. Bring up an isolated network and a postgres:17 sidecar.
+echo
+echo "--- starting postgres:17 ---"
+docker network create "$NET_NAME" >/dev/null
+docker run -d --name "$PG_NAME" --network "$NET_NAME" \
+  -e "POSTGRES_USER=$PG_USER" \
+  -e "POSTGRES_PASSWORD=$PG_PASSWORD" \
+  -e "POSTGRES_DB=$PG_DB" \
+  postgres:17 >/dev/null
+
+# Wait for postgres to accept connections. 60s ceiling: a pulled image
+# from cache is typically ready in <5s; the ceiling covers a cold cache.
+echo "waiting for postgres readiness..."
+for i in $(seq 1 60); do
+  if docker exec "$PG_NAME" pg_isready -U "$PG_USER" >/dev/null 2>&1; then
+    echo "postgres ready after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "::error::postgres did not become ready in 60s"
+    exit 1
+  fi
+  sleep 1
+done
+
+# 3. Generate a pg_doorman config against the real postgres.
+echo
+echo "--- pg_doorman generate ---"
+docker run --rm --network "$NET_NAME" \
+  -e "PGHOST=$PG_NAME" -e PGPORT=5432 \
+  -e "PGUSER=$PG_USER" -e "PGPASSWORD=$PG_PASSWORD" \
+  -e "PGDATABASE=$PG_DB" \
+  -v "$CONFIG_DIR:/work" \
+  "$IMAGE" \
+  pg_doorman generate --output /work/pg_doorman.toml --server-host "$PG_NAME"
+
+if [ ! -s "$CONFIG_DIR/pg_doorman.toml" ]; then
+  echo "::error::pg_doorman generate produced no output"
+  exit 1
+fi
+echo "generated $(wc -l < "$CONFIG_DIR/pg_doorman.toml") lines"
+
+# 4. Start pg_doorman on the generated config.
+echo
+echo "--- starting pg_doorman ---"
+docker run -d --name "$DOORMAN_NAME" --network "$NET_NAME" \
+  -v "$CONFIG_DIR/pg_doorman.toml:/etc/pg_doorman/pg_doorman.toml" \
+  "$IMAGE" \
+  pg_doorman /etc/pg_doorman/pg_doorman.toml >/dev/null
+
+# Same 60s ceiling as postgres above. pg_doorman binds the listener
+# before opening backend connections, so on a working image it answers
+# pg_isready within ~1s. The ceiling covers QEMU emulation on arm64
+# and a slow first run on a cold runner.
+echo "waiting for pg_doorman listener on 6432..."
+for i in $(seq 1 60); do
+  if docker run --rm --network "$NET_NAME" postgres:17 \
+       pg_isready -h "$DOORMAN_NAME" -p 6432 -U "$PG_USER" >/dev/null 2>&1; then
+    echo "pg_doorman ready after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "::error::pg_doorman did not start listening on 6432 in 60s"
+    exit 1
+  fi
+  sleep 1
+done
+
+# 5. Route SELECT 1 through pg_doorman.
+echo
+echo "--- psql SELECT 1 via pg_doorman ---"
+RESULT=$(docker run --rm --network "$NET_NAME" \
+  -e "PGPASSWORD=$PG_PASSWORD" \
+  postgres:17 \
+  psql -h "$DOORMAN_NAME" -p 6432 -U "$PG_USER" -d "$PG_DB" \
+       -At -c "SELECT 1")
+echo "result: '$RESULT'"
+if [ "$RESULT" != "1" ]; then
+  echo "::error::SELECT 1 through pg_doorman returned '$RESULT', expected '1'"
+  exit 1
+fi
+
+echo
+echo "=== smoke passed: $IMAGE ==="


### PR DESCRIPTION
## Summary

The release docker job pushed the multi-arch image and stopped there. Nothing pulled it back, ran it, or compared its version against the git tag. A broken Dockerfile or a busted arm64 build would only surface once users complained. DEB/RPM jobs in the same workflow already run a `pg_doorman --version` check after install; docker had the gap.