### PR TITLE
Fix GC race on freshly created dynamic pools via RAII guard

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1020,7 +1020,7 @@ where
             // again while TTL expiry or a concurrent refetch is changing it.
             let fetched_overlay = Arc::clone(cache_entry.startup_overlay.map());
             let fetched_overlay_hash = cache_entry.startup_overlay.hash();
-            let mut pool = create_dynamic_pool(
+            let (mut pool, init_guard) = create_dynamic_pool(
                 pool_name,
                 username,
                 backend_auth,
@@ -1049,17 +1049,13 @@ where
                     } = &err
                     {
                         error!("[{username}@{pool_name}] auth_query passthrough: PG rejected operator-supplied startup parameter: {pg_message}");
-                        // Invalidate before dropping the pool. A
-                        // concurrent reconnect that races us between
-                        // these two calls would otherwise read the
-                        // still-cached bad overlay, rebuild the same
-                        // dynamic pool against it, and trigger the
-                        // same rejection. Invalidating first guarantees
-                        // any racing get_or_fetch refetches before
-                        // reconstructing the pool.
+                        // Invalidate the cache so concurrent reconnects
+                        // see the new (or, if user fixes the row, fixed)
+                        // entry instead of the still-cached bad overlay.
+                        // The pool entry itself is removed by
+                        // `init_guard` falling out of scope without a
+                        // `commit`.
                         cache.invalidate(username);
-                        let identifier = crate::pool::PoolIdentifier::new(pool_name, username);
-                        crate::pool::drop_dynamic_pool(&identifier);
                         error_response(write, pg_message, sqlstate).await?;
                         return Err(err);
                     }
@@ -1073,6 +1069,10 @@ where
                     return Err(err);
                 }
             };
+
+            // First connection established — release the guard so GC
+            // resumes normal behavior for this pool.
+            init_guard.commit();
 
             aq_state.stats.auth_success.fetch_add(1, Ordering::Relaxed);
             info!("[{username}@{pool_name}] auth_query: authenticated (passthrough mode)");

--- a/src/pool/dynamic.rs
+++ b/src/pool/dynamic.rs
@@ -5,7 +5,7 @@
 //! and garbage-collected when idle. On RELOAD, dynamic pools are dropped and recreated
 //! on the next client connection with fresh settings.
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
 use log::{debug, info, warn};
@@ -37,7 +37,7 @@ pub fn create_dynamic_pool(
     backend_auth: Option<BackendAuthMethod>,
     fetched_overlay: Arc<std::collections::HashMap<String, String>>,
     fetched_overlay_hash: u64,
-) -> Result<ConnectionPool, Error> {
+) -> Result<(ConnectionPool, super::PoolInitGuard), Error> {
     // Fast path: pool already exists. The cache-side refetch path
     // already drops the live pool when an auth_query refetch changes
     // the overlay (see `drop_dynamic_pool_if_overlay_drifted`), but a
@@ -68,7 +68,7 @@ pub fn create_dynamic_pool(
                     *ba_lock.write() = new_ba.clone();
                 }
             }
