### PR TITLE
fix(server): use poll(2) in binary upgrade readiness wait — select(2) panics on fd >= 1024

### DIFF
--- a/.github/workflows/bdd-tests.yml
+++ b/.github/workflows/bdd-tests.yml
@@ -281,9 +281,16 @@ jobs:
             echo "$GHCR_TOKEN" | docker login ${{ env.REGISTRY }} -u "$GHCR_ACTOR" --password-stdin
 
       - name: Pull test image from GHCR
+        # The test-runner image is a nix-based ~1.5+ GB blob. On a
+        # GHA runner with a slow ghcr.io route, three 5-minute pulls
+        # in a row can each time out before the final layer lands,
+        # killing the job before any test runs (observed on the
+        # SIGUSR2 readiness fix PR). 10 minutes per attempt gives
+        # the slowest paths room to finish; the retry policy keeps
+        # the fast-path bound at the same overall wall time.
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 5
+          timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 10
           command: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare-tests.outputs.image-tag }}
@@ -410,9 +417,16 @@ jobs:
             echo "$GHCR_TOKEN" | docker login ${{ env.REGISTRY }} -u "$GHCR_ACTOR" --password-stdin
 
       - name: Pull test image from GHCR
+        # The test-runner image is a nix-based ~1.5+ GB blob. On a
+        # GHA runner with a slow ghcr.io route, three 5-minute pulls
+        # in a row can each time out before the final layer lands,
+        # killing the job before any test runs (observed on the
+        # SIGUSR2 readiness fix PR). 10 minutes per attempt gives
+        # the slowest paths room to finish; the retry policy keeps
+        # the fast-path bound at the same overall wall time.
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 5
+          timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 10
           command: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare-tests.outputs.image-tag }}

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -981,26 +981,9 @@ async fn binary_upgrade_and_shutdown(
                         }
 
                         let mut buf: [u8; 1] = [0];
-                        let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };
-                        unsafe {
-                            libc::FD_ZERO(&mut read_fds);
-                            libc::FD_SET(pipe_read_fd, &mut read_fds);
-                        }
-                        let mut timeout = libc::timeval {
-                            tv_sec: 10,
-                            tv_usec: 0,
-                        };
-                        let select_result = unsafe {
-                            libc::select(
-                                pipe_read_fd + 1,
-                                &mut read_fds,
-                                std::ptr::null_mut(),
-                                std::ptr::null_mut(),
-                                &mut timeout,
-                            )
-                        };
+                        let ready = wait_for_pipe_readiness(pipe_read_fd, 10_000);
 
