### PR TITLE
Surface query interner and anonymous LRU evictions in logs

### DIFF
--- a/src/admin/show.rs
+++ b/src/admin/show.rs
@@ -285,7 +285,7 @@ where
             InternerHandle::Named(e) => e.text().clone(),
             InternerHandle::Anon(e) => e.text().clone(),
         };
-        let preview = crate::server::preview_query(&text);
+        let preview = crate::utils::strings::preview_query(&text);
         res.put(data_row(&[
             format!("{hash:#x}"),
             kind.to_string(),

--- a/src/admin/show.rs
+++ b/src/admin/show.rs
@@ -285,7 +285,7 @@ where
             InternerHandle::Named(e) => e.text().clone(),
             InternerHandle::Anon(e) => e.text().clone(),
         };
-        let preview: String = text.chars().take(120).collect();
+        let preview = crate::server::preview_query(&text);
         res.put(data_row(&[
             format!("{hash:#x}"),
             kind.to_string(),

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpSocket;
 #[cfg(not(windows))]
@@ -366,6 +366,26 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                     let elapsed = started.elapsed().as_secs_f64();
 
                     record_interner_gc(named_stats, anon_stats, elapsed);
+
+                    // Aggregate sweep summary. Suppressed when nothing was
+                    // evicted so a quiet pooler at default INFO sees no churn,
+                    // but visible at DEBUG during an incident — together with
+                    // the per-entry TRACE lines in `gc_sweep_named` /
+                    // `gc_sweep_anon` this is enough to reconstruct what the
+                    // interner dropped without scraping Prometheus.
+                    if named_stats.evicted > 0 || anon_stats.evicted > 0 {
+                        debug!(
+                            "query_interner GC: named marked={}, evicted={}, bytes={}; anon marked={}, evicted={}, bytes={}, ttl_ms={}; elapsed={:.3}ms",
+                            named_stats.marked,
+                            named_stats.evicted,
+                            named_stats.bytes,
+                            anon_stats.marked,
+                            anon_stats.evicted,
+                            anon_stats.bytes,
+                            anon_ttl_ms,
+                            elapsed * 1000.0,
+                        );
+                    }
                 }
             });
         }

--- a/src/client/protocol.rs
+++ b/src/client/protocol.rs
@@ -1,5 +1,5 @@
 use bytes::{BufMut, BytesMut};
-use log::{debug, warn};
+use log::{debug, log_enabled, trace, warn, Level};
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::errors::Error;
 use crate::messages::{error_response, Bind, Close, Describe, Parse};
 use crate::pool::ConnectionPool;
-use crate::server::{now_monotonic_ms, Server};
+use crate::server::{now_monotonic_ms, truncate_query_for_log, Server};
 
 /// Throttle for the synthetic-miss WARN line. Without rate-limiting a
 /// driver hammering the pooler at 10k RPS would write 10k WARN lines per
@@ -51,16 +51,9 @@ where
         let cached = self.prepared.cache.get(&key).cloned();
         match cached {
             Some(cached) => {
-                if log::log_enabled!(log::Level::Debug) {
-                    let query = cached.parse.query().replace(['\n', '\r'], " ");
-                    let q: String = query.chars().take(80).collect();
-                    let el = if query.chars().count() > 80 {
-                        "..."
-                    } else {
-                        ""
-                    };
+                if log_enabled!(Level::Debug) {
                     debug!(
-                        "[{}@{} #c{}] client cache hit: {} query=\"{q}{el}\"",
+                        "[{}@{} #c{}] client cache hit: {} query=\"{}\"",
                         self.username,
                         self.pool_name,
                         self.connection_id,
@@ -68,7 +61,8 @@ where
                             PreparedStatementKey::Named(name) => format!("name=`{name}`"),
                             PreparedStatementKey::Anonymous(hash) =>
                                 format!("hash={hash:#x} (unnamed)"),
-                        }
+                        },
+                        truncate_query_for_log(cached.parse.query()),
                     );
                 }
                 // Get the server-side name (may be async_name for async clients)
@@ -208,16 +202,9 @@ where
             None
         };
 
-        if log::log_enabled!(log::Level::Debug) {
-            let query = shared_parse.query().replace(['\n', '\r'], " ");
-            let truncated: String = query.chars().take(80).collect();
-            let ellipsis = if query.chars().count() > 80 {
-                "..."
-            } else {
-                ""
-            };
+        if log_enabled!(Level::Debug) {
             debug!(
-                "[{}@{} #c{}] mapped statement `{}` -> `{}` (hash={:#x}{}) query=\"{truncated}{ellipsis}\"",
+                "[{}@{} #c{}] mapped statement `{}` -> `{}` (hash={:#x}{}) query=\"{}\"",
                 self.username,
                 self.pool_name,
                 self.connection_id,
@@ -227,7 +214,8 @@ where
                 async_name
                     .as_ref()
                     .map(|n| format!(", async_name={n}"))
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
+                truncate_query_for_log(shared_parse.query()),
             );
         }
 
@@ -247,9 +235,21 @@ where
         // re-Parse of the same anonymous hash) and Inserted must not bump
         // the operator counter — that was the bug behind a non-zero
         // eviction rate at zero capacity pressure.
-        if let PutOutcome::Evicted(_) = self.prepared.cache.put(cache_key, cached) {
+        if let PutOutcome::Evicted(evicted) = self.prepared.cache.put(cache_key, cached) {
             self.prepared.anonymous_evictions += 1;
             crate::web::metrics::observe_anonymous_eviction(&self.username, &self.pool_name);
+            if log_enabled!(Level::Trace) {
+                trace!(
+                    "[{}@{} #c{}] anonymous LRU evict: hash={:#x}, lru_size={}, evicted_total={}, query=\"{}\"",
+                    self.username,
+                    self.pool_name,
+                    self.connection_id,
+                    evicted.hash,
+                    self.prepared.cache.anonymous_count(),
+                    self.prepared.anonymous_evictions,
+                    truncate_query_for_log(evicted.parse.query()),
+                );
+            }
         }
 
         // Update prepared cache stats after modification

--- a/src/client/protocol.rs
+++ b/src/client/protocol.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use crate::errors::Error;
 use crate::messages::{error_response, Bind, Close, Describe, Parse};
 use crate::pool::ConnectionPool;
-use crate::server::{now_monotonic_ms, truncate_query_for_log, Server};
+use crate::server::{now_monotonic_ms, Server};
+use crate::utils::strings::truncate_query_for_log;
 
 /// Throttle for the synthetic-miss WARN line. Without rate-limiting a
 /// driver hammering the pooler at 10k RPS would write 10k WARN lines per

--- a/src/patroni/client.rs
+++ b/src/patroni/client.rs
@@ -4,18 +4,7 @@ use futures::future::select_all;
 use log::{debug, error, warn};
 
 use super::types::ClusterResponse;
-
-/// Truncate a string to at most `max_bytes`, ensuring the cut falls on a char boundary.
-fn truncate_str(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
+use crate::utils::strings::truncate_bytes;
 
 /// Errors from the Patroni REST API client.
 #[derive(Debug)]
@@ -84,7 +73,7 @@ impl PatroniClient {
                         if !resp.status().is_success() {
                             let status = resp.status();
                             let body = resp.text().await.unwrap_or_default();
-                            return Err(format!("HTTP {status}: {}", truncate_str(&body, 512)));
+                            return Err(format!("HTTP {status}: {}", truncate_bytes(&body, 512)));
                         }
 
                         let body = resp
@@ -92,7 +81,7 @@ impl PatroniClient {
                             .await
                             .map_err(|e| format!("reading body: {e}"))?;
                         serde_json::from_str::<ClusterResponse>(&body).map_err(|e| {
-                            format!("json parse: {e}, body: {}", truncate_str(&body, 512))
+                            format!("json parse: {e}, body: {}", truncate_bytes(&body, 512))
                         })
                     }
                     .await;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ mod server_backend;
 pub use parameters::ServerParameters;
 pub use prepared_statement_cache::{
     anon_len, anon_snapshot, gc_sweep_anon, gc_sweep_named, intern_query, named_len,
-    named_snapshot, now_monotonic_ms, record_query_count, record_query_duration_us,
+    named_snapshot, now_monotonic_ms, preview_query, record_query_count, record_query_duration_us,
     reset_interners_force, set_interner_worker_threads, truncate_query_for_log, AnonEntry,
     CacheEntryKind, GcStats, NamedEntry, PreparedStatementCache,
 };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,9 +15,9 @@ mod server_backend;
 pub use parameters::ServerParameters;
 pub use prepared_statement_cache::{
     anon_len, anon_snapshot, gc_sweep_anon, gc_sweep_named, intern_query, named_len,
-    named_snapshot, now_monotonic_ms, preview_query, record_query_count, record_query_duration_us,
-    reset_interners_force, set_interner_worker_threads, truncate_query_for_log, AnonEntry,
-    CacheEntryKind, GcStats, NamedEntry, PreparedStatementCache,
+    named_snapshot, now_monotonic_ms, record_query_count, record_query_duration_us,
+    reset_interners_force, set_interner_worker_threads, AnonEntry, CacheEntryKind, GcStats,
+    NamedEntry, PreparedStatementCache,
 };
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,8 +16,8 @@ pub use parameters::ServerParameters;
 pub use prepared_statement_cache::{
     anon_len, anon_snapshot, gc_sweep_anon, gc_sweep_named, intern_query, named_len,
     named_snapshot, now_monotonic_ms, record_query_count, record_query_duration_us,
-    reset_interners_force, set_interner_worker_threads, AnonEntry, CacheEntryKind, GcStats,
-    NamedEntry, PreparedStatementCache,
+    reset_interners_force, set_interner_worker_threads, truncate_query_for_log, AnonEntry,
+    CacheEntryKind, GcStats, NamedEntry, PreparedStatementCache,
 };
 
 #[cfg(test)]

--- a/src/server/prepared_statement_cache.rs
+++ b/src/server/prepared_statement_cache.rs
@@ -370,6 +370,19 @@ pub fn gc_sweep_anon(anon_idle_ttl_ms: u64) -> GcStats {
 /// can't blow up a log shipper.
 pub(crate) const LOG_QUERY_MAX_CHARS: usize = 80;
 
+/// Maximum characters preserved in API/admin previews of a query
+/// (`/api/top/queries`, `/api/interner`, `SHOW QUERIES`). Wider than the
+/// log line because the consumer is interactive UI / `psql` output that
+/// can wrap rather than a single-line shipper.
+pub const PREVIEW_QUERY_MAX_CHARS: usize = 120;
+
+/// First `PREVIEW_QUERY_MAX_CHARS` characters of `query`, verbatim. No
+/// ellipsis, no newline collapse — preview surfaces are expected to
+/// render the text as-is so operators can read the original statement.
+pub fn preview_query(query: &str) -> String {
+    query.chars().take(PREVIEW_QUERY_MAX_CHARS).collect()
+}
+
 /// Render a query string into a compact form safe for a single log line:
 /// newlines collapsed to spaces (one CR/LF = one space) and trimmed to
 /// `LOG_QUERY_MAX_CHARS` characters with a trailing "..." when truncated.
@@ -1148,5 +1161,25 @@ mod tests {
         let out = truncate_query_for_log(&q);
         assert!(out.ends_with("..."));
         assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
+    }
+
+    #[test]
+    fn preview_query_keeps_short_input_untouched() {
+        assert_eq!(preview_query("SELECT 1\nFROM t"), "SELECT 1\nFROM t");
+    }
+
+    #[test]
+    fn preview_query_caps_at_preview_max_no_ellipsis() {
+        let q: String = "a".repeat(PREVIEW_QUERY_MAX_CHARS + 50);
+        let out = preview_query(&q);
+        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
+        assert!(!out.ends_with("..."));
+    }
+
+    #[test]
+    fn preview_query_handles_multi_byte_chars() {
+        let q: String = "ы".repeat(PREVIEW_QUERY_MAX_CHARS + 5);
+        let out = preview_query(&q);
+        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
     }
 }

--- a/src/server/prepared_statement_cache.rs
+++ b/src/server/prepared_statement_cache.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::messages::Parse;
 use crate::utils::dashmap::new_dashmap_with_capacity;
+use crate::utils::strings::truncate_query_for_log;
 
 /// Worker-thread hint for the lazy interner DashMaps. `run_server` calls
 /// `set_interner_worker_threads(config.general.worker_threads)` before any
@@ -362,42 +363,6 @@ pub fn gc_sweep_anon(anon_idle_ttl_ms: u64) -> GcStats {
         );
     }
     stats
-}
-
-/// Maximum number of characters (not bytes — query text may contain
-/// multi-byte UTF-8) kept when a query is rendered into a log line.
-/// Long queries are truncated with an ellipsis so a runaway statement
-/// can't blow up a log shipper.
-pub(crate) const LOG_QUERY_MAX_CHARS: usize = 80;
-
-/// Maximum characters preserved in API/admin previews of a query
-/// (`/api/top/queries`, `/api/interner`, `SHOW QUERIES`). Wider than the
-/// log line because the consumer is interactive UI / `psql` output that
-/// can wrap rather than a single-line shipper.
-pub const PREVIEW_QUERY_MAX_CHARS: usize = 120;
-
-/// First `PREVIEW_QUERY_MAX_CHARS` characters of `query`, verbatim. No
-/// ellipsis, no newline collapse — preview surfaces are expected to
-/// render the text as-is so operators can read the original statement.
-pub fn preview_query(query: &str) -> String {
-    query.chars().take(PREVIEW_QUERY_MAX_CHARS).collect()
-}
-
-/// Render a query string into a compact form safe for a single log line:
-/// newlines collapsed to spaces (one CR/LF = one space) and trimmed to
-/// `LOG_QUERY_MAX_CHARS` characters with a trailing "..." when truncated.
-/// Always allocates; the `log` crate's macros already short-circuit
-/// argument evaluation below the active level, so a bare `trace!(...)`
-/// call is enough — explicit `log_enabled!` guards are only useful on
-/// hot paths where avoiding the allocation matters.
-pub fn truncate_query_for_log(query: &str) -> String {
-    let cleaned = query.replace(['\n', '\r'], " ");
-    if cleaned.chars().count() <= LOG_QUERY_MAX_CHARS {
-        return cleaned;
-    }
-    let mut out: String = cleaned.chars().take(LOG_QUERY_MAX_CHARS).collect();
-    out.push_str("...");
-    out
 }
 
 /// Bit set when at least one client has Parse'd this hash with a non-empty name.
@@ -1115,71 +1080,5 @@ mod tests {
         let snap = super::named_snapshot();
         let (_, e) = snap.iter().find(|(h, _)| *h == 0xD00D00).unwrap();
         assert_eq!(e.total_duration_us(), 350);
-    }
-
-    #[test]
-    fn truncate_query_for_log_keeps_short_query_intact() {
-        assert_eq!(truncate_query_for_log("select 1"), "select 1");
-    }
-
-    #[test]
-    fn truncate_query_for_log_collapses_newlines_to_spaces() {
-        assert_eq!(
-            truncate_query_for_log("select\n1\rfrom\r\nt"),
-            "select 1 from  t"
-        );
-    }
-
-    #[test]
-    fn truncate_query_for_log_no_ellipsis_at_exact_limit() {
-        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS);
-        let out = truncate_query_for_log(&q);
-        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS);
-        assert!(!out.ends_with("..."));
-    }
-
-    #[test]
-    fn truncate_query_for_log_appends_ellipsis_past_limit() {
-        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS + 5);
-        let out = truncate_query_for_log(&q);
-        assert!(out.ends_with("..."));
-        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
-    }
-
-    #[test]
-    fn truncate_query_for_log_empty_input() {
-        assert_eq!(truncate_query_for_log(""), "");
-    }
-
-    #[test]
-    fn truncate_query_for_log_truncates_by_chars_not_bytes() {
-        // Multi-byte chars: Cyrillic 'а' is 2 bytes. LOG_QUERY_MAX_CHARS
-        // characters of 'а' is 2 * LOG_QUERY_MAX_CHARS bytes; truncation
-        // must count chars, not bytes — otherwise a UTF-8 boundary slice
-        // panics or produces invalid UTF-8.
-        let q: String = "а".repeat(LOG_QUERY_MAX_CHARS + 10);
-        let out = truncate_query_for_log(&q);
-        assert!(out.ends_with("..."));
-        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
-    }
-
-    #[test]
-    fn preview_query_keeps_short_input_untouched() {
-        assert_eq!(preview_query("SELECT 1\nFROM t"), "SELECT 1\nFROM t");
-    }
-
-    #[test]
-    fn preview_query_caps_at_preview_max_no_ellipsis() {
-        let q: String = "a".repeat(PREVIEW_QUERY_MAX_CHARS + 50);
-        let out = preview_query(&q);
-        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
-        assert!(!out.ends_with("..."));
-    }
-
-    #[test]
-    fn preview_query_handles_multi_byte_chars() {
-        let q: String = "ы".repeat(PREVIEW_QUERY_MAX_CHARS + 5);
-        let out = preview_query(&q);
-        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
     }
 }