-            return Ok(existing);
+            return Ok((existing, super::PoolInitGuard::already_committed()));
         }
         if super::drop_dynamic_pool(&identifier) {
             info!(
@@ -268,7 +268,7 @@ pub fn create_dynamic_pool(
         check_query_cache: Arc::new(CheckQueryCache::new()),
         coordinator: get_coordinator(pool_name),
         replenish_failures: Arc::new(AtomicU32::new(0)),
-        created_at: std::time::Instant::now(),
+        init_complete: Arc::new(AtomicBool::new(false)),
     };
 
     // Atomic insert into POOLS
@@ -300,7 +300,7 @@ pub fn create_dynamic_pool(
                     *ba_lock.write() = new_ba.read().clone();
                 }
             }
-            return Ok(existing.clone());
+            return Ok((existing.clone(), super::PoolInitGuard::already_committed()));
         }
         info!(
             "[{username}@{pool_name}] auth_query: per-user startup_parameters overlay drift on slow-path race — replacing concurrently-built pool"
@@ -348,7 +348,9 @@ pub fn create_dynamic_pool(
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    Ok(conn_pool)
+    let guard =
+        super::PoolInitGuard::for_new_pool(identifier, Arc::clone(&conn_pool.init_complete));
+    Ok((conn_pool, guard))
 }
 
 /// Decide whether `create_dynamic_pool` should replace an existing

--- a/src/pool/gc.rs
+++ b/src/pool/gc.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use log::{debug, info};
 
-use super::{PoolIdentifier, AUTH_QUERY_STATE, DYNAMIC_POOLS, POOLS};
+use super::{ConnectionPool, PoolIdentifier, AUTH_QUERY_STATE, DYNAMIC_POOLS, POOLS};
 
 /// Spawn a background task that periodically removes idle dynamic pools.
 /// Dynamic pools are created by auth_query passthrough mode — one per user.
@@ -34,22 +34,7 @@ fn gc_idle_dynamic_pools() {
     for id in &dynamic_ids {
         match pools.get(id) {
             Some(pool) if pool.pool_state().size == 0 => {
-                // Don't GC paused pools — they're under admin control
-                if pool.database.is_paused() {
-                    debug!("[{id}] GC: paused, skipping");
-                    continue;
-                }
-                // Don't GC pools with min_pool_size — retain cycle manages them
-                if pool.settings.user.min_pool_size.unwrap_or(0) > 0 {
-                    debug!("[{id}] GC: min_pool_size > 0, skipping despite size=0");
-                    continue;
-                }
-                // Grace period: allow-mode retry does two sequential TCP connects
-                // (plain + TLS), each needing 1-2 RTT for handshake. Over WAN
-                // this totals ~1s. 2s = 2x worst case.
-                let age = pool.created_at.elapsed();
-                if age < std::time::Duration::from_secs(2) {
-                    debug!("[{id}] GC: pool age {age:?} < 2s, skipping");
+                if !should_gc_idle_pool(pool, id) {
                     continue;
                 }
                 debug!("[{id}] GC: 0 connections, marking for removal");
@@ -101,4 +86,139 @@ fn gc_idle_dynamic_pools() {
             .collect::<Vec<_>>()
             .join(", ")
     );
+}
+
+/// Decide whether an idle dynamic pool (`pool_state().size == 0`) is
+/// eligible for removal during this GC sweep. A pool is kept when it is
+/// paused (admin control), when it has a `min_pool_size` (retain cycle
+/// is responsible), or when its first server connection is still being
+/// established (`init_complete == false`). The last case is the race
+/// fix for issue #209 — `PoolInitGuard::commit` is what flips the flag
+/// to `true` after `get_server_parameters` succeeds, and any guard
+/// dropped without `commit` has already removed the pool entry by the
+/// time the next sweep observes the map.
+fn should_gc_idle_pool(pool: &ConnectionPool, id: &PoolIdentifier) -> bool {
+    if pool.database.is_paused() {
+        debug!("[{id}] GC: paused, skipping");
+        return false;
+    }
+    if pool.settings.user.min_pool_size.unwrap_or(0) > 0 {
+        debug!("[{id}] GC: min_pool_size > 0, skipping despite size=0");
+        return false;
+    }
+    if !pool.init_complete.load(Ordering::Acquire) {
+        debug!("[{id}] GC: init not complete, skipping");
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Address, PoolMode, User};
+    use crate::pool::{CheckQueryCache, Pool, PoolSettings, ServerParameters, ServerPool};
+    use dashmap::DashMap;
+    use std::sync::atomic::{AtomicBool, AtomicU32};
+
+    fn pool(init_complete: bool, min_pool_size: u32) -> ConnectionPool {
+        let server_pool = ServerPool::new(
+            Address::default(),
+            User {
+                min_pool_size: if min_pool_size == 0 {
+                    None
+                } else {
+                    Some(min_pool_size)
+                },
+                ..User::default()
+            },
+            "test_db",
+            Arc::new(DashMap::new()),
+            false,
+            false,
+            0,
+            "test_app".to_string(),
+            1,
+            60_000,
+            60_000,
+            60_000,
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            false,
+            None,
+            Arc::new(std::collections::BTreeMap::new()),
+            Arc::new(std::collections::BTreeMap::new()),
+        );
+        let database = Pool::builder(server_pool)
+            .pool_name("test_db".to_string())
+            .username("test_user".to_string())
+            .build();
+        ConnectionPool {
+            database,
+            address: Address::default(),
+            original_server_parameters: Arc::new(tokio::sync::Mutex::new(ServerParameters::new())),
+            settings: PoolSettings {
+                pool_mode: PoolMode::Transaction,
+                user: User {
+                    min_pool_size: if min_pool_size == 0 {
+                        None
+                    } else {
+                        Some(min_pool_size)
+                    },
+                    ..User::default()
+                },
+                db: "test_db".to_string(),
+                idle_timeout_ms: 60_000,
+                life_time_ms: 60_000,
+                sync_server_parameters: false,
+                min_guaranteed_pool_size: 0,
+            },
+            config_hash: 0,
+            per_user_startup_overlay_hash: crate::pool::empty_overlay_hash(),
+            prepared_statement_cache: None,
+            check_query_cache: Arc::new(CheckQueryCache::new()),
+            coordinator: None,
+            replenish_failures: Arc::new(AtomicU32::new(0)),
+            init_complete: Arc::new(AtomicBool::new(init_complete)),
+        }
+    }
+
+    #[test]
+    fn idle_pool_with_completed_init_is_collected() {
+        // Regular case: pool finished initializing, drained to zero, GC should reap it.
+        let id = PoolIdentifier::new("test_db", "test_user");
+        let p = pool(true, 0);
+        assert!(should_gc_idle_pool(&p, &id));
+    }
+
+    #[test]
+    fn idle_pool_still_initializing_is_skipped() {
+        // Issue #209: GC must not reap a pool whose first server connection
+        // is still being established. Without this check the next login
+        // observes "No pool configured" and the connection is dropped.
+        let id = PoolIdentifier::new("test_db", "test_user");
+        let p = pool(false, 0);
+        assert!(!should_gc_idle_pool(&p, &id));
+    }
+
+    #[test]
+    fn pool_with_min_pool_size_is_skipped() {
+        // The retain cycle keeps `min_pool_size` connections warm; GC must
+        // never compete with it on the same pool.
+        let id = PoolIdentifier::new("test_db", "test_user");
+        let p = pool(true, 5);
+        assert!(!should_gc_idle_pool(&p, &id));
+    }
+
+    #[test]
+    fn flipping_init_complete_makes_pool_eligible() {
+        // Same pool object, different observable behavior before and after
+        // `PoolInitGuard::commit` runs. Concretizes the contract between the
+        // guard and the GC sweep.
+        let id = PoolIdentifier::new("test_db", "test_user");
+        let p = pool(false, 0);
+        assert!(!should_gc_idle_pool(&p, &id));
+        p.init_complete.store(true, Ordering::Release);
+        assert!(should_gc_idle_pool(&p, &id));
+    }
 }

--- a/src/pool/init_guard.rs
+++ b/src/pool/init_guard.rs
@@ -1,0 +1,94 @@
+//! RAII handle that closes the GC race on freshly created dynamic pools.
+//!
+//! A dynamic pool is inserted into `POOLS` before its first server
+//! connection exists, so `pool_state().size == 0`. Without this guard
+//! the next GC sweep could remove the pool while the caller is still
+//! inside `get_server_parameters()` for the very first connection.
+//!
+//! The guard owns the pool's `init_complete` flag. `commit` flips the
+//! flag after the first connection is established and disables the
+//! `Drop` cleanup. If the guard is dropped without `commit` — typically
+//! because the auth flow failed or panicked between insertion and the
+//! first checkout — `Drop` removes the pool entry from `POOLS` so the
+//! next login rebuilds the pool from scratch.
+//!
+//! `PoolInitGuard::already_committed()` is a no-op variant returned from
+//! `create_dynamic_pool` when an existing pool is reused. Drop on it is
+//! a no-op; `commit` is harmless.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use super::PoolIdentifier;
+
+pub struct PoolInitGuard {
+    identifier: Option<PoolIdentifier>,
+    init_complete: Arc<AtomicBool>,
+    committed: bool,
+}
+
+impl PoolInitGuard {
+    /// Build a guard for a freshly inserted dynamic pool. The caller is
+    /// responsible for calling `commit` after the first connection has
+    /// been successfully established. Until then GC will skip the pool
+    /// because of its `init_complete == false` flag.
+    pub fn for_new_pool(identifier: PoolIdentifier, init_complete: Arc<AtomicBool>) -> Self {
+        Self {
+            identifier: Some(identifier),
+            init_complete,
+            committed: false,
+        }
+    }
+
+    /// Build a no-op guard for the early-return path in
+    /// `create_dynamic_pool` (existing pool reused). `Drop` does
+    /// nothing; `commit` is harmless.
+    pub fn already_committed() -> Self {
+        Self {
+            identifier: None,
+            init_complete: Arc::new(AtomicBool::new(true)),
+            committed: true,
+        }
+    }
+
+    /// Mark the pool as fully initialized. After this call the pool is
+    /// subject to normal GC rules. Consumes the guard so it cannot be
+    /// committed twice or dropped after commit.
+    pub fn commit(mut self) {
+        self.init_complete.store(true, Ordering::Release);
+        self.committed = true;
+    }
+}
+
+impl Drop for PoolInitGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if let Some(id) = self.identifier.take() {
+            crate::pool::drop_dynamic_pool(&id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_committed_leaves_flag_true_and_does_nothing_on_drop() {
+        let guard = PoolInitGuard::already_committed();
+        assert!(guard.init_complete.load(Ordering::Acquire));
+        drop(guard);
+    }
+
+    #[test]
+    fn commit_flips_flag_and_blocks_drop_cleanup() {
+        let id = PoolIdentifier::new("db", "user");
+        let flag = Arc::new(AtomicBool::new(false));
+        let guard = PoolInitGuard::for_new_pool(id, Arc::clone(&flag));
+        assert!(!flag.load(Ordering::Acquire));
+        guard.commit();
+        assert!(flag.load(Ordering::Acquire));
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -5,7 +5,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::config::{
@@ -33,6 +33,7 @@ mod check_query_cache;
 mod dynamic;
 mod eviction;
 pub mod gc;
+mod init_guard;
 pub mod pool_coordinator;
 pub mod retain;
 mod server_pool;
@@ -44,6 +45,7 @@ pub use auth_query_state::AuthQueryState;
 pub use check_query_cache::CheckQueryCache;
 pub use dynamic::create_dynamic_pool;
 pub use eviction::PoolEvictionSource;
+pub use init_guard::PoolInitGuard;
 pub use server_pool::ServerPool;
 
 pub type ProcessId = i32;
@@ -342,9 +344,14 @@ pub struct ConnectionPool {
     /// Reset to 0 on successful replenish.
     pub(crate) replenish_failures: Arc<AtomicU32>,
 
-    /// When this pool was created. Used by GC to avoid removing
-    /// dynamic pools that are still establishing their first connection.
-    pub(crate) created_at: std::time::Instant,
+    /// Whether the pool has completed initialization (first server
+    /// connection established). Static pools start with `true`. Dynamic
+    /// pools start with `false` and are flipped to `true` by
+    /// `PoolInitGuard::commit` once `get_server_parameters` succeeds.
+    /// GC skips pools with `init_complete == false` so a pool that is
+    /// still establishing its first connection cannot be reaped while
+    /// `pool_state().size` is still zero.
+    pub(crate) init_complete: Arc<AtomicBool>,
 }
 
 impl ConnectionPool {
@@ -633,7 +640,7 @@ impl ConnectionPool {
                     check_query_cache: Arc::new(CheckQueryCache::new()),
                     coordinator: coordinators.get(pool_name).cloned(),
                     replenish_failures: Arc::new(AtomicU32::new(0)),
-                    created_at: std::time::Instant::now(),
+                    init_complete: Arc::new(AtomicBool::new(true)),
                 };
 
                 // There is one pool per database/user pair.
@@ -858,7 +865,7 @@ impl ConnectionPool {
                             check_query_cache: Arc::new(CheckQueryCache::new()),
                             coordinator: coordinators.get(pool_name).cloned(),
                             replenish_failures: Arc::new(AtomicU32::new(0)),
-                            created_at: std::time::Instant::now(),
+                            init_complete: Arc::new(AtomicBool::new(true)),
                         };
 
                         new_pools.insert(identifier.clone(), conn_pool);

--- a/src/pool/retain.rs
+++ b/src/pool/retain.rs
@@ -297,7 +297,7 @@ pub fn drain_all_pools() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::time::Duration;
 
     use crate::config::{Address, PoolMode, User};
@@ -349,7 +349,7 @@ mod tests {
             check_query_cache: Arc::new(crate::pool::CheckQueryCache::new()),
             coordinator: None,
             replenish_failures: Arc::new(AtomicU32::new(0)),
-            created_at: std::time::Instant::now(),
+            init_complete: Arc::new(AtomicBool::new(true)),
         }
     }
 

--- a/tests/bdd/features/auth-query-init-race.feature
+++ b/tests/bdd/features/auth-query-init-race.feature
@@ -1,0 +1,84 @@
+@rust @rust-2 @auth-query @auth-query-init-race
+Feature: Dynamic pool survives GC sweeps that race its first connection
+  Issue #209: a dynamic pool is inserted into POOLS before its first
+  server connection exists. If GC sweeps the pool map while
+  get_server_parameters is still establishing that connection, the
+  pool is removed and the next client sees "No pool configured".
+
+  Until the RAII PoolInitGuard landed, GC relied on a `created_at`
+  field with a 2-second grace period — closing the race only when
+  the first connection completes inside that window. With slow CI
+  runners and the SSLRequest round-trip in `prefer` mode the window
+  closes early enough to drop pools mid-initialization. The new flow
+  flips `init_complete` from `false` to `true` exactly once
+  `get_server_parameters` succeeds, and the GC sweep keys off that
+  flag instead of timing.
+
+  Background:
+    Given PostgreSQL started with pg_hba.conf:
+      """
+      local   all             all                                     trust
+      host    all             postgres        127.0.0.1/32            trust
+      host    all             all             127.0.0.1/32            md5
+      host    all             all             ::1/128                 trust
+      """
+    And fixtures from "tests/auth_query_passthrough_fixture.sql" applied
+    And self-signed SSL certificates are generated
+    And pg_doorman hba file contains:
+      """
+      host all all 127.0.0.1/32 md5
+      """
+    And pg_doorman started with config:
+      """
+      general:
+        host: "127.0.0.1"
+        port: ${DOORMAN_PORT}
+        connect_timeout: 5000
+        idle_timeout: 500
+        server_lifetime: 1000
+        retain_connections_time: 200
+        admin_username: "admin"
+        admin_password: "admin"
+        tls_private_key: "${DOORMAN_SSL_KEY}"
+        tls_certificate: "${DOORMAN_SSL_CERT}"
+        pg_hba:
+          path: "${DOORMAN_HBA_FILE}"
+      pools:
+        postgres:
+          server_host: "127.0.0.1"
+          server_port: ${PG_PORT}
+          pool_mode: "transaction"
+          auth_query:
+            query: "SELECT username, password FROM auth_users WHERE username = $1"
+            user: "postgres"
+            password: ""
+            pool_size: 5
+            cache_ttl: "1h"
+            cache_failure_ttl: "30s"
+            min_interval: "0s"
+      """
+
+  Scenario: Concurrent first logins for two users with GC sweeping every 200 ms
+    # retain_connections_time drives the GC tick. 200 ms means the sweep
+    # fires roughly five times per second — every dynamic pool creation
+    # is observed by at least one sweep while its first connection is
+    # being established. Without the init_complete check the pool can be
+    # reaped before get_server_parameters returns; the next client sees
+    # `Connection refused` because pg_doorman lost the pool entry.
+    When I run shell command:
+      """
+      set -e
+      PGPASSWORD=md5_pass  psql -h 127.0.0.1 -p ${DOORMAN_PORT} -U pt_md5_user  -d postgres -c "select 1" >/dev/null &
+      PGPASSWORD=md5_pass2 psql -h 127.0.0.1 -p ${DOORMAN_PORT} -U pt_md5_user2 -d postgres -c "select 1" >/dev/null &
+      wait
+      """
+    Then the command should succeed
+    # After a quiet stretch the connections drain (idle_timeout=500ms,
+    # server_lifetime=1000ms) and the regular GC sweep reaps the pools.
+    # This confirms the init_complete flag does NOT permanently disable
+    # GC — it only delays it until the first connection lands.
+    When we create admin session "adm" to pg_doorman as "admin" with password "admin"
+    And we sleep for 5000 milliseconds
+    And we execute "SHOW POOLS" on admin session "adm" and store response
+    Then admin session "adm" response should not contain "pt_md5_user"
+    And admin session "adm" response should not contain "pt_md5_user2"


### PR DESCRIPTION
Closes #209.

## Summary

A dynamic auth_query passthrough pool was inserted into `POOLS` before
its first server connection existed. Between insertion and the
`get_server_parameters` call that establishes that connection, a GC
sweep could observe `pool_state().size == 0` and remove the pool. The
next client looking it up saw `No pool configured` until a fresh login
rebuilt it.

The previous mitigation was a 2-second `created_at` grace period in
`gc_idle_dynamic_pools`. It worked locally but on slow CI runners — and
in `prefer` TLS mode where the SSLRequest round-trip widens the
initialization window — the race still triggered.

## What changes for the operator

- A pool that has just been created stays in `POOLS` until its first
  server connection is established. GC keeps its hands off until
  initialization is done.
- An auth flow that fails after pool creation (PG rejected a startup
  parameter, backend unreachable, panic in the middle) leaves no
  stale pool entry behind. The next login starts from a clean slate.
- The `created_at` field and its 2-second grace period are gone.

## What changes internally

- `ConnectionPool` carries an `init_complete: Arc<AtomicBool>`. Static
  pools start with `true`. Dynamic pools start with `false`.
- `create_dynamic_pool` returns `(ConnectionPool, PoolInitGuard)`. The
  guard owns that flag and the pool identifier. `commit` flips the
  flag to `true`; `Drop` without `commit` calls `drop_dynamic_pool`.
- The auth flow calls `init_guard.commit()` right after the first
  successful `get_server_parameters`. Every error path returns before
  `commit`, so `Drop` cleans up.
- `gc_idle_dynamic_pools` now checks `init_complete` instead of an
  elapsed-time window. The decision logic is extracted into a small
  pure function (`should_gc_idle_pool`) covered by unit tests.

The earlier structural attempt (`089fc22`, reverted in `760ac60`)
moved the POOLS insertion to *after* the first connection. Two
concurrent first logins for the same user could then each build a
separate `ConnectionPool`, leaving one client wired to a `bb8::Pool`
that was about to be overwritten — the hang in `760ac60` traced back
to that race. The guard approach keeps the insertion order (POOLS
first, then connection) so the single-pool invariant survives, and
relies on the flag to close the GC window.

## Test plan

- [x] `cargo test --lib pool::gc::tests` — 4 unit tests on the pure
      decision function. Two of them encode the regression directly:
      `idle_pool_still_initializing_is_skipped` and
      `flipping_init_complete_makes_pool_eligible`. Without this fix
      they would assert against the missing `init_complete` field.
- [x] `cargo test --lib pool::init_guard::tests` — 2 unit tests on the
      guard (`already_committed_leaves_flag_true_and_does_nothing_on_drop`,
      `commit_flips_flag_and_blocks_drop_cleanup`).
- [x] `make test-bdd TAGS=@auth-query` — 10 features, 42 scenarios,
      360 steps, all green.
- [x] `make test-bdd TAGS=@auth-query-init-race` — new scenario opens
      two concurrent first logins for two different dynamic users with
      `retain_connections_time = 200ms` and short idle/server
      lifetimes, then asserts that both succeed and that GC reaps the
      pools the normal way once connections drain. On CI runners where
      the historical 2 s grace period was not enough, this scenario
      would have flaked without the fix.
- [x] `cargo fmt`, `cargo clippy --lib --tests -- --deny warnings`,
      and the full unit-test suite are clean.

## Performance

The new flag is a single `Arc<AtomicBool>`:

- BASELINE: `gc_idle_dynamic_pools` reads each dynamic pool once per
  sweep; `create_dynamic_pool` runs once per first login per user.
- BOTTLENECK: none.
- EVIDENCE: the only new operations are one relaxed atomic load per
  pool per sweep and one relaxed atomic store at first-login success.
- IMPACT: indistinguishable from the previous `Instant::elapsed`
  branch in any production workload; both bound by `O(N)` GC sweep
  over dynamic pools.