### PR TITLE
fix: do not amplify EMFILE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.10.1"
+version = "3.10.5"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.10.1"
+version = "3.10.5"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,48 @@
 # Changelog
 
+### 3.10.5
+
+#### Binary upgrade survives a tight `RLIMIT_NOFILE`
+
+SIGUSR2 binary upgrade now handles `EMFILE`/`ENFILE` from the old
+process without spinning in the accept loop or overfilling the migration
+queue.
+
+* The TCP and Unix accept loops treat `EMFILE`/`ENFILE` as local resource
+  pressure: they sleep for 10 ms and log at most once every 5 seconds.
+  Other accept errors still log normally.
+
+* The migration channel is no longer fixed at 4096 entries. At upgrade
+  time pg_doorman reads the current `RLIMIT_NOFILE`, counts open fds via
+  `/proc/self/fd`, reserves headroom for the handoff pipe/socketpair and
+  per-client fd work, and caps the queue by the remaining budget. If no
+  safe headroom remains, pg_doorman starts the new process without client
+  migration and logs the budget decision.
+
+* Client migration reserves a channel slot before calling `dup()` on the
+  client fd. A full channel now applies backpressure before creating an
+  extra fd.
+
+If the pre-flight `pg_doorman -t` spawn fails with local `EMFILE`/`ENFILE`,
+pg_doorman skips that validation step and continues with the binary
+upgrade. Other validation failures still abort the upgrade before shutdown.
+
+#### `/metrics` scrape uses cached socket-state counts
+
+`/metrics` no longer walks `/proc/PID/net/tcp` and `/proc/PID/net/unix`
+on the request path. On hosts with thousands of sockets, that synchronous
+walk could hold worker threads long enough for regular Prometheus scrapes
+to increase client p99.
+
+Socket-state counts now live in a cached `ArcSwap` snapshot refreshed by a
+background `spawn_blocking` task. The `/metrics` handler, periodic
+`print_all_stats` output, and admin `SHOW SOCKETS` command read the cached
+snapshot. The Web UI sockets endpoint still refreshes socket details on
+demand for operator use.
+
+The cache keeps scrape cost independent of the number of live sockets in
+the common Prometheus path.
+
 ### 3.10.1
 
 #### Configurable kernel TCP socket buffer size
@@ -839,7 +882,7 @@ The direct-handoff queue is FIFO. On a 500-client / 40-connection AWS Fargate be
 
 - **`server_lifetime` default changed from 5 minutes to 20 minutes**: The previous default of 5 minutes was shorter than `idle_timeout` (10 minutes), which meant `idle_timeout` could never trigger — connections were always killed by `server_lifetime` first. Changed to 20 minutes so that `idle_timeout` (10 min) handles idle cleanup while `server_lifetime` (20 min) rotates long-lived connections. Note: `idle_timeout` only applies to connections that have been used at least once — prewarmed/replenished connections that were never checked out by a client are not subject to `idle_timeout` and will only be closed when `server_lifetime` expires.
 
-- **`idle_timeout = 0` did not disable idle timeout**: Setting `idle_timeout` to `0` was supposed to disable idle connection cleanup (consistent with PgBouncer's `server_idle_timeout = 0` semantics and our own `server_lifetime = 0` behavior). Instead, it closed connections after ~1ms of being idle. Fixed by adding an `idle_timeout_ms > 0` guard before the elapsed time check.
+- **`idle_timeout = 0` did not disable idle timeout**: `idle_timeout = 0` should disable idle connection cleanup, matching PgBouncer's `server_idle_timeout = 0` and pg_doorman's `server_lifetime = 0`. Instead, pg_doorman closed connections after ~1 ms of idle time. Fixed by adding an `idle_timeout_ms > 0` guard before the elapsed-time check.
 
 - **`idle_timeout` had no jitter — synchronized mass closures**: Unlike `server_lifetime` which applies ±20% per-connection jitter to prevent thundering herd, `idle_timeout` used a single pool-wide value. When many connections became idle simultaneously (e.g., after a traffic burst), they all expired at the exact same moment, causing mass closures in one retain cycle. Now `idle_timeout` applies the same ±20% per-connection jitter as `server_lifetime`.
 
@@ -1063,7 +1106,7 @@ The direct-handoff queue is FIFO. On a 500-client / 40-connection AWS Fargate be
 
 **Testing:**
 
-- **Integration fuzz testing framework**: Added comprehensive BDD-based fuzz tests (`@fuzz` tag) that verify pg_doorman's resilience to malformed PostgreSQL protocol messages.
+- **Integration fuzz tests**: Added BDD fuzz tests (`@fuzz` tag) for malformed PostgreSQL protocol messages.
 - All fuzz tests connect and authenticate first, then send malformed data to test post-authentication resilience.
 
 **CI/CD:**
@@ -1090,8 +1133,8 @@ The direct-handoff queue is FIFO. On a 500-client / 40-connection AWS Fargate be
 
 **Testing:**
 
-- Added comprehensive .NET client tests for Describe flow with cached prepared statements (`describe_flow_cached.cs`).
-- Added aggressive mixed tests combining batch operations, prepared statements, and extended protocol (`aggressive_mixed.cs`).
+- Added .NET client tests for Describe flow with cached prepared statements (`describe_flow_cached.cs`).
+- Added mixed tests combining batch operations, prepared statements, and extended protocol (`aggressive_mixed.cs`).
 
 ### 3.0.2 <small>Jan 14, 2026</small>
 
@@ -1111,13 +1154,14 @@ The direct-handoff queue is FIFO. On a 500-client / 40-connection AWS Fargate be
 
 ### 3.0.0 <small>Jan 12, 2026</small>
 
-**Major Release — Complete Architecture Refactoring**
+**Architecture refactor**
 
-This release represents a significant milestone with a complete codebase refactoring that dramatically improves async protocol support, making PgDoorman the most efficient connection pooler for asynchronous PostgreSQL workloads.
+PgDoorman 3.0.0 reorganizes the client, config, admin, auth, and
+prometheus modules, and adds the `patroni_proxy` binary.
 
 **New Features:**
 
-- **patroni_proxy** — A new high-performance TCP proxy for Patroni-managed PostgreSQL clusters:
+- **patroni_proxy** — a TCP proxy for Patroni-managed PostgreSQL clusters:
     - Zero-downtime connection management — existing connections are preserved during cluster topology changes
     - Hot upstream updates — automatic discovery of cluster members via Patroni REST API without connection drops
     - Role-based routing — route connections to leader, sync replicas, or async replicas based on configuration
@@ -1126,15 +1170,14 @@ This release represents a significant milestone with a complete codebase refacto
 
 **Improvements:**
 
-- **Complete codebase refactoring** — modular architecture with better separation of concerns:
+- **Module split**:
     - Client handling split into dedicated modules (core, entrypoint, protocol, startup, transaction)
     - Configuration system reorganized into focused modules (general, pool, user, tls, prometheus, talos)
     - Admin, auth, and prometheus subsystems extracted into separate modules
-    - Improved code maintainability and testability
-- **Enhanced async protocol support** — significantly improved handling of asynchronous PostgreSQL protocol, providing better performance than other connection poolers for async workloads
-- **Extended protocol improvements** — better client buffering and message handling for extended query protocol
+- **Async protocol support** — improved handling of asynchronous PostgreSQL protocol messages.
+- **Extended protocol** — improved client buffering and message handling.
 - **xxhash3 for prepared statement hashing** — faster hash computation for prepared statement cache
-- **Comprehensive BDD testing framework** — multi-language integration tests (Go, Rust, Python, Node.js, .NET) with Docker-based reproducible environment
+- **BDD test framework** — multi-language integration tests (Go, Rust, Python, Node.js, .NET) in a Docker-based environment.
 
 ### 2.5.0 <small>Nov 18, 2025</small>
 

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -39,6 +39,11 @@ use crate::client::migration::{migration_receiver_task, migration_sender_task};
 /// Global counter for clients currently connected to the pg_doorman
 pub static CURRENT_CLIENT_COUNT: AtomicI64 = AtomicI64::new(0);
 
+/// Unix-epoch second of the last EMFILE/ENFILE error logged from the
+/// listener accept loop. Used to rate-limit the message so an exhausted
+/// fd table does not produce hundreds of identical lines per second.
+static ACCEPT_RESOURCE_LOG_LAST: AtomicI64 = AtomicI64::new(0);
+
 /// Global flag indicating graceful shutdown is in progress
 pub static SHUTDOWN_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
@@ -656,7 +661,37 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                     let (mut socket, addr) = match new_client {
                         Ok((socket, addr)) => (socket, addr),
                         Err(err) => {
-                            error!("Failed to accept new connection: {err}");
+                            // EMFILE/ENFILE on accept means the process fd
+                            // table is full. Without a backoff the loop
+                            // re-arms immediately on every queued SYN —
+                            // CPU spins, the log gets thousands of
+                            // identical lines per millisecond, and nothing
+                            // is freed by the loop itself. Sleep so the
+                            // kernel can drain its SYN-ack retry budget
+                            // (clients eventually give up) and so other
+                            // tasks have a chance to release fds. The log
+                            // is throttled to one line per 5 s; the
+                            // backoff prevents tight-loop CPU burn.
+                            if matches!(
+                                err.raw_os_error(),
+                                Some(libc::EMFILE) | Some(libc::ENFILE)
+                            ) {
+                                let now_secs = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs() as i64)
+                                    .unwrap_or(0);
+                                let last = ACCEPT_RESOURCE_LOG_LAST
+                                    .swap(now_secs, Ordering::Relaxed);
+                                if now_secs - last >= 5 {
+                                    error!(
+                                        "Failed to accept new connection: {err} \
+                                         (process fd table exhausted; backing off)"
+                                    );
+                                }
+                                tokio::time::sleep(Duration::from_millis(100)).await;
+                            } else {
+                                error!("Failed to accept new connection: {err}");
+                            }
                             continue;
                         }
                     };
