### PR TITLE
docs(install): expand docker reference and balance Quick start

### DIFF
--- a/documentation/en/src/index.md
+++ b/documentation/en/src/index.md
@@ -104,7 +104,20 @@ AWS Fargate (16 vCPU), pool size 40, `pgbench` 30 s per test:
 
 ## Quick start
 
-Run via Docker:
+Install via your distro package manager:
+
+```bash
+# Ubuntu / Debian
+sudo add-apt-repository ppa:vadv/pg-doorman
+sudo apt update
+sudo apt install pg-doorman
+
+# Fedora / RHEL family
+sudo dnf copr enable @pg-doorman/pg-doorman
+sudo dnf install pg_doorman
+```
+
+Or run via Docker:
 
 ```bash
 docker run -p 6432:6432 \

--- a/documentation/en/src/tutorials/installation.md
+++ b/documentation/en/src/tutorials/installation.md
@@ -113,6 +113,10 @@ docker run -p 6432:6432 \
   ghcr.io/ozontech/pg_doorman
 ```
 
+The image listens on `6432` for PostgreSQL traffic and `9127` for the metrics endpoint and the optional admin/web UI. Its `WORKDIR` is `/etc/pg_doorman/` and the default config path is `pg_doorman.toml`, overridable with the `CONFIG_FILE` environment variable. The other environment overrides are `LOG_LEVEL` (default `info`), `LOG_FORMAT` (`text` or `structured`), and `NO_COLOR`. The container's `STOPSIGNAL` is `SIGTERM`, so `docker stop` and Kubernetes pod termination cause `pg_doorman` to drain idle clients and exit cleanly. Do not send `SIGINT` to a containerised pg_doorman: that signal triggers a binary upgrade, and in a non-TTY context this kills PID 1, so the container exits.
+
+The public image is built without the `tls-migration` and `pam` Cargo features. For TLS on client or backend connections, or for PAM authentication, build your own image from the public `Dockerfile` with `--features tls-migration` (and/or `pam`) added to the `cargo build --release` step.
+
 A `docker-compose.yaml` with a sidecar PostgreSQL is in [`example/`](https://github.com/ozontech/pg_doorman/tree/master/example) for end-to-end smoke tests.
 
 ## Verifying the installation

--- a/documentation/ru/src/index.md
+++ b/documentation/ru/src/index.md
@@ -105,7 +105,20 @@ AWS Fargate (16 vCPU), pool size 40, `pgbench` 30 с на тест:
 
 ## Быстрый старт
 
-Запуск через Docker:
+Установите пакет через ваш дистрибутив:
+
+```bash
+# Ubuntu / Debian
+sudo add-apt-repository ppa:vadv/pg-doorman
+sudo apt update
+sudo apt install pg-doorman
+
+# Fedora / RHEL family
+sudo dnf copr enable @pg-doorman/pg-doorman
+sudo dnf install pg_doorman
+```
+
+Либо запустите через Docker:
 
 ```bash
 docker run -p 6432:6432 \

--- a/documentation/ru/src/tutorials/installation.md
+++ b/documentation/ru/src/tutorials/installation.md
@@ -113,6 +113,10 @@ docker run -p 6432:6432 \
   ghcr.io/ozontech/pg_doorman
 ```
 
+Образ слушает `6432` для трафика PostgreSQL и `9127` для эндпоинта метрик и опциональной admin/web-консоли. `WORKDIR` равен `/etc/pg_doorman/`, конфиг по умолчанию ищется в `pg_doorman.toml`; путь переопределяется переменной окружения `CONFIG_FILE`. Прочие env-переменные: `LOG_LEVEL` (значение по умолчанию `info`), `LOG_FORMAT` (`text` или `structured`), `NO_COLOR`. `STOPSIGNAL` контейнера равен `SIGTERM`, поэтому `docker stop` и остановка pod в Kubernetes позволяют `pg_doorman` штатно слить ожидающих клиентов и выйти. Не посылайте `SIGINT` в контейнер с pg_doorman: этот сигнал запускает миграцию бинарника, а в non-TTY контексте после этого pid 1 завершается, и контейнер падает.
+
+Публичный образ собран без cargo-фич `tls-migration` и `pam`. Если нужен TLS для клиентских или серверных соединений либо PAM-аутентификация, соберите свой образ из публичного `Dockerfile`, добавив `--features tls-migration` (и/или `pam`) в шаг `cargo build --release`.
+
 `docker-compose.yaml` с PostgreSQL в качестве sidecar лежит в [`example/`](https://github.com/ozontech/pg_doorman/tree/master/example) — для smoke-тестов.
 
 ## Проверка установки


### PR DESCRIPTION
## Summary

- Quick start in `index.md` (en + ru) led with `docker run`. Add a distro-package install block (PPA + COPR) above it so package install is the visible first option; docker now reads as an alternative ("Or run via Docker" / «Либо запустите через Docker»). Aligns the landing page with `installation.md`'s longer-standing recommendation that the production path is build-from-source or system packages.
- The installation page's Docker section was a four-line snippet plus a single-line warning. Add a short reference paragraph next to it that answers the minimum a reader needs to use the image: the ports the container listens on (6432 + 9127), the `WORKDIR` + default config path + `CONFIG_FILE` env override, the other supported env overrides (`LOG_LEVEL`, `LOG_FORMAT`, `NO_COLOR`), the `STOPSIGNAL` behaviour, and the `SIGINT` footgun (triggers binary upgrade, kills PID 1 in a non-TTY container).
- A second paragraph names the two Cargo features the public image does not ship (`tls-migration`, `pam`) and points readers at the public Dockerfile when they need to build with them.

## Test plan

- [x] `git diff --staged | grep -E '^\+' | grep -- '—'` returns nothing (no em-dashes in new EN/RU prose).
- [x] Facts verified against source: 9127 default web port (`src/config/web.rs`); `CONFIG_FILE` env (`src/app/args.rs:12`); `STOPSIGNAL SIGTERM` (`Dockerfile:24`); public image built without `--features` so `tls-migration` and `pam` are off (`Cargo.toml` defaults to `[]`); SIGINT triggers binary upgrade in non-TTY mode (`src/app/server.rs`).
- [ ] After merge: open the rendered site and confirm Quick start reads as "package install → or Docker", not "Docker first".

This PR does not conflict with PR #242 (docker run snippet fix): the new content is inserted around the existing snippet, not on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)