--- a/src/server/prepared_statement_cache.rs
+++ b/src/server/prepared_statement_cache.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use log::info;
+use log::{info, log_enabled, trace, Level};
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -312,12 +312,22 @@ where
 pub fn gc_sweep_named() -> GcStats {
     let mut stats = GcStats::default();
     for (hash, entry) in named_snapshot() {
+        let text_len = entry.text.len() as u64;
         sweep_entry(
             Arc::strong_count(&entry.text) == 1,
             &entry.gc_state,
-            entry.text.len() as u64,
+            text_len,
             &mut stats,
-            || NAMED_INTERNER.remove(&hash).is_some(),
+            || {
+                let removed = NAMED_INTERNER.remove(&hash).is_some();
+                if removed && log_enabled!(Level::Trace) {
+                    trace!(
+                        "query_interner evict named: hash={hash:#x}, bytes={text_len}, query=\"{}\"",
+                        truncate_query_for_log(&entry.text)
+                    );
+                }
+                removed
+            },
         );
     }
     stats
@@ -332,15 +342,49 @@ pub fn gc_sweep_anon(anon_idle_ttl_ms: u64) -> GcStats {
     let now = now_monotonic_ms();
     let mut stats = GcStats::default();
     for (hash, entry) in anon_snapshot() {
+        let text_len = entry.text.len() as u64;
+        let idle_ms = entry.idle_ms(now);
         sweep_entry(
-            entry.idle_ms(now) > anon_idle_ttl_ms,
+            idle_ms > anon_idle_ttl_ms,
             &entry.gc_state,
-            entry.text.len() as u64,
+            text_len,
             &mut stats,
-            || ANON_INTERNER.remove(&hash).is_some(),
+            || {
+                let removed = ANON_INTERNER.remove(&hash).is_some();
+                if removed && log_enabled!(Level::Trace) {
+                    trace!(
+                        "query_interner evict anon: hash={hash:#x}, bytes={text_len}, idle_ms={idle_ms}, query=\"{}\"",
+                        truncate_query_for_log(&entry.text)
+                    );
+                }
+                removed
+            },
         );
     }
     stats
+}
+
+/// Maximum number of characters (not bytes — query text may contain
+/// multi-byte UTF-8) kept when a query is rendered into a log line.
+/// Long queries are truncated with an ellipsis so a runaway statement
+/// can't blow up a log shipper.
+pub(crate) const LOG_QUERY_MAX_CHARS: usize = 80;
+
+/// Render a query string into a compact form safe for a single log line:
+/// newlines collapsed to spaces (one CR/LF = one space) and trimmed to
+/// `LOG_QUERY_MAX_CHARS` characters with a trailing "..." when truncated.
+/// Always allocates; the `log` crate's macros already short-circuit
+/// argument evaluation below the active level, so a bare `trace!(...)`
+/// call is enough — explicit `log_enabled!` guards are only useful on
+/// hot paths where avoiding the allocation matters.
+pub fn truncate_query_for_log(query: &str) -> String {
+    let cleaned = query.replace(['\n', '\r'], " ");
+    if cleaned.chars().count() <= LOG_QUERY_MAX_CHARS {
+        return cleaned;
+    }
+    let mut out: String = cleaned.chars().take(LOG_QUERY_MAX_CHARS).collect();
+    out.push_str("...");
+    out
 }
 
 /// Bit set when at least one client has Parse'd this hash with a non-empty name.
@@ -651,18 +695,12 @@ impl PreparedStatementCache {
             if let Some((_, entry)) = self.cache.remove(&key) {
                 self.total_memory_bytes
                     .fetch_sub(entry_bytes(&entry.parse), Ordering::Relaxed);
-                let query = entry.parse.query().replace(['\n', '\r'], " ");
-                let truncated: String = query.chars().take(80).collect();
-                let ellipsis = if query.chars().count() > 80 {
-                    "..."
-                } else {
-                    ""
-                };
                 info!(
-                    "Pool cache eviction: hash={:#x}, kind={}, name={}, query=\"{truncated}{ellipsis}\", size={}/{}",
+                    "Pool cache eviction: hash={:#x}, kind={}, name={}, query=\"{}\", size={}/{}",
                     key,
                     entry.kind().as_str(),
                     entry.parse.name,
+                    truncate_query_for_log(entry.parse.query()),
                     self.cache.len(),
                     self.max_size,
                 );
@@ -1064,5 +1102,51 @@ mod tests {
         let snap = super::named_snapshot();
         let (_, e) = snap.iter().find(|(h, _)| *h == 0xD00D00).unwrap();
         assert_eq!(e.total_duration_us(), 350);
+    }
+
+    #[test]
+    fn truncate_query_for_log_keeps_short_query_intact() {
+        assert_eq!(truncate_query_for_log("select 1"), "select 1");
+    }
+
+    #[test]
+    fn truncate_query_for_log_collapses_newlines_to_spaces() {
+        assert_eq!(
+            truncate_query_for_log("select\n1\rfrom\r\nt"),
+            "select 1 from  t"
+        );
+    }
+
+    #[test]
+    fn truncate_query_for_log_no_ellipsis_at_exact_limit() {
+        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS);
+        let out = truncate_query_for_log(&q);
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS);
+        assert!(!out.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_query_for_log_appends_ellipsis_past_limit() {
+        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS + 5);
+        let out = truncate_query_for_log(&q);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
+    }
+
+    #[test]
+    fn truncate_query_for_log_empty_input() {
+        assert_eq!(truncate_query_for_log(""), "");
+    }
+
+    #[test]
+    fn truncate_query_for_log_truncates_by_chars_not_bytes() {
+        // Multi-byte chars: Cyrillic 'а' is 2 bytes. LOG_QUERY_MAX_CHARS
+        // characters of 'а' is 2 * LOG_QUERY_MAX_CHARS bytes; truncation
+        // must count chars, not bytes — otherwise a UTF-8 boundary slice
+        // panics or produces invalid UTF-8.
+        let q: String = "а".repeat(LOG_QUERY_MAX_CHARS + 10);
+        let out = truncate_query_for_log(&q);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod core_affinity;
 pub mod dashmap;
 pub mod debug_messages;
 pub mod rate_limit;
+pub mod strings;
 
 /// Format chrono::Duration in Go-style: `4m30s`, `1h30m`, `2d 4h30m`.
 pub fn format_duration(duration: &chrono::Duration) -> String {

--- a/src/utils/strings.rs
+++ b/src/utils/strings.rs
@@ -1,0 +1,179 @@
+//! Shared string-truncation helpers. Three call sites — Patroni REST
+//! error rendering, query previews for admin/UI, and per-eviction log
+//! lines — used to maintain their own inline copies; this module is the
+//! one place where the byte/char limits live.
+
+/// Maximum number of characters (not bytes — query text may contain
+/// multi-byte UTF-8) kept when a query is rendered into a log line.
+/// Long queries are truncated with an ellipsis so a runaway statement
+/// can't blow up a log shipper.
+pub const LOG_QUERY_MAX_CHARS: usize = 80;
+
+/// Maximum characters preserved in API/admin previews of a query
+/// (`/api/top/queries`, `/api/interner`, `SHOW QUERIES`). Wider than
+/// the log line because the consumer is interactive UI / `psql` output
+/// that can wrap rather than a single-line shipper.
+pub const PREVIEW_QUERY_MAX_CHARS: usize = 120;
+
+/// Truncate `s` to at most `max_bytes`, walking back to the nearest
+/// UTF-8 char boundary so the slice is always valid UTF-8. Zero-copy.
+/// Use this when the limit is a wire-protocol or log-shipper byte cap
+/// (Patroni REST error bodies, syslog line size) and you don't need
+/// an ellipsis.
+pub fn truncate_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Take the first `max_chars` characters of `s`. Allocates a fresh
+/// `String`. No ellipsis, no normalisation. Building block for the
+/// query-rendering helpers below.
+pub fn truncate_chars(s: &str, max_chars: usize) -> String {
+    s.chars().take(max_chars).collect()
+}
+
+/// Render a query string into a compact form safe for a single log
+/// line: CR/LF collapsed to spaces and trimmed to `LOG_QUERY_MAX_CHARS`
+/// characters with a trailing "..." when truncated. Always allocates;
+/// the `log` crate's macros already short-circuit argument evaluation
+/// below the active level, so a bare `trace!(...)` call is enough —
+/// explicit `log_enabled!` guards are only useful on hot paths where
+/// avoiding the allocation matters.
+pub fn truncate_query_for_log(query: &str) -> String {
+    let cleaned = query.replace(['\n', '\r'], " ");
+    if cleaned.chars().count() <= LOG_QUERY_MAX_CHARS {
+        return cleaned;
+    }
+    let mut out = truncate_chars(&cleaned, LOG_QUERY_MAX_CHARS);
+    out.push_str("...");
+    out
+}
+
+/// First `PREVIEW_QUERY_MAX_CHARS` characters of `query`, verbatim. No
+/// ellipsis, no newline collapse — preview surfaces (admin SHOW,
+/// `/api/top/queries`, `/api/interner`) are expected to render the
+/// text as-is so operators can read the original statement.
+pub fn preview_query(query: &str) -> String {
+    truncate_chars(query, PREVIEW_QUERY_MAX_CHARS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_bytes_passthrough_when_within_limit() {
+        assert_eq!(truncate_bytes("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_bytes_at_exact_limit() {
+        assert_eq!(truncate_bytes("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_bytes_walks_back_to_char_boundary() {
+        // Cyrillic 'я' is 2 bytes (0xD1 0x8F). Limit 3 sits mid-char of
+        // the second letter; truncate_bytes must back off to 2.
+        let s = "яя";
+        assert_eq!(s.len(), 4);
+        assert_eq!(truncate_bytes(s, 3), "я");
+    }
+
+    #[test]
+    fn truncate_bytes_zero_limit() {
+        assert_eq!(truncate_bytes("abc", 0), "");
+    }
+
+    #[test]
+    fn truncate_chars_caps_at_limit() {
+        let q: String = "a".repeat(10);
+        assert_eq!(truncate_chars(&q, 5), "aaaaa");
+    }
+
+    #[test]
+    fn truncate_chars_passthrough_when_within_limit() {
+        assert_eq!(truncate_chars("abc", 10), "abc");
+    }
+
+    #[test]
+    fn truncate_chars_counts_multi_byte_as_one() {
+        // Five 'я' chars = 10 bytes; truncate_chars(_, 5) keeps all five.
+        let q = "я".repeat(5);
+        let out = truncate_chars(&q, 5);
+        assert_eq!(out.chars().count(), 5);
+        assert_eq!(out, q);
+    }
+
+    #[test]
+    fn truncate_query_for_log_keeps_short_query_intact() {
+        assert_eq!(truncate_query_for_log("select 1"), "select 1");
+    }
+
+    #[test]
+    fn truncate_query_for_log_collapses_newlines_to_spaces() {
+        assert_eq!(
+            truncate_query_for_log("select\n1\rfrom\r\nt"),
+            "select 1 from  t"
+        );
+    }
+
+    #[test]
+    fn truncate_query_for_log_no_ellipsis_at_exact_limit() {
+        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS);
+        let out = truncate_query_for_log(&q);
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS);
+        assert!(!out.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_query_for_log_appends_ellipsis_past_limit() {
+        let q: String = "a".repeat(LOG_QUERY_MAX_CHARS + 5);
+        let out = truncate_query_for_log(&q);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
+    }
+
+    #[test]
+    fn truncate_query_for_log_empty_input() {
+        assert_eq!(truncate_query_for_log(""), "");
+    }
+
+    #[test]
+    fn truncate_query_for_log_truncates_by_chars_not_bytes() {
+        // Multi-byte chars: Cyrillic 'а' is 2 bytes. LOG_QUERY_MAX_CHARS
+        // characters of 'а' is 2 * LOG_QUERY_MAX_CHARS bytes; truncation
+        // must count chars, not bytes — otherwise a UTF-8 boundary slice
+        // panics or produces invalid UTF-8.
+        let q: String = "а".repeat(LOG_QUERY_MAX_CHARS + 10);
+        let out = truncate_query_for_log(&q);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), LOG_QUERY_MAX_CHARS + 3);
+    }
+
+    #[test]
+    fn preview_query_keeps_short_input_untouched() {
+        assert_eq!(preview_query("SELECT 1\nFROM t"), "SELECT 1\nFROM t");
+    }
+
+    #[test]
+    fn preview_query_caps_at_preview_max_no_ellipsis() {
+        let q: String = "a".repeat(PREVIEW_QUERY_MAX_CHARS + 50);
+        let out = preview_query(&q);
+        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
+        assert!(!out.ends_with("..."));
+    }
+
+    #[test]
+    fn preview_query_handles_multi_byte_chars() {
+        let q: String = "ы".repeat(PREVIEW_QUERY_MAX_CHARS + 5);
+        let out = preview_query(&q);
+        assert_eq!(out.chars().count(), PREVIEW_QUERY_MAX_CHARS);
+    }
+}

--- a/src/web/routes/collect/interner.rs
+++ b/src/web/routes/collect/interner.rs
@@ -51,7 +51,7 @@ pub(crate) fn collect_interner_top(n: u64) -> InternerTopDto {
                 Handle::Named(e) => e.text().clone(),
                 Handle::Anon(e) => e.text().clone(),
             };
-            let preview: String = text.chars().take(120).collect();
+            let preview = crate::server::preview_query(&text);
             InternerTopRowDto {
                 hash: format!("{:#x}", hash),
                 kind: kind.to_string(),

--- a/src/web/routes/collect/interner.rs
+++ b/src/web/routes/collect/interner.rs
@@ -51,7 +51,7 @@ pub(crate) fn collect_interner_top(n: u64) -> InternerTopDto {
                 Handle::Named(e) => e.text().clone(),
                 Handle::Anon(e) => e.text().clone(),
             };
-            let preview = crate::server::preview_query(&text);
+            let preview = crate::utils::strings::preview_query(&text);
             InternerTopRowDto {
                 hash: format!("{:#x}", hash),
                 kind: kind.to_string(),

--- a/src/web/routes/collect/top.rs
+++ b/src/web/routes/collect/top.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use crate::pool::get_all_pools;
-use crate::server::{anon_snapshot, named_snapshot};
+use crate::server::{anon_snapshot, named_snapshot, preview_query};
 use crate::stats::get_client_stats;
 use crate::web::routes::dto::{
     TopClientBy, TopClientFilters, TopClientRowDto, TopClientsDto, TopPreparedBy, TopPreparedDto,
@@ -139,7 +139,7 @@ pub(crate) fn collect_top_queries(filters: &TopQueryFilters) -> TopQueriesDto {
         } else {
             total_duration_us as f64 / count as f64 / 1_000.0
         };
-        let preview: String = entry.text().chars().take(120).collect();
+        let preview = preview_query(entry.text());
         rows.push(TopQueryRowDto {
             hash: format!("{:#x}", hash),
             kind: "named".to_string(),
@@ -157,7 +157,7 @@ pub(crate) fn collect_top_queries(filters: &TopQueryFilters) -> TopQueriesDto {
         } else {
             total_duration_us as f64 / count as f64 / 1_000.0
         };
-        let preview: String = entry.text().chars().take(120).collect();
+        let preview = preview_query(entry.text());
         rows.push(TopQueryRowDto {
             hash: format!("{:#x}", hash),
             kind: "anonymous".to_string(),

--- a/src/web/routes/collect/top.rs
+++ b/src/web/routes/collect/top.rs
@@ -1,8 +1,9 @@
 use std::sync::atomic::Ordering;
 
 use crate::pool::get_all_pools;
-use crate::server::{anon_snapshot, named_snapshot, preview_query};
+use crate::server::{anon_snapshot, named_snapshot};
 use crate::stats::get_client_stats;
+use crate::utils::strings::preview_query;
 use crate::web::routes::dto::{
     TopClientBy, TopClientFilters, TopClientRowDto, TopClientsDto, TopPreparedBy, TopPreparedDto,
     TopPreparedFilters, TopPreparedRowDto, TopQueriesDto, TopQueryBy, TopQueryFilters,


### PR DESCRIPTION
## Summary

- Each eviction from the NAMED/ANON query interners and the per-client anonymous LRU now emits one TRACE line (hash, bytes, anon idle_ms, truncated query). The interner GC tokio task additionally emits one DEBUG aggregate per sweep that actually dropped something.
- Default INFO behaviour is unchanged. Operators flip per-module trace at runtime via the existing admin command, e.g. `SET log_level = 'info,pg_doorman::server::prepared_statement_cache=trace,pg_doorman::client::protocol=trace'`. TRACE branches in the client hot path are gated by `log_enabled!` so production-level cost is zero.
- Three inline copies of the 80-char-with-ellipsis snippet (pool-cache eviction log, client cache-hit debug, statement-mapping debug) collapsed into a shared `truncate_query_for_log` helper with six unit tests covering short input, CR/LF collapse, exact-limit boundary, past-limit ellipsis, empty string, and multi-byte UTF-8.

## Why

Before this change `pg_doorman_query_interner_evictions_total` and `pg_doorman_clients_prepared_anonymous_evictions_total` were the only operator-visible signal — aggregate counters with no way to see *which* queries dropped, how stale they were, or how often. Dynamic `SET log_level` had nothing to expose in those modules, so triage of a synthetic-miss spike required external instrumentation.

## Test plan

- [x] `cargo test --lib` — 1125 pass; 1 pre-existing flaky on master (`web::metrics::tests::test_prometheus_server_basic`, `Connection reset by peer`), reproduced 3/3 on clean `master` locally.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests --bins -- --deny warnings`
- [ ] Manual smoke: bring up pg_doorman, set `query_interner_anon_idle_ttl_seconds = 1` + small `client_anonymous_prepared_cache_size`, run a flock of `psql` clients with `BEGIN ... PREPARE ANONYMOUS ...`, then `SET log_level = '...=trace'` via admin and confirm per-eviction TRACE lines appear and disappear when the level is lowered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)