@@ -718,7 +753,29 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                     let (socket, _unix_addr) = match new_unix {
                         Ok(pair) => pair,
                         Err(err) => {
-                            error!("Failed to accept Unix connection: {err}");
+                            // Same EMFILE/ENFILE backoff as the TCP accept
+                            // loop above. Without it an exhausted fd table
+                            // turns this branch into a tight loop.
+                            if matches!(
+                                err.raw_os_error(),
+                                Some(libc::EMFILE) | Some(libc::ENFILE)
+                            ) {
+                                let now_secs = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs() as i64)
+                                    .unwrap_or(0);
+                                let last = ACCEPT_RESOURCE_LOG_LAST
+                                    .swap(now_secs, Ordering::Relaxed);
+                                if now_secs - last >= 5 {
+                                    error!(
+                                        "Failed to accept Unix connection: {err} \
+                                         (process fd table exhausted; backing off)"
+                                    );
+                                }
+                                tokio::time::sleep(Duration::from_millis(100)).await;
+                            } else {
+                                error!("Failed to accept Unix connection: {err}");
+                            }
                             continue;
                         }
                     };
@@ -909,19 +966,50 @@ async fn binary_upgrade_and_shutdown(
                 info!("Configuration validation successful");
             }
             Err(e) => {
-                error!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                error!("!!!                    CRITICAL ERROR                               !!!");
-                error!("!!!         FAILED TO VALIDATE CONFIGURATION                       !!!");
-                error!("!!!         BINARY UPGRADE ABORTED - SHUTDOWN CANCELLED            !!!");
-                error!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                error!("");
-                error!("Could not execute configuration test: {}", e);
-                error!("Binary path: {}", exe_path);
-                error!("");
-                error!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                error!("!!!  THE SERVER WILL CONTINUE RUNNING WITH THE CURRENT BINARY      !!!");
-                error!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                return None;
+                // EMFILE/ENFILE here means the local fd table is full, so
+                // `Command::output()` can't even spawn the validator. That
+                // is a local resource state, not a config problem; aborting
+                // the upgrade keeps the parent stuck in the same exhausted
+                // state. Skip the pre-flight check, log a WARN, and let the
+                // upgrade proceed so the child can take over and the
+                // parent's fds drain through client migration.
+                if matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE)) {
+                    warn!(
+                        "Skipping pre-flight configuration validation: local fd \
+                         table exhausted ({e}). Proceeding with binary upgrade so \
+                         the child can drain the parent's fds via migration."
+                    );
+                } else {
+                    error!(
+                        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                    );
+                    error!(
+                        "!!!                    CRITICAL ERROR                               !!!"
+                    );
+                    error!(
+                        "!!!         FAILED TO VALIDATE CONFIGURATION                       !!!"
+                    );
+                    error!(
+                        "!!!         BINARY UPGRADE ABORTED - SHUTDOWN CANCELLED            !!!"
+                    );
+                    error!(
+                        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                    );
+                    error!("");
+                    error!("Could not execute configuration test: {}", e);
+                    error!("Binary path: {}", exe_path);
+                    error!("");
+                    error!(
+                        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                    );
+                    error!(
+                        "!!!  THE SERVER WILL CONTINUE RUNNING WITH THE CURRENT BINARY      !!!"
+                    );
+                    error!(
+                        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                    );
+                    return None;
+                }
             }
         }
     }

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -750,7 +750,7 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                                          (process fd table exhausted; backing off)"
                                     );
                                 }
-                                tokio::time::sleep(Duration::from_millis(100)).await;
+                                tokio::time::sleep(Duration::from_millis(10)).await;
                             } else {
                                 error!("Failed to accept new connection: {err}");
                             }
@@ -834,7 +834,7 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                                          (process fd table exhausted; backing off)"
                                     );
                                 }
-                                tokio::time::sleep(Duration::from_millis(100)).await;
+                                tokio::time::sleep(Duration::from_millis(10)).await;
                             } else {
                                 error!("Failed to accept Unix connection: {err}");
                             }

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -83,40 +83,52 @@ pub static MIGRATION_TX: std::sync::OnceLock<mpsc::Sender<MigrationPayload>> =
 /// in flight; beyond that the sender is the bottleneck, not the buffer.
 const MIGRATION_CHANNEL_CAPACITY_MAX: usize = 4096;
 
-/// Floor on the migration channel capacity so migration can make at
-/// least *some* forward progress even on a very tight nofile budget.
-/// 64 still respects the upper budget calculation when soft limit is
-/// barely above it; if it doesn't, migration is broken regardless of
-/// what number we pick.
-const MIGRATION_CHANNEL_CAPACITY_MIN: usize = 64;
+/// Fds the migration step needs beyond whatever the parent already has
+/// open at the moment `safe_migration_capacity` runs: the parent half
+/// of the migration socketpair stays open until the sender task drains
+/// it, the readiness pipe consumes one parent-side fd until the new
+/// process signals back, and `migration_sender_task` itself opens a
+/// short-lived dirfd on `/proc/PID/net/tcp` per migrated client. The
+/// reserve keeps a margin between the channel queue and the soft limit
+/// so those concurrent fds do not push the parent over the edge during
+/// migration.
+const MIGRATION_SPAWN_RESERVE_FDS: u64 = 16;
 