-                        if select_result > 0 {
+                        if ready {
                             unsafe {
                                 libc::read(pipe_read_fd, buf.as_mut_ptr() as *mut libc::c_void, 1);
                             }
@@ -1016,7 +999,15 @@ async fn binary_upgrade_and_shutdown(
                                 warn!("sd_notify MAINPID failed: {e}. systemd may restart the service after old process exits.");
                             }
                         } else {
-                            warn!("Timeout waiting for new process readiness");
+                            // No POLLIN within the deadline. Either the
+                            // 10s timer elapsed, or the child closed the
+                            // pipe before writing the readiness byte
+                            // (poll reports POLLHUP without POLLIN, and
+                            // `wait_for_pipe_readiness` filters those
+                            // out). Either way the new process did not
+                            // confirm it is serving, so keep the
+                            // listener and skip the MainPID handoff.
+                            warn!("New process did not signal readiness within 10s (timeout or early exit)");
                         }
 
                         unsafe {
@@ -1068,6 +1059,36 @@ async fn binary_upgrade_and_shutdown(
 
     spawn_shutdown_timer(exit_tx.clone(), shutdown_timeout);
     migration_handles
+}
+
+/// Wait up to `timeout_ms` for `pipe_read_fd` to become readable.
+///
+/// Uses `poll(2)`, not `select(2)`. select's `fd_set` is a 1024-bit
+/// bitmap; `libc::FD_SET` indexes a fixed-size array (16 longs on
+/// x86_64) and any fd >= 1024 panics with `index out of bounds`,
+/// taking the parent process down before it can drain clients or
+/// hand `MainPID` off to systemd. With `LimitNOFILE` well above
+/// 1024 in production, the readiness pipe created during a binary
+/// upgrade routinely lands above that cap. poll takes a `pollfd`
+/// array and accepts any fd.
+///
+/// The predicate is strict on `POLLIN`: if the child closes the
+/// write end without writing the readiness byte, poll reports
+/// `POLLHUP` alone and the function returns `false`. This is a
+/// deliberate change from the previous `select(2)` implementation,
+/// which treated "ready to read EOF" as "ready" and forwarded
+/// `sd_notify(MAINPID=child)` to systemd for an already-dead child.
+/// Returning `false` keeps systemd tracking the still-living parent
+/// until the next upgrade attempt.
+#[cfg(not(windows))]
+fn wait_for_pipe_readiness(pipe_read_fd: libc::c_int, timeout_ms: libc::c_int) -> bool {
+    let mut pfd = libc::pollfd {
+        fd: pipe_read_fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let result = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+    result > 0 && (pfd.revents & libc::POLLIN) != 0
 }
 
 /// Spawn a task that waits for all clients to disconnect (or timeout) and then signals exit.
@@ -1609,5 +1630,108 @@ mod umask_guard_tests {
             assert_eq!(inside & 0o077, 0o077);
         }
         unsafe { libc::umask(prior) };
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod wait_for_pipe_readiness_tests {
+    use super::wait_for_pipe_readiness;
+
+    /// Build a pipe and reserve any fd we are handed so the test
+    /// always closes both ends, even when `dup2` to a high fd fails.
+    struct Pipe {
+        read: libc::c_int,
+        write: libc::c_int,
+    }
+
+    impl Pipe {
+        fn new() -> Self {
+            let mut fds = [0_i32; 2];
+            let r = unsafe { libc::pipe(fds.as_mut_ptr()) };
+            assert_eq!(r, 0, "pipe(2) failed: {}", std::io::Error::last_os_error());
+            Self {
+                read: fds[0],
+                write: fds[1],
+            }
+        }
+    }
+
+    impl Drop for Pipe {
+        fn drop(&mut self) {
+            if self.read >= 0 {
+                unsafe { libc::close(self.read) };
+            }
+            if self.write >= 0 {
+                unsafe { libc::close(self.write) };
+            }
+        }
+    }
+
+    #[test]
+    fn returns_false_on_timeout() {
+        let pipe = Pipe::new();
+        // 50 ms timeout, nothing was written — poll must return 0.
+        assert!(!wait_for_pipe_readiness(pipe.read, 50));
+    }
+
+    #[test]
+    fn returns_true_when_byte_is_pending() {
+        let pipe = Pipe::new();
+        let byte: u8 = 1;
+        let written =
+            unsafe { libc::write(pipe.write, &byte as *const u8 as *const libc::c_void, 1) };
+        assert_eq!(written, 1, "write to pipe failed");
+        assert!(wait_for_pipe_readiness(pipe.read, 1_000));
+    }
+
+    /// POLLHUP without POLLIN: the child closes the pipe before
+    /// writing the readiness byte. The previous `select(2)` code
+    /// considered the fd "ready", read 0 bytes, and forwarded
+    /// `sd_notify(MAINPID=child)` for an already-dead child;
+    /// the poll-based predicate requires `POLLIN` and returns false.
+    /// Guards against a future "simplification" that drops the
+    /// `POLLIN` mask in the predicate.
+    #[test]
+    fn returns_false_when_writer_closes_without_writing() {
+        let mut pipe = Pipe::new();
+        unsafe { libc::close(pipe.write) };
+        pipe.write = -1;
+        assert!(!wait_for_pipe_readiness(pipe.read, 1_000));
+    }
+
+    /// Regression: select(2) on `fd >= 1024` panics inside
+    /// `libc::FD_SET` (`index out of bounds: the len is 16 but the
+    /// index is 16`) and kills the parent of the binary-upgrade
+    /// handshake. poll(2) accepts any fd, so the same scenario must
+    /// resolve as "ready" without panicking.
+    #[test]
+    fn handles_fd_above_fd_setsize() {
+        let pipe = Pipe::new();
+        // Pick a target fd well above the 1023 cap select(2)
+        // tolerates. dup2 closes the destination if it was open.
+        let target_fd: libc::c_int = 1500;
+        let dup_result = unsafe { libc::dup2(pipe.read, target_fd) };
+        if dup_result == -1 {
+            // CI sandbox without enough RLIMIT_NOFILE headroom: skip.
+            // The default soft limit on GitHub-hosted runners is well
+            // above 1500, so this should rarely trigger.
+            eprintln!(
+                "skipping handles_fd_above_fd_setsize: dup2 to {target_fd} failed ({})",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        // Pre-fill so poll has data to read immediately.
+        let byte: u8 = 1;
+        let written =
+            unsafe { libc::write(pipe.write, &byte as *const u8 as *const libc::c_void, 1) };
+        assert_eq!(written, 1, "write to pipe failed");
+
+        // This call would panic on the pre-poll implementation.
+        let ready = wait_for_pipe_readiness(target_fd, 1_000);
+
+        // Always close the dup'd fd so the runner does not leak it.
+        unsafe { libc::close(target_fd) };
+        assert!(ready, "poll must observe POLLIN on a high-numbered fd");
     }
 }


### PR DESCRIPTION
## Summary

Binary upgrade via SIGUSR2 panics in the parent process on hosts where the readiness pipe lands on an fd ≥ 1024. The new process keeps serving on the inherited listener, but the parent dies before it can drain in-flight clients or hand `MainPID` off to systemd, leaving the unit's `MainPID` pointing at a corpse until `Restart=always` re-spawns the unit.

## The bug

`src/app/server.rs` waited for the freshly spawned child to signal readiness through a pipe via `libc::select` + `libc::FD_SET`. `select(2)`'s `fd_set` is a 1024-bit bitmap; `libc::FD_SET` indexes a fixed-size array of 16 c_longs on x86_64 (16 × 64 = 1024 bits) and panics with `index out of bounds: the len is 16 but the index is 16` for any fd ≥ 1024.

Under load with `LimitNOFILE` above 1024 — one observed real case: 15200, set explicitly in the systemd unit — the readiness pipe routinely lands above that cap.

Reproduced verbatim from production logs:

```
pg-pooler[2663954]: Got SIGUSR2, starting binary upgrade and graceful shutdown
pg-pooler[2663954]: Starting new process with inherited listener fd=10
pg-pooler[2663954]: thread 'main' panicked at .../libc-0.2.172/src/unix/linux_like/mod.rs:1744:9:
pg-pooler[2663954]: index out of bounds: the len is 16 but the index is 16
pg-pooler[469714]: Welcome to PgDoorman! (Version 3.9.1)
pg-pooler[469714]: Inheriting listener from parent process (fd=10)
```

The child was already `fork+exec`-ed by the time `FD_SET` was called, so the new PID kept serving on the inherited listener fd. The parent died before:

- draining in-flight clients (they got an abrupt connection close instead of a migrate or finish-and-disconnect path);
- calling `sd_notify(NotifyState::MainPid(child_pid))`. systemd kept `MainPID` pointing at the now-dead parent until `Restart=always` re-spawned the unit, so `systemctl reload`, `systemctl kill -s SIGUSR2`, and admin probes against the published MainPID hit a corpse.

## Fix

Replace the wait with `poll(2)`. poll takes a `pollfd` array, has no 1024-fd cap, and works for any fd. The change lives behind a new helper `wait_for_pipe_readiness(pipe_read_fd, timeout_ms) -> bool` with four unit tests covering timeout, ready, POLLHUP-without-POLLIN, and the fd ≥ 1024 regression (dup2 onto fd=1500, assert no panic and `true` returned).

## Behavioural notes

Two intentional changes worth calling out:

- The 10-second deadline of the SIGUSR2 path is preserved (10_000 ms ↔ the previous `timeval { tv_sec: 10, tv_usec: 0 }`).
- The readiness predicate is strict on `POLLIN`. If the child closes the pipe before writing the readiness byte, poll reports `POLLHUP` alone and the helper returns `false`. The previous select-based code treated "ready to read EOF" the same as "ready to read data" and forwarded `sd_notify(MAINPID=child)` for an already-dead child. The new code keeps systemd tracking the still-living parent and logs `"New process did not signal readiness within 10s (timeout or early exit)"` instead.

## Risk

Linux-only path; the helper and its tests are gated on `#[cfg(not(windows))]` to match the existing `binary_upgrade_and_shutdown` scope. Behaviour on a happy upgrade is unchanged.

## Test plan

- [ ] `cargo test --lib app::server::wait_for_pipe_readiness_tests` — 4/4 pass (locally green: timeout, ready, POLLHUP-only, fd ≥ 1024 dup2).
- [ ] BDD: existing `BDD: Binary upgrade graceful shutdown` suite remains green.
- [ ] Manual: trigger SIGUSR2 on a host where `ulimit -n` is raised so the new pipe lands above 1024 (`ulimit -n 65536`, hold ~1100 backend connections, then `kill -USR2 $MAINPID`); parent should drain and hand MainPID off cleanly.