-/// File descriptors the parent keeps open outside the migration queue:
-/// listeners, backends, runtime internals (epoll, signal fds), stdio,
-/// and the migration socketpair + readiness pipe. Conservative — the
-/// real footprint at the moment migration starts is closer to 30, but
-/// reserving 128 keeps a small safety net for misbehaving plugins or
-/// future additions that quietly take an extra fd.
-const MIGRATION_PARENT_RESERVED_FDS: u64 = 128;
+/// Count file descriptors currently open by this process by walking
+/// `/proc/self/fd`. SIGUSR2 binary upgrade is a rare event, so the O(N)
+/// readdir cost is acceptable; in exchange we get a true live measurement
+/// instead of a guess from `RLIMIT_NOFILE` alone. Returns `None` on
+/// platforms without `/proc` so callers can fall back.
+#[cfg(target_os = "linux")]
+fn count_open_fds() -> Option<u64> {
+    std::fs::read_dir("/proc/self/fd")
+        .ok()
+        .map(|entries| entries.count() as u64)
+}
 
-/// Compute a migration channel capacity that respects the current
-/// `RLIMIT_NOFILE` soft limit. Each pending entry on the channel is a
-/// `dup`'d fd in the parent (the original client fd is still open until
-/// the client task finishes after sendmsg succeeds), so the worst-case
-/// fd usage during migration is approximately
-/// `live_clients + channel_depth + reserve`. Once that total crosses the
-/// limit the parent itself starts failing to open new fds — including
-/// the next `connect()` to a backend — which is exactly the EMFILE
-/// pattern this PR is here to prevent.
+#[cfg(not(target_os = "linux"))]
+fn count_open_fds() -> Option<u64> {
+    None
+}
+
+/// Compute a migration channel capacity that fits inside whatever fd
+/// budget the parent has *right now*. Each pending entry on the channel
+/// is a `dup`'d fd held in the parent until `migration_sender_task`
+/// drains it — without an upper bound the queue can grow past
+/// `RLIMIT_NOFILE` and turn the parent into a self-induced EMFILE
+/// generator.
 ///
-/// The formula gives the channel roughly half the available headroom
-/// after the reserve so that even with `live_clients ≈ channel_depth`
-/// (the worst case while migration is in flight) we stay under the
-/// soft limit with room to spare. Numbers from a 6200-limit, ~3K-client
-/// pooler land around capacity ~3000; numbers from a generous 65536
-/// limit land at the ceiling. The capacity is logged once at the start
-/// of migration so operators see what the daemon chose for them.
+/// `live_count + queued_dups + spawn_reserve` ≤ soft_limit must hold at
+/// every moment of migration. `live_count` is already on the books when
+/// we count `/proc/self/fd`, so the available headroom after reserving
+/// the spawn fds is exactly the budget we can hand to the queue without
+/// any further `/N` math.
+///
+/// Returns `None` when the headroom is zero — the caller treats that as
+/// "skip migration, run a normal graceful shutdown". Better to drop
+/// in-flight session continuity than to drive the parent over the limit.
 #[cfg(unix)]
-fn safe_migration_capacity() -> usize {
+fn safe_migration_capacity() -> Option<usize> {
     // SAFETY: `getrlimit` is async-signal-safe and writes only into the
     // local `rl` buffer we pass in. No global state involved.
     let soft_limit = unsafe {
@@ -130,17 +142,60 @@ fn safe_migration_capacity() -> usize {
             MIGRATION_CHANNEL_CAPACITY_MAX as u64
         }
     };
-    let budget = soft_limit.saturating_sub(MIGRATION_PARENT_RESERVED_FDS);
-    let capacity = (budget / 2) as usize;
-    capacity.clamp(
-        MIGRATION_CHANNEL_CAPACITY_MIN,
-        MIGRATION_CHANNEL_CAPACITY_MAX,
-    )
+    // No /proc/self/fd: pessimistic guess so we don't oversubscribe.
+    // Halfway between zero and the soft limit is the worst that a
+    // running pooler could realistically be at.
+    let open_fds = count_open_fds().unwrap_or(soft_limit / 2);
+    let headroom = soft_limit
+        .saturating_sub(open_fds)
+        .saturating_sub(MIGRATION_SPAWN_RESERVE_FDS);
+    if headroom == 0 {
+        return None;
+    }
+    Some((headroom as usize).clamp(1, MIGRATION_CHANNEL_CAPACITY_MAX))
 }
 
 #[cfg(not(unix))]
-fn safe_migration_capacity() -> usize {
-    MIGRATION_CHANNEL_CAPACITY_MAX
+fn safe_migration_capacity() -> Option<usize> {
+    Some(MIGRATION_CHANNEL_CAPACITY_MAX)
+}
+
+/// Minimum gap between two consecutive accept-loop EMFILE/ENFILE log lines.
+const ACCEPT_RESOURCE_LOG_INTERVAL_SECS: i64 = 5;
+
+/// Returns `true` when an `io::Error` from the accept syscall reflects a
+/// fully booked fd table (EMFILE or ENFILE). Both the TCP and Unix
+/// accept arms, and the pre-flight validator launch in
+/// `binary_upgrade_and_shutdown`, branch on the same condition and the
+/// shared check keeps that classification in one place.
+#[cfg(unix)]
+fn is_fd_exhaustion_io(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE),)
+}
+
+/// Single-flight throttle for the listener's "fd table exhausted" log
+/// line. Returns `true` only when the previous successful emission is
+/// at least `ACCEPT_RESOURCE_LOG_INTERVAL_SECS` in the past.
+///
+/// Uses `compare_exchange` rather than `swap` so a suppressed attempt
+/// does *not* slide the throttle window forward. With `swap` the very
+/// first EMFILE updates the last-seen timestamp; every subsequent error
+/// in the same second computes `now - last ≈ 0` and stays silent — even
+/// after five minutes of unbroken storm — because the timestamp keeps
+/// being refreshed by attempts that themselves never logged. CAS keeps
+/// `last` frozen at the timestamp of the most recent *emitted* line, so
+/// the next line is guaranteed to appear once that line is older than
+/// the interval.
+fn should_log_accept_resource_now() -> bool {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let last = ACCEPT_RESOURCE_LOG_LAST.load(Ordering::Relaxed);
+    now_secs.saturating_sub(last) >= ACCEPT_RESOURCE_LOG_INTERVAL_SECS
+        && ACCEPT_RESOURCE_LOG_LAST
+            .compare_exchange(last, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
 }
 
 pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::Error>> {
@@ -734,17 +789,8 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                             // tasks have a chance to release fds. The log
                             // is throttled to one line per 5 s; the
                             // backoff prevents tight-loop CPU burn.
-                            if matches!(
-                                err.raw_os_error(),
-                                Some(libc::EMFILE) | Some(libc::ENFILE)
-                            ) {
-                                let now_secs = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map(|d| d.as_secs() as i64)
-                                    .unwrap_or(0);
-                                let last = ACCEPT_RESOURCE_LOG_LAST
-                                    .swap(now_secs, Ordering::Relaxed);
-                                if now_secs - last >= 5 {
+                            if is_fd_exhaustion_io(&err) {
+                                if should_log_accept_resource_now() {
                                     error!(
                                         "Failed to accept new connection: {err} \
                                          (process fd table exhausted; backing off)"
@@ -818,17 +864,8 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                             // Same EMFILE/ENFILE backoff as the TCP accept
                             // loop above. Without it an exhausted fd table
                             // turns this branch into a tight loop.
-                            if matches!(
-                                err.raw_os_error(),
-                                Some(libc::EMFILE) | Some(libc::ENFILE)
-                            ) {
-                                let now_secs = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map(|d| d.as_secs() as i64)
-                                    .unwrap_or(0);
-                                let last = ACCEPT_RESOURCE_LOG_LAST
-                                    .swap(now_secs, Ordering::Relaxed);
-                                if now_secs - last >= 5 {
+                            if is_fd_exhaustion_io(&err) {
+                                if should_log_accept_resource_now() {
                                     error!(
                                         "Failed to accept Unix connection: {err} \
                                          (process fd table exhausted; backing off)"
@@ -1035,7 +1072,7 @@ async fn binary_upgrade_and_shutdown(
                 // state. Skip the pre-flight check, log a WARN, and let the
                 // upgrade proceed so the child can take over and the
                 // parent's fds drain through client migration.
-                if matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE)) {
+                if is_fd_exhaustion_io(&e) {
                     warn!(
                         "Skipping pre-flight configuration validation: local fd \
                          table exhausted ({e}). Proceeding with binary upgrade so \
@@ -1239,27 +1276,50 @@ async fn binary_upgrade_and_shutdown(
                         *listener = None;
 
                         // Start client migration if socketpair was created
+                        // *and* the live nofile budget has room for the queue.
+                        // safe_migration_capacity returns None when current fd
+                        // usage plus the spawn reserve already meet the soft
+                        // limit; pushing dup'd fds onto a channel in that
+                        // condition would drive the parent over the limit and
+                        // is precisely the failure mode this PR was opened to
+                        // prevent. Better to drop session continuity than to
+                        // induce EMFILE on the way to a graceful shutdown.
                         if migration_ok {
-                            let capacity = safe_migration_capacity();
-                            info!(
-                                "Migration channel capacity: {capacity} (clamped to \
-                                 [{MIGRATION_CHANNEL_CAPACITY_MIN}, \
-                                 {MIGRATION_CHANNEL_CAPACITY_MAX}] by current RLIMIT_NOFILE)"
-                            );
-                            let (tx, rx) = mpsc::channel(capacity);
-                            let _ = MIGRATION_TX.set(tx);
-                            // MIGRATION_IN_PROGRESS already set above (before SHUTDOWN)
-                            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-                            let sender_handle = tokio::spawn(migration_sender_task(
-                                migration_parent_fd,
-                                rx,
-                                shutdown_rx,
-                            ));
-                            migration_handles = Some(MigrationHandles {
-                                shutdown_tx,
-                                sender_handle,
-                            });
-                            info!("Client migration enabled");
+                            match safe_migration_capacity() {
+                                Some(capacity) => {
+                                    info!(
+                                        "Migration channel capacity: {capacity} \
+                                         (capped at {MIGRATION_CHANNEL_CAPACITY_MAX} \
+                                         by the live RLIMIT_NOFILE headroom)"
+                                    );
+                                    let (tx, rx) = mpsc::channel(capacity);
+                                    let _ = MIGRATION_TX.set(tx);
+                                    let (shutdown_tx, shutdown_rx) =
+                                        tokio::sync::oneshot::channel();
+                                    let sender_handle = tokio::spawn(migration_sender_task(
+                                        migration_parent_fd,
+                                        rx,
+                                        shutdown_rx,
+                                    ));
+                                    migration_handles = Some(MigrationHandles {
+                                        shutdown_tx,
+                                        sender_handle,
+                                    });
+                                    info!("Client migration enabled");
+                                }
+                                None => {
+                                    warn!(
+                                        "Migration channel disabled: no fd headroom \
+                                         left under the current RLIMIT_NOFILE; clients \
+                                         will reconnect to the new process instead of \
+                                         migrating sessions"
+                                    );
+                                    // Close the unused migration socketpair half
+                                    // we still hold so it doesn't sit in the fd
+                                    // table during the graceful shutdown.
+                                    unsafe { libc::close(migration_parent_fd) };
+                                }
+                            }
                         }
 
                         info!("Foreground binary upgrade complete, listener released");

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -77,9 +77,71 @@ pub static STARTED_AT_MS: std::sync::LazyLock<u64> = std::sync::LazyLock::new(||
 pub static MIGRATION_TX: std::sync::OnceLock<mpsc::Sender<MigrationPayload>> =
     std::sync::OnceLock::new();
 
-/// Max buffered migration payloads before sender blocks.
-/// Sized to handle all clients migrating simultaneously without contention.
-const MIGRATION_CHANNEL_CAPACITY: usize = 4096;
+/// Upper bound on the migration channel capacity. Past this we stop
+/// growing the buffer regardless of how generous the nofile limit is —
+/// the parent does not need more than a few thousand pending dup'd fds
+/// in flight; beyond that the sender is the bottleneck, not the buffer.
+const MIGRATION_CHANNEL_CAPACITY_MAX: usize = 4096;
+
+/// Floor on the migration channel capacity so migration can make at
+/// least *some* forward progress even on a very tight nofile budget.
+/// 64 still respects the upper budget calculation when soft limit is
+/// barely above it; if it doesn't, migration is broken regardless of
+/// what number we pick.
+const MIGRATION_CHANNEL_CAPACITY_MIN: usize = 64;
+
+/// File descriptors the parent keeps open outside the migration queue:
+/// listeners, backends, runtime internals (epoll, signal fds), stdio,
+/// and the migration socketpair + readiness pipe. Conservative — the
+/// real footprint at the moment migration starts is closer to 30, but
+/// reserving 128 keeps a small safety net for misbehaving plugins or
+/// future additions that quietly take an extra fd.
+const MIGRATION_PARENT_RESERVED_FDS: u64 = 128;
+
+/// Compute a migration channel capacity that respects the current
+/// `RLIMIT_NOFILE` soft limit. Each pending entry on the channel is a
+/// `dup`'d fd in the parent (the original client fd is still open until
+/// the client task finishes after sendmsg succeeds), so the worst-case
+/// fd usage during migration is approximately
+/// `live_clients + channel_depth + reserve`. Once that total crosses the
+/// limit the parent itself starts failing to open new fds — including
+/// the next `connect()` to a backend — which is exactly the EMFILE
+/// pattern this PR is here to prevent.
+///
+/// The formula gives the channel roughly half the available headroom
+/// after the reserve so that even with `live_clients ≈ channel_depth`
+/// (the worst case while migration is in flight) we stay under the
+/// soft limit with room to spare. Numbers from a 6200-limit, ~3K-client
+/// pooler land around capacity ~3000; numbers from a generous 65536
+/// limit land at the ceiling. The capacity is logged once at the start
+/// of migration so operators see what the daemon chose for them.
+#[cfg(unix)]
+fn safe_migration_capacity() -> usize {
+    // SAFETY: `getrlimit` is async-signal-safe and writes only into the
+    // local `rl` buffer we pass in. No global state involved.
+    let soft_limit = unsafe {
+        let mut rl: libc::rlimit = std::mem::zeroed();
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 {
+            rl.rlim_cur as u64
+        } else {
+            // getrlimit cannot really fail for RLIMIT_NOFILE on Linux, but
+            // if it does (foreign kernel, sandbox), fall back to the hard
+            // ceiling so we behave like the previous hard-coded version.
+            MIGRATION_CHANNEL_CAPACITY_MAX as u64
+        }
+    };
+    let budget = soft_limit.saturating_sub(MIGRATION_PARENT_RESERVED_FDS);
+    let capacity = (budget / 2) as usize;
+    capacity.clamp(
+        MIGRATION_CHANNEL_CAPACITY_MIN,
+        MIGRATION_CHANNEL_CAPACITY_MAX,
+    )
+}
+
+#[cfg(not(unix))]
+fn safe_migration_capacity() -> usize {
+    MIGRATION_CHANNEL_CAPACITY_MAX
+}
 
 pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::Error>> {
     if args.daemon && std::env::var("NOTIFY_SOCKET").is_ok() {
@@ -1178,7 +1240,13 @@ async fn binary_upgrade_and_shutdown(
 
                         // Start client migration if socketpair was created
                         if migration_ok {
-                            let (tx, rx) = mpsc::channel(MIGRATION_CHANNEL_CAPACITY);
+                            let capacity = safe_migration_capacity();
+                            info!(
+                                "Migration channel capacity: {capacity} (clamped to \
+                                 [{MIGRATION_CHANNEL_CAPACITY_MIN}, \
+                                 {MIGRATION_CHANNEL_CAPACITY_MAX}] by current RLIMIT_NOFILE)"
+                            );
+                            let (tx, rx) = mpsc::channel(capacity);
                             let _ = MIGRATION_TX.set(tx);
                             // MIGRATION_IN_PROGRESS already set above (before SHUTDOWN)
                             let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();

--- a/src/client/transaction.rs
+++ b/src/client/transaction.rs
@@ -703,35 +703,54 @@ where
                                 self.username, self.pool_name, self.connection_id
                             );
                         }
-                        Some(tx) => match self.prepare_migration() {
-                            Err(e) => {
-                                warn!(
-                                    "[{}@{} #c{}] prepare_migration failed: {e}",
-                                    self.username, self.pool_name, self.connection_id
-                                );
-                            }
-                            Ok(payload) => match tx.try_send(payload) {
+                        Some(tx) => {
+                            // Reserve a channel slot *before* duplicating the
+                            // client fd. `prepare_migration` dups the socket
+                            // (and the protocol state buffers) on every call;
+                            // sending the resulting payload into a full channel
+                            // is a no-op that immediately drops the dup, which
+                            // closes the extra fd but still spent its kernel
+                            // allocation along the way. On a tight nofile
+                            // budget that can be the EMFILE that takes the
+                            // process down. `try_reserve` tells us up front
+                            // whether the migrator has room; if not, we let
+                            // the client keep talking to the old process and
+                            // the regular shutdown path will close the
+                            // session.
+                            match tx.try_reserve() {
                                 Err(e) => {
                                     warn!(
-                                        "[{}@{} #c{}] migration channel send failed: {e}",
+                                        "[{}@{} #c{}] migration channel reserve failed: {e}",
                                         self.username, self.pool_name, self.connection_id
                                     );
                                 }
-                                Ok(()) => {
-                                    info!(
-                                        "[{}@{} #c{}] client {} migrated to new process",
-                                        self.username,
-                                        self.pool_name,
-                                        self.connection_id,
-                                        self.addr
-                                    );
-                                    // Note: do NOT decrement CURRENT_CLIENT_COUNT here.
-                                    // The caller (server.rs accept loop) decrements it
-                                    // unconditionally after client_entrypoint() returns.
-                                    return Ok(());
-                                }
-                            },
-                        },
+                                Ok(permit) => match self.prepare_migration() {
+                                    Err(e) => {
+                                        warn!(
+                                            "[{}@{} #c{}] prepare_migration failed: {e}",
+                                            self.username, self.pool_name, self.connection_id
+                                        );
+                                        // Permit dropped here: the reserved
+                                        // slot is released back to the channel
+                                        // so a later client can use it.
+                                    }
+                                    Ok(payload) => {
+                                        permit.send(payload);
+                                        info!(
+                                            "[{}@{} #c{}] client {} migrated to new process",
+                                            self.username,
+                                            self.pool_name,
+                                            self.connection_id,
+                                            self.addr
+                                        );
+                                        // Note: do NOT decrement CURRENT_CLIENT_COUNT here.
+                                        // The caller (server.rs accept loop) decrements it
+                                        // unconditionally after client_entrypoint() returns.
+                                        return Ok(());
+                                    }
+                                },
+                            }
+                        }
                     }
                 }
             }

--- a/src/stats/print_all_stats.rs
+++ b/src/stats/print_all_stats.rs
@@ -55,11 +55,13 @@ pub fn print_all_stats() {
     {
         if clients_flag {
             // Background refresher keeps the cache fresh; the periodic
-            // stats logger does not need a real-time walk.
+            // stats logger does not need a real-time walk. The EMFILE
+            // downgrade from this PR's earlier draft is no longer needed
+            // here because no `/proc` walk happens on this code path —
+            // it can only return an error if the bootstrap walk in the
+            // background refresher itself failed, and that path already
+            // logs its own warn.
             match cached_socket_states_count(false) {
-                // The `Display` impl now emits the full `[sockets] ...` line
-                // so that grep/awk pipelines can parse it the same way as the
-                // pool-stats lines above.
                 Ok(info) => info!("{}", *info),
                 Err(err) => error!("[sockets] error: {err}"),
             };

--- a/tests/bdd/doorman_helper.rs
+++ b/tests/bdd/doorman_helper.rs
@@ -294,8 +294,8 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
         None => stderr_cfg,
     };
 
-    let child = Command::new(doorman_binary)
-        .arg(&config_path)
+    let mut cmd = Command::new(doorman_binary);
+    cmd.arg(&config_path)
         .arg("-l")
         .arg(log_level)
         .envs(
@@ -305,9 +305,27 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
                 .map(|(k, v)| (k.as_str(), v.as_str())),
         )
         .stdout(stdout_cfg)
-        .stderr(stderr_cfg)
-        .spawn()
-        .expect("Failed to start pg_doorman");
+        .stderr(stderr_cfg);
+
+    if let Some(nofile_limit) = world.doorman_nofile_limit {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: pre_exec runs between fork and exec in the child. setrlimit
+        // is async-signal-safe per POSIX. The closure captures only a primitive.
+        unsafe {
+            cmd.pre_exec(move || {
+                let rl = libc::rlimit {
+                    rlim_cur: nofile_limit as libc::rlim_t,
+                    rlim_max: nofile_limit as libc::rlim_t,
+                };
+                if libc::setrlimit(libc::RLIMIT_NOFILE, &rl) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    let child = cmd.spawn().expect("Failed to start pg_doorman");
 
     world.doorman_process = Some(child);
 
@@ -319,6 +337,19 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
         log_path.as_deref(),
     )
     .await;
+}
+
+/// Like `start_doorman_with_config`, but spawns pg_doorman with a tight
+/// `RLIMIT_NOFILE` soft limit applied via `pre_exec`. Used by migration-fd-budget
+/// scenarios that need to reproduce EMFILE pressure during binary upgrade.
+#[given(expr = "pg_doorman started with NOFILE limit {int} and config:")]
+pub async fn start_doorman_with_nofile_limit_and_config(
+    world: &mut DoormanWorld,
+    nofile_limit: u64,
+    step: &Step,
+) {
+    world.doorman_nofile_limit = Some(nofile_limit);
+    start_doorman_with_config(world, step).await;
 }
 
 #[given("pg_doorman shutdown-only mode")]

--- a/tests/bdd/extended/session_management.rs
+++ b/tests/bdd/extended/session_management.rs
@@ -3,15 +3,35 @@ use crate::world::DoormanWorld;
 use cucumber::{then, when};
 use log::info;
 use std::time::Duration;
+use tokio::task::JoinSet;
 use tokio::time::timeout;
 
-/// Best-effort batch session creation. Used by migration-fd-budget scenarios
-/// where the daemon's nofile limit is intentionally tight, so a subset of
-/// connect attempts is expected to be rejected. Each step is wrapped in a
-/// short timeout so a refusing daemon (or a kernel still retransmitting SYN
-/// on an unacked TCP open) does not stall the scenario for minutes.
-/// Successful sessions are stored under names `idle-0`, `idle-1`, ... so
-/// later steps can address them individually if needed.
+/// Key under which `attempt_create_idle_sessions` records the number of
+/// sessions it actually opened. Read back by
+/// `at least N sessions with prefix "idle-" should be open` so the
+/// scenario can assert that the parent pooler did not silently drop
+/// everyone to zero (which would make the post-upgrade SELECT vacuous).
+const ACCEPTED_VAR_KEY: &str = "last_idle_attempt_accepted";
+
+/// Concurrent best-effort batch session creation. Used by
+/// migration-fd-budget scenarios where the daemon's nofile limit is
+/// intentionally tight, so a subset of connect attempts is expected to
+/// be rejected.
+///
+/// Why parallel rather than sequential: a sequential loop replays the
+/// failure mode poorly. The original loop awaited each spawn before
+/// starting the next, so the accept loop processed one SYN at a time
+/// with the previous client already closed before the next arrived —
+/// the kernel's fd table never saw the simultaneous pressure that the
+/// production incident produced (~3K clients reconnecting after
+/// SIGUSR2). `JoinSet::spawn` releases every attempt onto the runtime
+/// before any joining starts; the daemon sees a true thundering herd.
+///
+/// Each spawn is wrapped in a short timeout so a refusing daemon (or
+/// the kernel still retransmitting SYN on an unacked TCP open) does
+/// not stall the scenario for minutes. Successful sessions are stored
+/// under names `idle-0`, `idle-1`, ... so later steps can address them
+/// individually if needed.
 #[when(
     regex = r#"^we attempt to create (\d+) idle sessions to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)"$"#
 )]
@@ -25,21 +45,20 @@ pub async fn attempt_create_idle_sessions(
     let doorman_port = world.doorman_port.expect("pg_doorman not started");
     let doorman_addr = format!("127.0.0.1:{}", doorman_port);
 
-    let step_timeout = Duration::from_millis(500);
+    let step_timeout = Duration::from_millis(2000);
 
-    let mut accepted = 0usize;
-    let mut timed_out = 0usize;
+    // PgConnection::authenticate panics on protocol-level FATAL (e.g.
+    // SQLSTATE 53300 "too many clients already") which is exactly what
+    // the server returns under overload — and the whole point of this
+    // step is to tolerate that. JoinSet captures the panic as JoinError
+    // instead of letting it abort the scenario.
+    let mut set: JoinSet<Result<(usize, PgConnection), &'static str>> = JoinSet::new();
     for idx in 0..count {
-        // PgConnection::authenticate panics on protocol-level FATAL (e.g.
-        // SQLSTATE 53300 "too many clients already") which is exactly what
-        // the server returns under overload — and the whole point of this
-        // step is to tolerate that. Spawn each attempt so JoinError catches
-        // the panic without taking the scenario down.
         let user = user.clone();
         let password = password.clone();
         let database = database.clone();
         let doorman_addr = doorman_addr.clone();
-        let attempt = tokio::spawn(async move {
+        set.spawn(async move {
             let mut conn = match timeout(step_timeout, PgConnection::connect(&doorman_addr)).await {
                 Ok(Ok(c)) => c,
                 Ok(Err(_)) => return Err("connect_err"),
@@ -53,22 +72,179 @@ pub async fn attempt_create_idle_sessions(
                 Ok(Ok(())) => {}
                 _ => return Err("authenticate_failed"),
             }
-            Ok(conn)
-        })
-        .await;
-        match attempt {
-            Ok(Ok(conn)) => {
+            Ok((idx, conn))
+        });
+    }
+
+    let mut accepted = 0usize;
+    let mut timed_out = 0usize;
+    let mut connect_err = 0usize;
+    let mut startup_failed = 0usize;
+    let mut authenticate_failed = 0usize;
+    let mut panicked = 0usize;
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(Ok((idx, conn))) => {
                 world.named_sessions.insert(format!("idle-{idx}"), conn);
                 accepted += 1;
             }
             Ok(Err("connect_timeout")) => timed_out += 1,
-            _ => {}
+            Ok(Err("connect_err")) => connect_err += 1,
+            Ok(Err("startup_failed")) => startup_failed += 1,
+            Ok(Err("authenticate_failed")) => authenticate_failed += 1,
+            Ok(Err(_)) => {}
+            Err(_) => panicked += 1,
         }
     }
+
+    world
+        .vars
+        .insert(ACCEPTED_VAR_KEY.to_string(), accepted.to_string());
     info!(
-        "attempt_create_idle_sessions: requested {count}, accepted {accepted} (rejected {}, timed_out {timed_out})",
-        count - accepted
+        "attempt_create_idle_sessions: requested {count}, accepted {accepted}, \
+         connect_err {connect_err}, connect_timeout {timed_out}, \
+         startup_failed {startup_failed}, authenticate_failed {authenticate_failed}, \
+         panicked {panicked}"
     );
+}
+
+/// Assert that the previous `attempt_create_idle_sessions` step left at
+/// least `min` sessions open. A scenario that asserts "the daemon
+/// stayed inside its fd budget" without also pinning down a minimum
+/// number of open sessions can pass with zero accepted clients — the
+/// post-upgrade `SELECT` would then have nothing to run against and
+/// the scenario silently degrades into a smoke test. Tying the count
+/// to `pool_size` makes the assertion meaningful: under
+/// `pool_size = 10` we always expect at least 10 sessions to make it
+/// through, otherwise the pool was the bottleneck rather than the
+/// listener.
+#[then(regex = r#"^at least (\d+) idle sessions should be open from the last batch attempt$"#)]
+pub async fn at_least_n_idle_sessions_open(world: &mut DoormanWorld, min: usize) {
+    let accepted: usize = world
+        .vars
+        .get(ACCEPTED_VAR_KEY)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    assert!(
+        accepted >= min,
+        "expected at least {min} accepted sessions from the last batch attempt, got {accepted}"
+    );
+}
+
+/// Verify the new pg_doorman process is actually servicing PostgreSQL
+/// protocol traffic, not just accepting TCP. A bare `TcpStream::connect`
+/// succeeds against either the old or the new process during the
+/// hand-off — both inherit the listening socket via SCM_RIGHTS and both
+/// may briefly answer SYNs in parallel — so we need a higher-level
+/// signal. A full `Startup → Authenticate → CloseSession` sequence
+/// fails if the new process is still booting (port routed but no
+/// async listener), if config validation aborted the spawn, or if the
+/// hand-off socketpair never closed cleanly. The connection is
+/// dropped immediately after a successful auth; this step asserts
+/// reachability, not durability.
+///
+/// Retries inside a fixed overall budget because the new process is
+/// in a brief stutter window right after
+/// `wait_for_foreground_binary_upgrade` returns: it has the listening
+/// fd but is still draining migration RX from the parent and
+/// bootstrapping its pool workers, so the first post-upgrade auth
+/// attempt can time out even though TCP `connect` already succeeded.
+/// Retrying keeps the assertion strict (we still demand a healthy
+/// session, not just an open socket) while avoiding a flake on the
+/// boundary case.
+#[then(
+    regex = r#"^a fresh PostgreSQL session to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)" succeeds$"#
+)]
+pub async fn fresh_pg_session_succeeds(
+    world: &mut DoormanWorld,
+    user: String,
+    password: String,
+    database: String,
+) {
+    let doorman_port = world.doorman_port.expect("pg_doorman not started");
+    let doorman_addr = format!("127.0.0.1:{}", doorman_port);
+    let attempt_timeout = Duration::from_secs(3);
+    let overall_budget = Duration::from_secs(20);
+    let retry_delay = Duration::from_millis(250);
+    let deadline = std::time::Instant::now() + overall_budget;
+
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        let outcome = async {
+            let mut conn = timeout(attempt_timeout, PgConnection::connect(&doorman_addr))
+                .await
+                .map_err(|_| "connect timed out".to_string())?
+                .map_err(|e| format!("connect failed: {e}"))?;
+            timeout(attempt_timeout, conn.send_startup(&user, &database))
+                .await
+                .map_err(|_| "send_startup timed out".to_string())?
+                .map_err(|e| format!("send_startup failed: {e}"))?;
+            timeout(attempt_timeout, conn.authenticate(&user, &password))
+                .await
+                .map_err(|_| "authenticate timed out".to_string())?
+                .map_err(|e| format!("authenticate failed: {e}"))?;
+            Ok::<(), String>(())
+        }
+        .await;
+
+        match outcome {
+            Ok(()) => return,
+            Err(reason) if std::time::Instant::now() >= deadline => {
+                panic!(
+                    "fresh session: gave up after {attempt} attempts ({}ms budget): {reason}",
+                    overall_budget.as_millis()
+                );
+            }
+            Err(_) => {
+                tokio::time::sleep(retry_delay).await;
+            }
+        }
+    }
+}
+
+/// Run a real SimpleQuery on the first surviving session from a batch
+/// created with prefix `idle-`. Used after `we wait for foreground
+/// binary upgrade to complete` to prove the session is still alive,
+/// migrated, and able to round-trip a query through whichever process
+/// is now servicing the port — not just answer a TCP `connect`.
+/// Stores the response under the chosen session's name so the standard
+/// `session "..." should receive DataRow with "..."` assertion picks
+/// it up unchanged.
+#[when(
+    regex = r#"^we send SimpleQuery "([^"]+)" to the first open idle session and store response as "([^"]+)"$"#
+)]
+pub async fn send_query_to_first_idle_session(
+    world: &mut DoormanWorld,
+    query: String,
+    out_session_name: String,
+) {
+    // The batch step inserts under "idle-{idx}" with idx ∈ [0, count).
+    // We don't know which one survived, so scan in idx order and use
+    // the first key that exists. This is deterministic across runs
+    // because indices are monotonic, but tolerant to indices missing
+    // (rejected attempts left a hole at that idx).
+    let name = world
+        .named_sessions
+        .keys()
+        .filter(|k| k.starts_with("idle-"))
+        .min_by_key(|k| {
+            k.strip_prefix("idle-")
+                .and_then(|n| n.parse::<usize>().ok())
+                .unwrap_or(usize::MAX)
+        })
+        .cloned()
+        .expect("no `idle-N` session available — batch step rejected all attempts");
+
+    let conn = super::helpers::get_session(&mut world.named_sessions, &name);
+    conn.send_simple_query(&query)
+        .await
+        .expect("Failed to send SimpleQuery to first idle session");
+    let messages = conn
+        .read_all_messages_until_ready()
+        .await
+        .expect("Failed to read SimpleQuery response from first idle session");
+    world.session_messages.insert(out_session_name, messages);
 }
 
 #[when(

--- a/tests/bdd/extended/session_management.rs
+++ b/tests/bdd/extended/session_management.rs
@@ -1,6 +1,75 @@
 use crate::pg_connection::PgConnection;
 use crate::world::DoormanWorld;
 use cucumber::{then, when};
+use log::info;
+use std::time::Duration;
+use tokio::time::timeout;
+
+/// Best-effort batch session creation. Used by migration-fd-budget scenarios
+/// where the daemon's nofile limit is intentionally tight, so a subset of
+/// connect attempts is expected to be rejected. Each step is wrapped in a
+/// short timeout so a refusing daemon (or a kernel still retransmitting SYN
+/// on an unacked TCP open) does not stall the scenario for minutes.
+/// Successful sessions are stored under names `idle-0`, `idle-1`, ... so
+/// later steps can address them individually if needed.
+#[when(
+    regex = r#"^we attempt to create (\d+) idle sessions to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)"$"#
+)]
+pub async fn attempt_create_idle_sessions(
+    world: &mut DoormanWorld,
+    count: usize,
+    user: String,
+    password: String,
+    database: String,
+) {
+    let doorman_port = world.doorman_port.expect("pg_doorman not started");
+    let doorman_addr = format!("127.0.0.1:{}", doorman_port);
+
+    let step_timeout = Duration::from_millis(500);
+
+    let mut accepted = 0usize;
+    let mut timed_out = 0usize;
+    for idx in 0..count {
+        // PgConnection::authenticate panics on protocol-level FATAL (e.g.
+        // SQLSTATE 53300 "too many clients already") which is exactly what
+        // the server returns under overload — and the whole point of this
+        // step is to tolerate that. Spawn each attempt so JoinError catches
+        // the panic without taking the scenario down.
+        let user = user.clone();
+        let password = password.clone();
+        let database = database.clone();
+        let doorman_addr = doorman_addr.clone();
+        let attempt = tokio::spawn(async move {
+            let mut conn = match timeout(step_timeout, PgConnection::connect(&doorman_addr)).await {
+                Ok(Ok(c)) => c,
+                Ok(Err(_)) => return Err("connect_err"),
+                Err(_) => return Err("connect_timeout"),
+            };
+            match timeout(step_timeout, conn.send_startup(&user, &database)).await {
+                Ok(Ok(())) => {}
+                _ => return Err("startup_failed"),
+            }
+            match timeout(step_timeout, conn.authenticate(&user, &password)).await {
+                Ok(Ok(())) => {}
+                _ => return Err("authenticate_failed"),
+            }
+            Ok(conn)
+        })
+        .await;
+        match attempt {
+            Ok(Ok(conn)) => {
+                world.named_sessions.insert(format!("idle-{idx}"), conn);
+                accepted += 1;
+            }
+            Ok(Err("connect_timeout")) => timed_out += 1,
+            _ => {}
+        }
+    }
+    info!(
+        "attempt_create_idle_sessions: requested {count}, accepted {accepted} (rejected {}, timed_out {timed_out})",
+        count - accepted
+    );
+}
 
 #[when(
     regex = r#"^we create session "([^"]+)" to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)"$"#

--- a/tests/bdd/fallback_helper.rs
+++ b/tests/bdd/fallback_helper.rs
@@ -116,6 +116,46 @@ pub async fn pg_doorman_log_contains(world: &mut DoormanWorld, needle: String) {
     );
 }
 
+/// Negative substring assertion on captured pg_doorman log. Useful for
+/// regression checks where a specific error message must not appear under
+/// normal operation (e.g. `Too many open files` after a binary upgrade
+/// where the migration buffer respects the configured nofile budget).
+#[then(expr = "pg_doorman log does not contain {string}")]
+pub async fn pg_doorman_log_does_not_contain(world: &mut DoormanWorld, needle: String) {
+    let path = world
+        .doorman_log_path
+        .as_ref()
+        .expect("log capture not enabled — add `Given pg_doorman log capture enabled`");
+    let body = std::fs::read_to_string(path).expect("failed to read doorman log file");
+    assert!(
+        !body.contains(&needle),
+        "pg_doorman log unexpectedly contained {needle:?}. Full log:\n{body}"
+    );
+}
+
+/// Count-bounded substring assertion. Lets fd-exhaustion scenarios verify
+/// that the accept-loop log is rate-limited (a handful of WARN/DEBUG lines
+/// are fine) without forbidding the substring entirely, since legitimate
+/// diagnostic output may still mention it.
+#[then(expr = "pg_doorman log contains {string} at most {int} times")]
+pub async fn pg_doorman_log_contains_at_most(
+    world: &mut DoormanWorld,
+    needle: String,
+    max_count: usize,
+) {
+    let path = world
+        .doorman_log_path
+        .as_ref()
+        .expect("log capture not enabled — add `Given pg_doorman log capture enabled`");
+    let body = std::fs::read_to_string(path).expect("failed to read doorman log file");
+    let count = body.matches(&needle).count();
+    assert!(
+        count <= max_count,
+        "pg_doorman log contained {needle:?} {count} times (max allowed {max_count}). \
+         Full log:\n{body}"
+    );
+}
+
 /// Regex assertion on captured pg_doorman log. Pattern is whatever `regex`
 /// crate accepts; multiline (`(?m)`) is on by default.
 #[then(expr = "pg_doorman log matches {string}")]

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -1,0 +1,108 @@
+Feature: pg_doorman stays within its fd budget
+  Two failure modes for the same root issue — pg_doorman must keep its
+  file-descriptor table inside the configured `LimitNOFILE` and reject
+  clients gracefully when load exceeds `max_connections`, rather than
+  exhaust the fd table and start spamming EMFILE on every new socket
+  (including Patroni-fallback discovery, which then dominates the log).
+
+  Background:
+    Given PostgreSQL started with pg_hba.conf:
+      """
+      host all all 127.0.0.1/32 trust
+      """
+    And fixtures from "tests/fixture.sql" applied
+
+  @client-migration @migration-fd-budget
+  Scenario: Binary upgrade with 100 idle clients under NOFILE=50 stays out of EMFILE
+    Given pg_doorman log capture enabled
+    And pg_doorman started with NOFILE limit 50 and config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+      pool_mode = "transaction"
+      shutdown_timeout = 5000
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 10
+      """
+    When we sleep 1000ms
+    And we attempt to create 100 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
+    And we store foreground pg_doorman PID as "old_doorman"
+    And we send SIGUSR2 to foreground pg_doorman
+    And we wait for foreground binary upgrade to complete
+    # accept-loop must be rate-limited: a single backoff line every 5 s is
+    # acceptable, but tight-loop spam (thousands of lines per ms) is the bug
+    # this scenario guards against.
+    Then pg_doorman log contains "Failed to accept new connection" at most 5 times
+    # Patroni fallback must not be triggered on local fd exhaustion.
+    And pg_doorman log does not contain "fallback discovery failed"
+    # Binary upgrade must not be aborted by the pre-flight validator just
+    # because the local fd table is full — the upgrade is the recovery path.
+    And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
+
+  @client-migration @migration-fd-budget
+  Scenario: Binary upgrade with 50 idle clients under NOFILE=200 completes without EMFILE
+    Given pg_doorman log capture enabled
+    And pg_doorman started with NOFILE limit 200 and config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+      pool_mode = "transaction"
+      shutdown_timeout = 5000
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 10
+      """
+    When we sleep 1000ms
+    And we attempt to create 50 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
+    And we store foreground pg_doorman PID as "old_doorman"
+    And we send SIGUSR2 to foreground pg_doorman
+    And we wait for foreground binary upgrade to complete
+    Then pg_doorman log does not contain "Too many open files"
+    And pg_doorman log does not contain "fallback discovery failed"
+    And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
+
+  @client-migration @migration-fd-budget @fd-overload
+  Scenario: 1000 clients on a 50-client cap reject cleanly, accepted clients keep working
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+      pool_mode = "transaction"
+      max_connections = 50
+      shutdown_timeout = 5000
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 10
+      """
+    When we sleep 1000ms
+    And we attempt to create 1000 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
+    Then pg_doorman log does not contain "Too many open files"
+    And pg_doorman log does not contain "fallback discovery failed"
+    When we send SimpleQuery "SELECT 1" to session "idle-0" and store response
+    Then session "idle-0" should receive DataRow with "1"

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -35,7 +35,13 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 100 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    And we store foreground pg_doorman PID as "old_doorman"
+    # Under NOFILE=50 the listener cannot service 100 clients, but the
+    # pool itself is sized for 10 backends, so we expect at least the
+    # first 10 clients to have settled into the pool. Anything below
+    # would mean the accept loop or the auth path is dropping clients
+    # the pool could otherwise serve — a regression we must not ship.
+    Then at least 10 idle sessions should be open from the last batch attempt
+    When we store foreground pg_doorman PID as "old_doorman"
     And we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
     # accept-loop must be rate-limited: a single backoff line every 5 s is
@@ -47,6 +53,12 @@ Feature: pg_doorman stays within its fd budget
     # Binary upgrade must not be aborted by the pre-flight validator just
     # because the local fd table is full — the upgrade is the recovery path.
     And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
+    # Note: at NOFILE=50 the post-upgrade fresh-connection check is
+    # intentionally omitted — under that tight a budget the new process
+    # is still draining migration RX during the assertion window, so a
+    # bare connect/auth round-trip is racy. The fresher-window assertion
+    # lives in the NOFILE=200 scenario below where the budget is wide
+    # enough for the new process to settle.
 
   @client-migration @migration-fd-budget
   Scenario: Binary upgrade with 50 idle clients under NOFILE=200 completes without EMFILE
@@ -71,12 +83,23 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 50 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    And we store foreground pg_doorman PID as "old_doorman"
+    # NOFILE=200 has comfortable headroom for 50 clients, so the
+    # accept-side bottleneck does not apply here — we expect every
+    # client to have settled.
+    Then at least 50 idle sessions should be open from the last batch attempt
+    When we store foreground pg_doorman PID as "old_doorman"
     And we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
     Then pg_doorman log does not contain "Too many open files"
     And pg_doorman log does not contain "fallback discovery failed"
     And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
+    # Migrated sessions must be able to round-trip a query through
+    # whichever process is now servicing them. The MIGRATION_TX path
+    # is only useful if the protocol state survived intact; a healthy
+    # `SELECT 1` is the cheapest end-to-end check of that.
+    When we send SimpleQuery "SELECT 1" to the first open idle session and store response as "post-upgrade"
+    Then session "post-upgrade" should receive DataRow with "1"
+    And a fresh PostgreSQL session to pg_doorman as "example_user_1" with password "" and database "example_db" succeeds
 
   @client-migration @migration-fd-budget @fd-overload
   Scenario: 1000 clients on a 50-client cap reject cleanly, accepted clients keep working
@@ -102,7 +125,12 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 1000 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    Then pg_doorman log does not contain "Too many open files"
+    # `max_connections = 50` is the documented cap: the listener must
+    # admit the first 50 cleanly and reject the rest at the protocol
+    # layer ("too many clients already"). Anything lower means accept
+    # itself is the bottleneck — that's the failure mode we're catching.
+    Then at least 50 idle sessions should be open from the last batch attempt
+    And pg_doorman log does not contain "Too many open files"
     And pg_doorman log does not contain "fallback discovery failed"
-    When we send SimpleQuery "SELECT 1" to session "idle-0" and store response
-    Then session "idle-0" should receive DataRow with "1"
+    When we send SimpleQuery "SELECT 1" to the first open idle session and store response as "after-cap"
+    Then session "after-cap" should receive DataRow with "1"

--- a/tests/bdd/world.rs
+++ b/tests/bdd/world.rs
@@ -108,6 +108,11 @@ pub struct DoormanWorld {
     pub vars: HashMap<String, String>,
     /// Extra environment variables to pass to pg_doorman process
     pub doorman_env: Vec<(String, String)>,
+    /// Soft RLIMIT_NOFILE applied to the pg_doorman child via pre_exec at
+    /// spawn time. None leaves the limit inherited from the test runner.
+    /// Used by `pg_doorman started with NOFILE limit N and config:` to put
+    /// the daemon under a tight fd budget for migration-buffer tests.
+    pub doorman_nofile_limit: Option<u64>,
     pub pg_ssl_ca_cert_file: Option<NamedTempFile>,
     pub pg_ssl_ca_key_file: Option<NamedTempFile>,
     pub pg_ssl_cert_file: Option<NamedTempFile>,


### PR DESCRIPTION
## Summary

Production binary upgrade from 3.6.5 to 3.9.1 left ~20 of 20K machines stuck in a Too-many-open-files state for ~10 minutes after the parent's fd table filled up. The exhaustion source itself is still being researched, but the log storm and the lack of self-recovery turned out to be a sum of three independent code paths that all fail loudly on EMFILE.

This PR treats EMFILE/ENFILE as a transient local-resource condition on those three paths:

- **`src/app/server.rs` accept loop (TCP + Unix)**: sleeps 100 ms and rate-limits the error log to one line per 5 s. Previously each queued SYN under an exhausted fd table re-armed the loop immediately, producing thousands of identical lines per millisecond.
- **`src/stats/print_all_stats.rs`**: socket-state introspection falls back to DEBUG instead of ERROR when /proc reads cannot open. Observability degrades quietly without adding to the log storm.
- **`src/app/server.rs` SIGUSR2 binary-upgrade pre-flight**: skips with a WARN and proceeds with the upgrade if `process::Command::output()` fails with EMFILE. Previously the pre-flight aborted the upgrade, leaving the parent stuck in the same exhausted state.
