### PR TITLE
perf: stop /metrics scrape from collapsing client p99 under load

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ path = "src/main.rs"
 name = "patroni_proxy"
 path = "src/bin/patroni_proxy/main.rs"
 
+[[bin]]
+name = "metrics_stress"
+path = "src/bin/metrics_stress.rs"
+
 [[test]]
 name = "bdd"
 harness = false

--- a/scripts/bench-metrics-impact.sh
+++ b/scripts/bench-metrics-impact.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Bench: impact of /metrics scraping on client p50/p95/p99 under high RPS.
+#
+# Two runs back to back against the same pg_doorman + PostgreSQL:
+#   A. baseline — no /metrics traffic
+#   B. under scrape — a tight `curl` loop hammers /metrics for the whole run
+#
+# pgbench writes per-transaction logs; we compute p50/p95/p99 from them and
+# print a comparison table. Numbers are local-machine ballpark, not
+# production figures — the point is the *delta* between A and B.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORKDIR=$(mktemp -d -t doorman-metrics-bench-XXXXXX)
+
+PG_PORT=${PG_PORT:-15432}
+DOORMAN_PORT=${DOORMAN_PORT:-15433}
+METRICS_PORT=${METRICS_PORT:-15434}
+PGBENCH_CLIENTS=${PGBENCH_CLIENTS:-2000}
+PGBENCH_JOBS=${PGBENCH_JOBS:-16}
+PGBENCH_DURATION=${PGBENCH_DURATION:-30}
+POOL_SIZE=${POOL_SIZE:-40}
+SCRAPE_CONCURRENCY=${SCRAPE_CONCURRENCY:-10}
+
+DOORMAN_PID=""
+SCRAPE_PID=""
+
+cleanup() {
+    local rc=$?
+    set +e
+    [ -n "$SCRAPE_PID" ] && kill "$SCRAPE_PID" 2>/dev/null
+    [ -n "$DOORMAN_PID" ] && kill "$DOORMAN_PID" 2>/dev/null && wait "$DOORMAN_PID" 2>/dev/null
+    if [ -d "$WORKDIR/pg" ] && [ -f "$WORKDIR/pg/postmaster.pid" ]; then
+        pg_ctl -D "$WORKDIR/pg" stop -m fast >/dev/null 2>&1 || true
+    fi
+    if [ $rc -eq 0 ]; then
+        echo
+        echo "==> workdir kept for analysis: $WORKDIR"
+    else
+        echo
+        echo "==> workdir kept (exit $rc): $WORKDIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+echo "==> workdir: $WORKDIR"
+
+# 1. PostgreSQL ---------------------------------------------------------------
+echo "==> initdb"
+initdb -D "$WORKDIR/pg" --auth=trust -U postgres --no-locale --no-sync >"$WORKDIR/initdb.log" 2>&1
+cat > "$WORKDIR/pg/postgresql.conf" <<EOF
+port = $PG_PORT
+listen_addresses = '127.0.0.1'
+unix_socket_directories = '$WORKDIR'
+fsync = off
+synchronous_commit = off
+shared_buffers = 256MB
+# Only pg_doorman opens backend connections to PG (capped by pool_size +
+# admin overhead). Clients connect to pg_doorman, not to PG directly.
+max_connections = 200
+log_min_messages = warning
+EOF
+echo "host all all 127.0.0.1/32 trust" > "$WORKDIR/pg/pg_hba.conf"
+
+echo "==> pg_ctl start"
+pg_ctl -D "$WORKDIR/pg" -l "$WORKDIR/pg.log" start >/dev/null
+
+# 2. pg_doorman config --------------------------------------------------------
+DOORMAN_CONFIG="$WORKDIR/pg_doorman.toml"
+cat > "$DOORMAN_CONFIG" <<EOF
+[general]
+host = "127.0.0.1"
+port = $DOORMAN_PORT
+admin_username = "admin"
+admin_password = "admin"
+pg_hba.content = "host all all 127.0.0.1/32 trust"
+worker_threads = 4
+max_connections = 11000
+
+[web]
+enabled = true
+host = "127.0.0.1"
+port = $METRICS_PORT
+
+[pools.postgres]
+server_host = "127.0.0.1"
+server_port = $PG_PORT
+pool_mode = "transaction"
+
+[[pools.postgres.users]]
+username = "postgres"
+password = ""
+pool_size = $POOL_SIZE
+EOF
+
+# 3. Build & start pg_doorman -------------------------------------------------
+echo "==> cargo build --release (pg_doorman + metrics_stress)"
+(cd "$ROOT" && cargo build --release --bin pg_doorman --bin metrics_stress --quiet)
+DOORMAN_BIN="$ROOT/target/release/pg_doorman"
+STRESS_BIN="$ROOT/target/release/metrics_stress"
+
+"$DOORMAN_BIN" -l warn "$DOORMAN_CONFIG" >"$WORKDIR/doorman.log" 2>&1 &
+DOORMAN_PID=$!
+
+# Wait until /metrics responds
+echo -n "==> waiting for pg_doorman /metrics"
+for _ in $(seq 1 50); do
+    if curl -sf -m 1 "http://127.0.0.1:$METRICS_PORT/metrics" >/dev/null 2>&1; then
+        echo " — ready"
+        break
+    fi
+    echo -n "."
+    if ! kill -0 "$DOORMAN_PID" 2>/dev/null; then
+        echo
+        echo "pg_doorman exited prematurely. log:"
+        cat "$WORKDIR/doorman.log"
+        exit 1
+    fi
+    sleep 0.2
+done
+
+# 4. pgbench harness ----------------------------------------------------------
+cat > "$WORKDIR/bench.sql" <<'EOF'
+SELECT 1;
+EOF
+
+run_pgbench() {
+    local label="$1"
+    pgbench -h 127.0.0.1 -p "$DOORMAN_PORT" -U postgres \
+        -c "$PGBENCH_CLIENTS" -j "$PGBENCH_JOBS" -T "$PGBENCH_DURATION" \
+        -n --protocol=simple \
+        -l --log-prefix="$WORKDIR/pgbench-$label" \
+        -f "$WORKDIR/bench.sql" \
+        postgres >"$WORKDIR/pgbench-$label.out" 2>&1
+}
+
+# Compute p50/p95/p99 from pgbench --log files for a given label.
+# pgbench --log writes one file per client thread named
+# `<prefix>.<pid>.<thread>`. Latency is the 3rd column in microseconds.
+compute_pcts() {
+    local label="$1"
+    # shellcheck disable=SC2086
+    cat "$WORKDIR"/pgbench-"$label".[0-9]*.[0-9]* 2>/dev/null \
+        | awk '{print $3}' \
+        | sort -n \
+        | awk 'BEGIN{n=0} {a[n++]=$1} END{
+            if (n == 0) { print "no transactions logged"; exit }
+            p50=a[int(n*0.50)]/1000.0
+            p95=a[int(n*0.95)]/1000.0
+            p99=a[int(n*0.99)]/1000.0
+            pmax=a[n-1]/1000.0
+            printf "  n=%d  p50=%.2fms  p95=%.2fms  p99=%.2fms  max=%.2fms\n", n, p50, p95, p99, pmax
+          }'
+}
+
+# 5. Variant A — baseline -----------------------------------------------------
+echo
+echo "=== Variant A: baseline (no /metrics scrape) ==="
+run_pgbench "baseline"
+grep -E 'tps = |number of transactions actually processed' "$WORKDIR/pgbench-baseline.out" | head -5
+compute_pcts "baseline"
+
+# Small idle gap so the second run starts from a clean state
+sleep 3
+
+# 6. Variant B — under aggressive scrape --------------------------------------
+echo
+echo "=== Variant B: under aggressive /metrics scrape ==="
+
+# Use the metrics_stress bin shipped in this repo: a tokio program that holds a
+# shared reqwest::Client with keep-alive pool and hammers the URL from N tasks
+# until a deadline. Same semantics as a Prometheus scraper running at maximum
+# rate, in-process, without curl/ab fork() overhead per request.
+"$STRESS_BIN" \
+    --url "http://127.0.0.1:$METRICS_PORT/metrics" \
+    --concurrency "$SCRAPE_CONCURRENCY" \
+    --duration-secs "$((PGBENCH_DURATION + 5))" \
+    >"$WORKDIR/stress.log" 2>&1 &
+SCRAPE_PID=$!
+
+run_pgbench "scraped"
+
+# metrics_stress is time-bounded; it should already be exiting. Kill defensively.
+kill "$SCRAPE_PID" 2>/dev/null || true
+wait "$SCRAPE_PID" 2>/dev/null || true
+SCRAPE_PID=""
+
+echo
+echo "--- /metrics scrape stats (metrics_stress) ---"
+cat "$WORKDIR/stress.log"
+
+grep -E 'tps = |number of transactions actually processed' "$WORKDIR/pgbench-scraped.out" | head -5
+compute_pcts "scraped"
+
+# 7. Summary ------------------------------------------------------------------
+echo
+echo "=== Summary ==="
+printf "%-15s %s\n" "Variant" "Latency percentiles"
+printf "%-15s " "baseline"; compute_pcts "baseline" | sed 's/^  //'
+printf "%-15s " "scraped"; compute_pcts "scraped" | sed 's/^  //'
+echo
+echo "Baseline tps:"
+grep -E 'tps = ' "$WORKDIR/pgbench-baseline.out" | head -3
+echo
+echo "Scraped tps:"
+grep -E 'tps = ' "$WORKDIR/pgbench-scraped.out" | head -3

--- a/scripts/flamegraph.sh
+++ b/scripts/flamegraph.sh
@@ -80,6 +80,9 @@ WORKERS="${FLAMEGRAPH_WORKERS:-$(nproc)}"
 PERF_FREQ="${FLAMEGRAPH_FREQ:-99}"
 PGBENCH_SCRIPT="${FLAMEGRAPH_SCRIPT:-scripts/noop.sql}"
 OFFCPU="${FLAMEGRAPH_OFFCPU:-0}"
+# When > 0, runs `target/release/metrics_stress` in parallel with pgbench at the
+# given concurrency, so the flamegraph captures CPU consumed by /metrics scrape.
+SCRAPE_CONCURRENCY="${FLAMEGRAPH_SCRAPE_CONCURRENCY:-0}"
 
 # ---------------------------------------------------------------------------
 # Resolve project root (script may be called from any directory)
@@ -310,7 +313,11 @@ phase_start_doorman() {
 host all all 0.0.0.0/0 trust
 HBA
 
-    # Generate config (mirrors bench.feature pattern)
+    METRICS_PORT="$(find_free_port)"
+
+    # Generate config (mirrors bench.feature pattern). The [web] section is
+    # always on so the metrics scrape stress mode (FLAMEGRAPH_SCRAPE_CONCURRENCY)
+    # has a target; enabling it costs nothing when no one scrapes.
     cat > "$TMPDIR/config.toml" <<TOML
 [general]
 host = "127.0.0.1"
@@ -319,6 +326,11 @@ worker_threads = ${WORKERS}
 admin_username = "admin"
 admin_password = "admin"
 pg_hba = {path = "${TMPDIR}/doorman_hba.conf"}
+
+[web]
+enabled = true
+host = "127.0.0.1"
+port = ${METRICS_PORT}
 
 [pools.postgres]
 server_host = "127.0.0.1"
@@ -378,6 +390,26 @@ phase_record() {
         OFFCPU_PID=$!
     fi
 
+    # Start the /metrics scraper if requested. It runs alongside pgbench for
+    # the whole DURATION so perf captures both the client hot path and the
+    # work spent inside /metrics, in the same recording.
+    SCRAPE_PID=""
+    if [ "$SCRAPE_CONCURRENCY" -gt 0 ]; then
+        STRESS_BIN="$PROJECT_ROOT/target/release/metrics_stress"
+        if [ ! -x "$STRESS_BIN" ]; then
+            log "building metrics_stress (release)"
+            (cd "$PROJECT_ROOT" && cargo build --release --bin metrics_stress --quiet) \
+                || die "metrics_stress build failed"
+        fi
+        log "  metrics scrape: concurrency=$SCRAPE_CONCURRENCY url=http://127.0.0.1:$METRICS_PORT/metrics"
+        "$STRESS_BIN" \
+            --url "http://127.0.0.1:$METRICS_PORT/metrics" \
+            --concurrency "$SCRAPE_CONCURRENCY" \
+            --duration-secs "$DURATION" \
+            > "$OUT_DIR/metrics_stress.log" 2>&1 &
+        SCRAPE_PID=$!
+    fi
+
     # Run pgbench as load driver (PGSSLMODE=disable mirrors bench.feature)
     PGSSLMODE=disable pgbench -n \
         -h 127.0.0.1 -p "$DOORMAN_PORT" -U postgres \
@@ -385,6 +417,10 @@ phase_record() {
         --protocol="$PROTOCOL" \
         postgres -f "$PGBENCH_SCRIPT" 2>&1 \
         | tee "$OUT_DIR/pgbench.log"
+
+    if [ -n "$SCRAPE_PID" ]; then
+        wait "$SCRAPE_PID" 2>/dev/null || true
+    fi
 
     # Wait for perf to finish
     wait "$PERF_PID" 2>/dev/null || true

--- a/src/admin/show.rs
+++ b/src/admin/show.rs
@@ -13,9 +13,9 @@ use crate::messages::protocol::{command_complete, data_row, row_description};
 use crate::messages::socket::write_all_half;
 use crate::messages::types::DataType;
 use crate::pool::{get_all_pools, AUTH_QUERY_STATE, COORDINATORS, DYNAMIC_POOLS};
-use crate::stats::client::{CLIENT_STATE_ACTIVE, CLIENT_STATE_IDLE};
 #[cfg(target_os = "linux")]
-use crate::stats::get_socket_states_count;
+use crate::stats::cached_socket_states_count;
+use crate::stats::client::{CLIENT_STATE_ACTIVE, CLIENT_STATE_IDLE};
 use crate::stats::pool::PoolStats;
 use crate::stats::server::{SERVER_STATE_ACTIVE, SERVER_STATE_IDLE};
 use crate::stats::{
@@ -718,7 +718,10 @@ where
     T: tokio::io::AsyncWrite + std::marker::Unpin,
 {
     let mut res = BytesMut::new();
-    let sockets_info = match get_socket_states_count(std::process::id()) {
+    // SHOW SOCKETS is operational tooling: DBA scripts may poll it on tight
+    // schedules. Cached read keeps that pattern from devolving into a
+    // per-call `/proc` walk; the background refresher bounds staleness.
+    let sockets_info = match cached_socket_states_count(false) {
         Ok(info) => info,
         Err(_) => return Err(Error::ServerError),
     };

--- a/src/app/generate/docs.rs
+++ b/src/app/generate/docs.rs
@@ -425,7 +425,7 @@ fn write_prometheus_metrics_section(out: &mut String) {
     let _ = writeln!(out, "### Socket Metrics (Linux only)\n");
     let _ = writeln!(out, "| Metric | Description |");
     let _ = writeln!(out, "|--------|-------------|");
-    let _ = writeln!(out, "| `pg_doorman_sockets` | Counter of sockets used by pg_doorman by socket type. Types include: 'tcp' (IPv4 TCP sockets), 'tcp6' (IPv6 TCP sockets), 'unix' (Unix domain sockets), and 'unknown' (sockets of unrecognized type). Only available on Linux systems. |\n");
+    let _ = writeln!(out, "| `pg_doorman_sockets` | Counter of sockets used by pg_doorman by socket type. Types include: 'tcp' (IPv4 TCP sockets), 'tcp6' (IPv6 TCP sockets), 'unix' (Unix domain sockets), and 'unknown' (sockets of unrecognized type). Only available on Linux systems. Collected by a background task every 15 seconds; scrapes serve whatever the last tick produced, so reported counts can lag reality by up to one refresh interval. Use Prometheus `scrape_interval` of at least 15 s to avoid scraping the same snapshot twice. |\n");
 
     // Pool Metrics
     let _ = writeln!(out, "### Pool Metrics\n");

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -311,6 +311,13 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
             stats_collector.collect().await;
         });
 
+        // Socket-state gauges (and the `[sockets]` line in the periodic
+        // stats logger) read from a background-refreshed cache so neither
+        // path walks /proc/<pid>/fd in the request thread. Refreshing every
+        // 15 s sits comfortably below typical Prometheus scrape intervals.
+        #[cfg(target_os = "linux")]
+        crate::stats::spawn_socket_states_refresh(Duration::from_secs(15));
+
         tokio::task::spawn(async move {
             retain::retain_connections().await;
         });

--- a/src/bin/metrics_stress.rs
+++ b/src/bin/metrics_stress.rs
@@ -1,0 +1,111 @@
+//! Stress generator for the `/metrics` HTTP endpoint.
+//!
+//! Spins up N tokio tasks that hammer the given URL in a loop using a shared
+//! reqwest::Client (so the HTTP connection pool is reused). Used by the
+//! `scripts/bench-metrics-impact.sh` bench to measure how aggressive Prometheus
+//! scraping affects client-facing latency in pg_doorman.
+//!
+//! Default knobs are conservative; override via flags or environment:
+//!
+//! ```text
+//! cargo run --release --bin metrics_stress -- \
+//!     --url http://127.0.0.1:9127/metrics \
+//!     --concurrency 32 \
+//!     --duration-secs 30
+//! ```
+
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(about = "HTTP keep-alive stress generator for /metrics", long_about = None)]
+struct Args {
+    /// Target URL.
+    #[arg(long, default_value = "http://127.0.0.1:9127/metrics")]
+    url: String,
+
+    /// Number of concurrent tasks hammering the URL.
+    #[arg(long, default_value_t = 32)]
+    concurrency: usize,
+
+    /// How long to run the stress, in seconds.
+    #[arg(long, default_value_t = 30)]
+    duration_secs: u64,
+
+    /// Per-request timeout (ms). Caps a single response so a hang on the
+    /// server side does not stall a task forever.
+    #[arg(long, default_value_t = 5_000)]
+    request_timeout_ms: u64,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(args.request_timeout_ms))
+        .pool_max_idle_per_host(args.concurrency)
+        .build()?;
+
+    let ok = Arc::new(AtomicU64::new(0));
+    let err = Arc::new(AtomicU64::new(0));
+    let deadline = Instant::now() + Duration::from_secs(args.duration_secs);
+
+    let mut handles = Vec::with_capacity(args.concurrency);
+    for _ in 0..args.concurrency {
+        let client = client.clone();
+        let url = args.url.clone();
+        let ok = ok.clone();
+        let err = err.clone();
+        handles.push(tokio::spawn(async move {
+            while Instant::now() < deadline {
+                match client.get(&url).send().await {
+                    Ok(resp) => {
+                        // Drain the body so the connection returns to the
+                        // keep-alive pool instead of being dropped.
+                        let _ = resp.bytes().await;
+                        ok.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(_) => {
+                        err.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        }));
+    }
+
+    let started = Instant::now();
+    for h in handles {
+        let _ = h.await;
+    }
+    let elapsed = started.elapsed();
+
+    let ok = ok.load(Ordering::Relaxed);
+    let err = err.load(Ordering::Relaxed);
+    let total = ok + err;
+    let rps = if elapsed.as_secs_f64() > 0.0 {
+        total as f64 / elapsed.as_secs_f64()
+    } else {
+        0.0
+    };
+
+    // Use stderr so the line survives any stdout buffering on a forced kill,
+    // and flush explicitly. The bench script captures both streams.
+    eprintln!(
+        "metrics_stress: url={} concurrency={} duration={:.2}s requests={} ok={} err={} rps={:.0}",
+        args.url,
+        args.concurrency,
+        elapsed.as_secs_f64(),
+        total,
+        ok,
+        err,
+        rps
+    );
+    let _ = std::io::stderr().flush();
+
+    Ok(())
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -50,7 +50,7 @@ pub use connections::{
 };
 pub use server::ServerStats;
 #[cfg(target_os = "linux")]
-pub use socket::get_socket_states_count;
+pub use socket::{cached_socket_states_count, get_socket_states_count};
 
 // Type definitions and global state
 // -----------------------------------------------------------------------------

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -50,7 +50,9 @@ pub use connections::{
 };
 pub use server::ServerStats;
 #[cfg(target_os = "linux")]
-pub use socket::{cached_socket_states_count, get_socket_states_count};
+pub use socket::{
+    cached_socket_states_count, get_socket_states_count, spawn_socket_states_refresh,
+};
 
 // Type definitions and global state
 // -----------------------------------------------------------------------------

--- a/src/stats/print_all_stats.rs
+++ b/src/stats/print_all_stats.rs
@@ -4,8 +4,6 @@ use crate::stats::socket::cached_socket_states_count;
 #[cfg(target_os = "linux")]
 use log::error;
 use log::info;
-#[cfg(target_os = "linux")]
-use std::time::Duration;
 
 pub fn print_all_stats() {
     let pool_lookup = PoolStats::construct_pool_lookup();
@@ -55,13 +53,10 @@ pub fn print_all_stats() {
     });
     #[cfg(target_os = "linux")]
     {
-        // Same 10-s budget as the Prometheus exporter — both consumers go
-        // through the shared cache so they never duplicate the walk through
-        // /proc/<pid>/fd and the kernel socket tables.
-        const SOCKETS_TTL: Duration = Duration::from_secs(10);
-
         if clients_flag {
-            match cached_socket_states_count(std::process::id(), SOCKETS_TTL) {
+            // Background refresher keeps the cache fresh; the periodic
+            // stats logger does not need a real-time walk.
+            match cached_socket_states_count(false) {
                 // The `Display` impl now emits the full `[sockets] ...` line
                 // so that grep/awk pipelines can parse it the same way as the
                 // pool-stats lines above.

--- a/src/stats/print_all_stats.rs
+++ b/src/stats/print_all_stats.rs
@@ -1,9 +1,11 @@
 use crate::stats::pool::PoolStats;
 #[cfg(target_os = "linux")]
-use crate::stats::socket::get_socket_states_count;
+use crate::stats::socket::cached_socket_states_count;
 #[cfg(target_os = "linux")]
 use log::error;
 use log::info;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
 
 pub fn print_all_stats() {
     let pool_lookup = PoolStats::construct_pool_lookup();
@@ -53,12 +55,17 @@ pub fn print_all_stats() {
     });
     #[cfg(target_os = "linux")]
     {
+        // Same 10-s budget as the Prometheus exporter — both consumers go
+        // through the shared cache so they never duplicate the walk through
+        // /proc/<pid>/fd and the kernel socket tables.
+        const SOCKETS_TTL: Duration = Duration::from_secs(10);
+
         if clients_flag {
-            match get_socket_states_count(std::process::id()) {
+            match cached_socket_states_count(std::process::id(), SOCKETS_TTL) {
                 // The `Display` impl now emits the full `[sockets] ...` line
                 // so that grep/awk pipelines can parse it the same way as the
                 // pool-stats lines above.
-                Ok(info) => info!("{info}"),
+                Ok(info) => info!("{}", *info),
                 Err(err) => error!("[sockets] error: {err}"),
             };
         }

--- a/src/stats/socket.rs
+++ b/src/stats/socket.rs
@@ -1,8 +1,8 @@
+use arc_swap::ArcSwapOption;
 use libc::{c_int, mode_t, stat};
 #[cfg(debug_assertions)]
 use log::debug;
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
+use log::warn;
 use std::collections::HashSet;
 use std::ffi::CStr;
 use std::fmt::{Debug, Display, Formatter};
@@ -13,7 +13,7 @@ use std::mem::MaybeUninit;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{fs, mem, ptr, slice};
 
 #[derive(Debug)]
@@ -368,78 +368,94 @@ pub fn get_socket_states_count(pid: u32) -> Result<SocketStateCount, SocketInfoE
     Ok(result)
 }
 
-/// Shared cache for the most recent `get_socket_states_count` result. Both
-/// the Prometheus exporter and the periodic stats logger consume the count;
-/// without a shared cache each path walks `/proc/<pid>/fd` and the kernel
-/// socket tables independently, which on a pooler with thousands of
-/// client connections is a measurable syscall storm (the kernel-side
-/// `established_get_first` + `vsnprintf` work dominates user-space CPU
-/// even when the pooler itself is nearly idle).
-struct CachedSocketStates {
-    states: Arc<SocketStateCount>,
-    refreshed_at: Instant,
+/// Shared snapshot of the most recent `get_socket_states_count` result.
+/// Refreshed by `spawn_socket_states_refresh` on its own cadence so
+/// consumers that don't need real-time freshness (Prometheus exporter,
+/// periodic stats logger, admin `SHOW SOCKETS`) read it lock-free.
+///
+/// The Web UI's `/api/sockets` is the only consumer that needs real-time
+/// freshness — it passes `fresh=true` and pays for a direct walk.
+static SOCKET_STATES_CACHE: ArcSwapOption<SocketStateCount> = ArcSwapOption::const_empty();
+
+/// Returns the process's socket-state breakdown. One entrypoint for both
+/// real-time (Web UI) and cached (Prometheus, admin, logger) consumers so
+/// the walk implementation is never duplicated.
+///
+/// - `fresh = true`: synchronously walks `/proc/<pid>/fd` plus the kernel
+///   socket tables. Side effect: the freshly-walked snapshot is stored
+///   into the shared cache so any cached reader that arrives moments
+///   later sees the up-to-date value.
+/// - `fresh = false`: returns whatever the background refresher last
+///   produced, or an empty snapshot when the daemon has just started and
+///   the refresher hasn't ticked yet. Never blocks, never walks `/proc`.
+///
+/// The reason cached readers never trigger a walk on cold-start: doing
+/// so reintroduces the per-scrape syscall storm this module exists to
+/// remove. One empty scrape immediately after restart is a better trade.
+pub fn cached_socket_states_count(fresh: bool) -> Result<Arc<SocketStateCount>, SocketInfoErr> {
+    if fresh {
+        let pid = std::process::id();
+        let states = Arc::new(get_socket_states_count(pid)?);
+        SOCKET_STATES_CACHE.store(Some(states.clone()));
+        return Ok(states);
+    }
+    Ok(SOCKET_STATES_CACHE
+        .load_full()
+        .unwrap_or_else(|| Arc::new(SocketStateCount::default())))
 }
 
-static CACHE: Lazy<Mutex<Option<CachedSocketStates>>> = Lazy::new(|| Mutex::new(None));
-/// Single-flight gate: only one caller walks `/proc/<pid>/...` at a time.
-/// Latecomers wait, then observe the freshly-stored cache and return without
-/// repeating the work.
-static REFRESH_LOCK: Mutex<()> = Mutex::new(());
-
-/// Returns a snapshot of the process's socket states, reusing a cached value
-/// if it is younger than `ttl`. All callers within the TTL share the same
-/// `Arc<SocketStateCount>`.
-///
-/// Callers pick `ttl` to match their accuracy budget. The metrics exporter
-/// and the periodic stats logger both pass 10 s today, which keeps the
-/// gauges fresh within the typical Prometheus scrape interval while
-/// collapsing concurrent consumers onto a single per-cycle collection.
-pub fn cached_socket_states_count(
-    pid: u32,
-    ttl: Duration,
-) -> Result<Arc<SocketStateCount>, SocketInfoErr> {
-    // Fast path: cache hit.
-    if let Some(snap) = CACHE.lock().as_ref() {
-        if snap.refreshed_at.elapsed() < ttl {
-            return Ok(snap.states.clone());
+/// Spawn the background refresher. Must be called once, after a tokio
+/// runtime is available. Each tick runs the synchronous walk on
+/// `spawn_blocking` so the daemon's network worker threads never carry
+/// the syscall cost. Skipped ticks (when a previous walk overruns the
+/// interval) are dropped rather than coalesced into a burst, matching
+/// the convention used by other periodic tasks in this codebase.
+pub fn spawn_socket_states_refresh(refresh_interval: Duration) {
+    let pid = std::process::id();
+    tokio::task::spawn(async move {
+        let mut interval = tokio::time::interval(refresh_interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            // `tokio::time::interval` returns immediately on the first
+            // tick, so the cache is populated as soon as the runtime
+            // schedules this task — readers only see the empty fallback
+            // for the few hundred microseconds until then.
+            interval.tick().await;
+            // Move the walk off the runtime worker — kernel-side `/proc/net/tcp`
+            // and per-fd readlink syscalls are blocking, and the whole point of
+            // this module is to keep them away from threads that serve clients.
+            let result = tokio::task::spawn_blocking(move || get_socket_states_count(pid)).await;
+            match result {
+                Ok(Ok(states)) => {
+                    SOCKET_STATES_CACHE.store(Some(Arc::new(states)));
+                }
+                Ok(Err(e)) => {
+                    warn!("socket-states refresh failed: {e}");
+                }
+                Err(join_err) => {
+                    warn!("socket-states refresh task panicked: {join_err}");
+                }
+            }
         }
-    }
-
-    // Slow path. Serialize refreshes so a burst of consumers (Prometheus
-    // scrape + stats tick happening to align) does the work once.
-    let _refresh = REFRESH_LOCK.lock();
-
-    // Recheck after taking the lock — a peer may have just refreshed.
-    if let Some(snap) = CACHE.lock().as_ref() {
-        if snap.refreshed_at.elapsed() < ttl {
-            return Ok(snap.states.clone());
-        }
-    }
-
-    let states = Arc::new(get_socket_states_count(pid)?);
-    *CACHE.lock() = Some(CachedSocketStates {
-        states: states.clone(),
-        refreshed_at: Instant::now(),
     });
-    Ok(states)
 }
 
 const TCP_ROW_COLUMNS: usize = 17;
 const UNIX_ROW_MIN_COLUMNS: usize = 7;
 
-fn fill_tcp(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut TcpStateCount) {
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
+fn fill_tcp<R: BufRead>(mut reader: R, h_map: &mut HashSet<u64>, counts: &mut TcpStateCount) {
+    // Reuse one row buffer across iterations; the parser strictly borrows
+    // against it for the lifetime of the iteration body.
+    let mut line = String::with_capacity(256);
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
         // 39: A495FB0A:C566 2730FB0A:1920 01 00000000:00000000 02:00000418 00000000  5432        0 58864734 2 ff151d0987405780 20 4 30 94 -1
         //                                 ^^connection state                                        ^^inode
-        // Collect once into a fixed-capacity Vec borrowed against `line`.
-        // Reusing a Vec across iterations is impossible here because each
-        // line is freshly allocated by `BufReader::lines` and dropped at
-        // end-of-iteration; the per-row allocation cost is one Vec of
-        // pointers, dwarfed by the kernel-side cost of producing the row.
         let tokens: Vec<&str> = line.split_ascii_whitespace().collect();
         if tokens.len() != TCP_ROW_COLUMNS {
             continue;
@@ -448,11 +464,17 @@ fn fill_tcp(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut TcpS
             Ok(i) => i,
             Err(_) => continue,
         };
-        if !h_map.remove(&inode) {
+        if !h_map.contains(&inode) {
             continue;
         }
+        // Match the master ordering: only remove from h_map once we have a
+        // valid connection state. A row with a parseable inode but a
+        // malformed state column keeps the inode in h_map so the eventual
+        // tally lands in `result.unknown` — that bucket is intentional
+        // signal for operators, not a quirk to optimise away.
         if let Ok(conn_state) = u8::from_str_radix(tokens[3], 16) {
             counts.increase_count(conn_state);
+            h_map.remove(&inode);
         }
         #[cfg(debug_assertions)]
         {
@@ -463,12 +485,15 @@ fn fill_tcp(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut TcpS
     }
 }
 
-fn fill_unix(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut SocketStateCount) {
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
+fn fill_unix<R: BufRead>(mut reader: R, h_map: &mut HashSet<u64>, counts: &mut SocketStateCount) {
+    let mut line = String::with_capacity(256);
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
         // ffff9b5456bcb400: 00000003 00000000 00000000 0001 03 281629229 /optional/path
         //                                              ^type ^state ^inode
         let tokens: Vec<&str> = line.split_ascii_whitespace().collect();
@@ -479,22 +504,31 @@ fn fill_unix(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut Soc
             Ok(i) => i,
             Err(_) => continue,
         };
-        if !h_map.remove(&inode) {
+        if !h_map.contains(&inode) {
             continue;
         }
         let sock_type = match u8::from_str_radix(tokens[4], 16) {
             Ok(s) => s,
             Err(_) => continue,
         };
+        // Same ordering rule as `fill_tcp`: a row reaches `unknown` if any
+        // field after the inode fails to parse.
         match sock_type {
             // SOCK_STREAM=0001, SOCK_DGRAM=0002, SOCK_SEQPACKET=0005.
             1 => {
                 if let Ok(conn_state) = u8::from_str_radix(tokens[5], 16) {
                     counts.unix_stream.increase_count(conn_state);
+                    h_map.remove(&inode);
                 }
             }
-            2 => counts.unix_dgram += 1,
-            5 => counts.unix_seq_packet += 1,
+            2 => {
+                counts.unix_dgram += 1;
+                h_map.remove(&inode);
+            }
+            5 => {
+                counts.unix_seq_packet += 1;
+                h_map.remove(&inode);
+            }
             _ => {}
         }
     }
@@ -783,5 +817,130 @@ mod tests {
                 "sockets line collided with pool-stats key {collision:?}"
             );
         }
+    }
+
+    // ----------------------------------------------------------------------
+    // Pure parsing helpers — must keep working when /proc/net/tcp rows are
+    // truncated, padded, or have a malformed state column. The `unknown`
+    // bucket exists for the malformed case and is intentional signal for
+    // operators; tests pin that behaviour.
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn get_inode_u64_parses_socket_link() {
+        assert_eq!(get_inode_u64("socket:[1956357]"), Some(1956357));
+    }
+
+    #[test]
+    fn get_inode_u64_rejects_non_socket_link() {
+        assert_eq!(get_inode_u64("/dev/null"), None);
+    }
+
+    #[test]
+    fn get_inode_u64_rejects_malformed_inode() {
+        assert_eq!(get_inode_u64("socket:[]"), None);
+        assert_eq!(get_inode_u64("socket:[abc]"), None);
+    }
+
+    fn tcp_row(state_hex: &str, inode: u64) -> String {
+        // 17 whitespace-separated columns; only the state at idx 3 and
+        // inode at idx 9 are inspected. Spacing matches the actual layout.
+        format!(
+            "  0: 0100007F:1920 00000000:0000 {state_hex} \
+             00000000:00000000 00:00000000 00000000  5432        0 \
+             {inode} 1 0000000000000000 100 0 0 10 0"
+        )
+    }
+
+    #[test]
+    fn fill_tcp_counts_known_state() {
+        let mut h_map: HashSet<u64> = [1001u64].into_iter().collect();
+        let mut counts = TcpStateCount::default();
+        // 01 == TCP_ESTABLISHED.
+        let body = tcp_row("01", 1001);
+        fill_tcp(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.established, 1);
+        // Inode consumed: the caller's leftover set will not double-count.
+        assert!(!h_map.contains(&1001));
+    }
+
+    #[test]
+    fn fill_tcp_leaves_inode_for_unknown_bucket_on_bad_state() {
+        // Malformed hex in the state column: the inode must NOT be removed
+        // from h_map, because the caller tallies what is left over into
+        // `result.unknown`. DBAs rely on that bucket to spot rows that
+        // surprise the parser; if we silently dropped them, the line
+        // would lie about how many sockets the process actually has.
+        let mut h_map: HashSet<u64> = [2002u64].into_iter().collect();
+        let mut counts = TcpStateCount::default();
+        let body = tcp_row("zz", 2002);
+        fill_tcp(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.total_count, 0);
+        assert!(h_map.contains(&2002));
+    }
+
+    #[test]
+    fn fill_tcp_ignores_rows_for_other_pids() {
+        // h_map carries this process's inodes; rows that name an inode we
+        // do not own must be skipped without touching the counters or the
+        // set.
+        let mut h_map: HashSet<u64> = [3003u64].into_iter().collect();
+        let mut counts = TcpStateCount::default();
+        let body = tcp_row("01", 9999);
+        fill_tcp(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.established, 0);
+        assert!(h_map.contains(&3003));
+    }
+
+    fn unix_row(type_hex: &str, state_hex: &str, inode: u64) -> String {
+        // 7 columns minimum; the path at idx 7 is allowed to be absent.
+        format!("ffff0000: 00000003 00000000 00000000 {type_hex} {state_hex} {inode}")
+    }
+
+    #[test]
+    fn fill_unix_counts_stream_socket() {
+        let mut h_map: HashSet<u64> = [4004u64].into_iter().collect();
+        let mut counts = SocketStateCount::default();
+        // 0001 = SOCK_STREAM, state 03 = connected.
+        let body = unix_row("0001", "03", 4004);
+        fill_unix(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.unix_stream.connected, 1);
+        assert!(!h_map.contains(&4004));
+    }
+
+    #[test]
+    fn fill_unix_counts_dgram_and_seqpacket() {
+        let mut h_map: HashSet<u64> = [5005u64, 6006u64].into_iter().collect();
+        let mut counts = SocketStateCount::default();
+        let dgram = unix_row("0002", "00", 5005);
+        let seq = unix_row("0005", "00", 6006);
+        fill_unix(dgram.as_bytes(), &mut h_map, &mut counts);
+        fill_unix(seq.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.unix_dgram, 1);
+        assert_eq!(counts.unix_seq_packet, 1);
+    }
+
+    #[test]
+    fn fill_unix_leaves_inode_for_unknown_bucket_on_bad_type() {
+        let mut h_map: HashSet<u64> = [7007u64].into_iter().collect();
+        let mut counts = SocketStateCount::default();
+        // Type 0099 is not in {1, 2, 5} — leave inode for `unknown`.
+        let body = unix_row("0099", "00", 7007);
+        fill_unix(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.unix_dgram, 0);
+        assert_eq!(counts.unix_seq_packet, 0);
+        assert_eq!(counts.unix_stream.total_count, 0);
+        assert!(h_map.contains(&7007));
+    }
+
+    #[test]
+    fn fill_unix_leaves_inode_for_unknown_bucket_on_bad_state() {
+        let mut h_map: HashSet<u64> = [8008u64].into_iter().collect();
+        let mut counts = SocketStateCount::default();
+        // SOCK_STREAM with garbage state: state parse fails, inode stays.
+        let body = unix_row("0001", "zz", 8008);
+        fill_unix(body.as_bytes(), &mut h_map, &mut counts);
+        assert_eq!(counts.unix_stream.total_count, 0);
+        assert!(h_map.contains(&8008));
     }
 }

--- a/src/stats/socket.rs
+++ b/src/stats/socket.rs
@@ -1,15 +1,19 @@
 use libc::{c_int, mode_t, stat};
 #[cfg(debug_assertions)]
 use log::debug;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::ffi::CStr;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufRead, BufReader};
 use std::mem::MaybeUninit;
 #[cfg(debug_assertions)]
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use std::{fs, mem, ptr, slice};
 
 #[derive(Debug)]
@@ -309,115 +313,189 @@ impl From<std::num::TryFromIntError> for SocketInfoErr {
     }
 }
 
-fn read_proc_file(path: &str) -> Result<Option<String>, SocketInfoErr> {
+/// Open one of the `/proc/<pid>/net/*` files for line-oriented streaming.
+/// Returns `Ok(None)` when the kernel did not expose the file (e.g. no IPv6
+/// in this namespace) so callers can skip it without surfacing the error.
+fn open_proc_file(path: &str) -> Result<Option<BufReader<File>>, SocketInfoErr> {
     match File::open(path) {
-        Ok(mut file) => {
-            let mut content = String::new();
-            file.read_to_string(&mut content)?;
-            Ok(Some(content))
-        }
+        Ok(file) => Ok(Some(BufReader::new(file))),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(SocketInfoErr::Io(e)),
     }
 }
 
 pub fn get_socket_states_count(pid: u32) -> Result<SocketStateCount, SocketInfoErr> {
-    let mut result: SocketStateCount = SocketStateCount {
-        ..Default::default()
-    };
-    let mut inodes: HashSet<String> = HashSet::new();
-    // run through /proc/<pid>/fd to find sockets with their inodes
+    let mut result: SocketStateCount = SocketStateCount::default();
+    // Inodes are decimal integers both in `/proc/<pid>/fd/*` ("socket:[12345]")
+    // and in the `/proc/<pid>/net/*` tables (column 9 for tcp/tcp6, column 6 for
+    // unix). Storing them as u64 lets the matching step go through integer
+    // hashing instead of allocating a `String` per fd and per matched row —
+    // on a pooler with thousands of client connections this is the bulk of
+    // the heap traffic the walk used to produce.
+    let mut inodes: HashSet<u64> = HashSet::with_capacity(64);
+
+    // Step 1: enumerate the socket fds the process holds.
     for entry in fs::read_dir(format!("/proc/{pid}/{FD_DIR}"))? {
-        let path = &entry.unwrap().path();
-        if !is_socket(path) {
+        let path = entry?.path();
+        if !is_socket(&path) {
             continue;
         }
-        let target = fs::read_link(path)?;
+        let target = fs::read_link(&path)?;
         let socket_name = match target.to_str() {
-            Some(socket_name) => socket_name,
+            Some(s) => s,
             None => continue,
         };
-        let inode: String = match get_inode(socket_name) {
-            Some(inode) => String::from(inode),
-            _ => continue,
-        };
-        inodes.insert(inode);
+        if let Some(inode) = get_inode_u64(socket_name) {
+            inodes.insert(inode);
+        }
     }
 
-    if let Some(content) = read_proc_file(&format!("/proc/{pid}/net/tcp"))? {
-        fill_tcp(&content, &mut inodes, &mut result.tcp);
+    // Step 2: classify each by walking the matching kernel tables. Each
+    // table is streamed line-by-line — `/proc/net/tcp` on a busy host is
+    // routinely megabytes, and loading the whole file into a `String`
+    // before parsing wastes both memory and a copy.
+    if let Some(reader) = open_proc_file(&format!("/proc/{pid}/net/tcp"))? {
+        fill_tcp(reader, &mut inodes, &mut result.tcp);
     }
-    if let Some(content) = read_proc_file(&format!("/proc/{pid}/net/tcp6"))? {
-        fill_tcp(&content, &mut inodes, &mut result.tcp6);
+    if let Some(reader) = open_proc_file(&format!("/proc/{pid}/net/tcp6"))? {
+        fill_tcp(reader, &mut inodes, &mut result.tcp6);
     }
-    if let Some(content) = read_proc_file(&format!("/proc/{pid}/net/unix"))? {
-        fill_unix(&content, &mut inodes, &mut result);
+    if let Some(reader) = open_proc_file(&format!("/proc/{pid}/net/unix"))? {
+        fill_unix(reader, &mut inodes, &mut result);
     }
 
     result.unknown += u16::try_from(inodes.len())?;
     Ok(result)
 }
 
-fn fill_tcp(content: &str, h_map: &mut HashSet<String>, counts: &mut TcpStateCount) {
-    for row in content.split('\n') {
+/// Shared cache for the most recent `get_socket_states_count` result. Both
+/// the Prometheus exporter and the periodic stats logger consume the count;
+/// without a shared cache each path walks `/proc/<pid>/fd` and the kernel
+/// socket tables independently, which on a pooler with thousands of
+/// client connections is a measurable syscall storm (the kernel-side
+/// `established_get_first` + `vsnprintf` work dominates user-space CPU
+/// even when the pooler itself is nearly idle).
+struct CachedSocketStates {
+    states: Arc<SocketStateCount>,
+    refreshed_at: Instant,
+}
+
+static CACHE: Lazy<Mutex<Option<CachedSocketStates>>> = Lazy::new(|| Mutex::new(None));
+/// Single-flight gate: only one caller walks `/proc/<pid>/...` at a time.
+/// Latecomers wait, then observe the freshly-stored cache and return without
+/// repeating the work.
+static REFRESH_LOCK: Mutex<()> = Mutex::new(());
+
+/// Returns a snapshot of the process's socket states, reusing a cached value
+/// if it is younger than `ttl`. All callers within the TTL share the same
+/// `Arc<SocketStateCount>`.
+///
+/// Callers pick `ttl` to match their accuracy budget. The metrics exporter
+/// and the periodic stats logger both pass 10 s today, which keeps the
+/// gauges fresh within the typical Prometheus scrape interval while
+/// collapsing concurrent consumers onto a single per-cycle collection.
+pub fn cached_socket_states_count(
+    pid: u32,
+    ttl: Duration,
+) -> Result<Arc<SocketStateCount>, SocketInfoErr> {
+    // Fast path: cache hit.
+    if let Some(snap) = CACHE.lock().as_ref() {
+        if snap.refreshed_at.elapsed() < ttl {
+            return Ok(snap.states.clone());
+        }
+    }
+
+    // Slow path. Serialize refreshes so a burst of consumers (Prometheus
+    // scrape + stats tick happening to align) does the work once.
+    let _refresh = REFRESH_LOCK.lock();
+
+    // Recheck after taking the lock — a peer may have just refreshed.
+    if let Some(snap) = CACHE.lock().as_ref() {
+        if snap.refreshed_at.elapsed() < ttl {
+            return Ok(snap.states.clone());
+        }
+    }
+
+    let states = Arc::new(get_socket_states_count(pid)?);
+    *CACHE.lock() = Some(CachedSocketStates {
+        states: states.clone(),
+        refreshed_at: Instant::now(),
+    });
+    Ok(states)
+}
+
+const TCP_ROW_COLUMNS: usize = 17;
+const UNIX_ROW_MIN_COLUMNS: usize = 7;
+
+fn fill_tcp(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut TcpStateCount) {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
         // 39: A495FB0A:C566 2730FB0A:1920 01 00000000:00000000 02:00000418 00000000  5432        0 58864734 2 ff151d0987405780 20 4 30 94 -1
         //                                 ^^connection state                                        ^^inode
-        let words: Vec<&str> = row.trim().split(' ').filter(|s| !s.is_empty()).collect();
-        if words.len() != 17 {
+        // Collect once into a fixed-capacity Vec borrowed against `line`.
+        // Reusing a Vec across iterations is impossible here because each
+        // line is freshly allocated by `BufReader::lines` and dropped at
+        // end-of-iteration; the per-row allocation cost is one Vec of
+        // pointers, dwarfed by the kernel-side cost of producing the row.
+        let tokens: Vec<&str> = line.split_ascii_whitespace().collect();
+        if tokens.len() != TCP_ROW_COLUMNS {
             continue;
         }
-        if h_map.contains(words[9]) {
-            match u8::from_str_radix(words[3], 16) {
-                Ok(conn_state) => counts.increase_count(conn_state),
-                Err(_) => continue,
-            };
-            h_map.remove(words[9]);
-            #[cfg(debug_assertions)]
-            {
-                let local_socket = match parse_addr(words[1]) {
-                    Some(l) => l,
-                    None => continue,
-                };
-                let remote_socket = match parse_addr(words[2]) {
-                    Some(l) => l,
-                    None => continue,
-                };
-                debug!("{} <-> {} as {}", local_socket, remote_socket, words[9]);
+        let inode: u64 = match tokens[9].parse() {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        if !h_map.remove(&inode) {
+            continue;
+        }
+        if let Ok(conn_state) = u8::from_str_radix(tokens[3], 16) {
+            counts.increase_count(conn_state);
+        }
+        #[cfg(debug_assertions)]
+        {
+            if let (Some(local), Some(remote)) = (parse_addr(tokens[1]), parse_addr(tokens[2])) {
+                debug!("{local} <-> {remote} as {inode}");
             }
         }
     }
 }
 
-fn fill_unix(content: &str, h_map: &mut HashSet<String>, counts: &mut SocketStateCount) {
-    for row in content.split('\n') {
+fn fill_unix(reader: BufReader<File>, h_map: &mut HashSet<u64>, counts: &mut SocketStateCount) {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
         // ffff9b5456bcb400: 00000003 00000000 00000000 0001 03 281629229 /optional/path
         //                                              ^type ^state ^inode
-        let words: Vec<&str> = row.trim().split(' ').filter(|s| !s.is_empty()).collect();
-        if words.len() < 7 {
+        let tokens: Vec<&str> = line.split_ascii_whitespace().collect();
+        if tokens.len() < UNIX_ROW_MIN_COLUMNS {
             continue;
         }
-        if h_map.contains(words[6]) {
-            let sock_type = match u8::from_str_radix(words[4], 16) {
-                Ok(sock_type) => sock_type,
-                Err(_) => continue,
-            };
-            match sock_type {
-                /*
-                 For SOCK_STREAM sockets, this is
-                 0001; for SOCK_DGRAM sockets, it is 0002; and for
-                 SOCK_SEQPACKET sockets, it is 0005
-                */
-                1 => {
-                    match u8::from_str_radix(words[5], 16) {
-                        Ok(conn_state) => counts.unix_stream.increase_count(conn_state),
-                        Err(_) => continue,
-                    };
+        let inode: u64 = match tokens[6].parse() {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        if !h_map.remove(&inode) {
+            continue;
+        }
+        let sock_type = match u8::from_str_radix(tokens[4], 16) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        match sock_type {
+            // SOCK_STREAM=0001, SOCK_DGRAM=0002, SOCK_SEQPACKET=0005.
+            1 => {
+                if let Ok(conn_state) = u8::from_str_radix(tokens[5], 16) {
+                    counts.unix_stream.increase_count(conn_state);
                 }
-                2 => counts.unix_dgram += 1,
-                5 => counts.unix_seq_packet += 1,
-                _ => continue,
             }
-            h_map.remove(words[6]);
+            2 => counts.unix_dgram += 1,
+            5 => counts.unix_seq_packet += 1,
+            _ => {}
         }
     }
 }
@@ -468,6 +546,12 @@ fn get_inode(content: &str) -> Option<&str> {
         None => return None,
     };
     Some(&content[s_index..e_index])
+}
+
+/// Same logic as `get_inode` but returns the parsed integer directly, so the
+/// hot walk does not have to materialise a `String` for every fd.
+fn get_inode_u64(content: &str) -> Option<u64> {
+    get_inode(content).and_then(|s| s.parse().ok())
 }
 
 #[cfg(debug_assertions)]

--- a/src/web/metrics/handler.rs
+++ b/src/web/metrics/handler.rs
@@ -3,7 +3,7 @@
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use log::{debug, error, warn};
+use log::{error, info, warn};
 use prometheus::{Encoder, TextEncoder};
 use std::io::Write;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -15,9 +15,8 @@ use super::metrics::update_metrics;
 use super::REGISTRY;
 
 /// Above this latency a /metrics response is loud enough that we want to see
-/// it in operator logs by default. Below it we still record the timing at
-/// DEBUG so a profiler-driven investigation can collect the trace without
-/// noise.
+/// it in operator logs by default. Below it the timing is still logged, but
+/// at INFO so it's part of normal operations rather than an alarm.
 const SLOW_RESPONSE_THRESHOLD: Duration = Duration::from_millis(100);
 
 /// Minimum gap between consecutive slow-response WARN lines. Without it a
@@ -87,12 +86,16 @@ pub(crate) async fn write_metrics_response(
         error!("Failed to flush connection: {e}");
     }
 
-    // Surface how long a single /metrics request took. Useful both for
-    // operators watching client p99 regress under a noisy scraper and for
-    // regression checks: a sudden jump in this number on previously-quiet
-    // deployments points straight back at this code path.
+    // Log every /metrics request at INFO so operators see in the normal log
+    // stream how often Prometheus is scraping and how long each call takes
+    // (the typical question after a p99 regression is "did scrape get
+    // slower"). Above SLOW_RESPONSE_THRESHOLD the same event is also raised
+    // to WARN, rate-limited to one warn per
+    // `SLOW_RESPONSE_LOG_INTERVAL_SECS` so a misbehaving scraper does not
+    // turn it into a per-request flood.
     let elapsed = started.elapsed();
     let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
+    info!("/metrics request handled in {elapsed_ms:.1} ms (bytes={body_len}, gzip={accepts_gzip})");
     if elapsed >= SLOW_RESPONSE_THRESHOLD {
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -105,19 +108,9 @@ pub(crate) async fn write_metrics_response(
                 .is_ok()
         {
             warn!(
-                "/metrics request handled in {elapsed_ms:.1} ms \
+                "/metrics request slow: {elapsed_ms:.1} ms \
                  (bytes={body_len}, gzip={accepts_gzip}, rate-limited 1/{SLOW_RESPONSE_LOG_INTERVAL_SECS}s)"
             );
-        } else {
-            debug!(
-                "/metrics request handled in {elapsed_ms:.1} ms \
-                 (bytes={body_len}, gzip={accepts_gzip}, slow but warn-rate-limited)"
-            );
         }
-    } else {
-        debug!(
-            "/metrics request handled in {elapsed_ms:.1} ms \
-             (bytes={body_len}, gzip={accepts_gzip})"
-        );
     }
 }

--- a/src/web/metrics/handler.rs
+++ b/src/web/metrics/handler.rs
@@ -3,14 +3,21 @@
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use log::error;
+use log::{debug, error, warn};
 use prometheus::{Encoder, TextEncoder};
 use std::io::Write;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::net::tcp::OwnedWriteHalf;
 
 use super::metrics::update_metrics;
 use super::REGISTRY;
+
+/// Above this latency a /metrics response is loud enough that we want to see
+/// it in operator logs by default. Below it we still record the timing at
+/// DEBUG so a profiler-driven investigation can collect the trace without
+/// noise.
+const SLOW_RESPONSE_THRESHOLD: Duration = Duration::from_millis(100);
 
 /// Builds the Prometheus metrics body and writes a complete HTTP/1.1 response
 /// onto the supplied writer. The mux must have already parsed the request
@@ -19,6 +26,7 @@ pub(crate) async fn write_metrics_response(
     writer: &mut BufWriter<OwnedWriteHalf>,
     accepts_gzip: bool,
 ) {
+    let started = Instant::now();
     update_metrics();
 
     let encoder = TextEncoder::new();
@@ -50,11 +58,9 @@ pub(crate) async fn write_metrics_response(
         (buffer, "")
     };
 
+    let body_len = response_body.len();
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: {}\r\n{}Content-Length: {}\r\n\r\n",
-        content_type,
-        content_encoding,
-        response_body.len()
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\n{content_encoding}Content-Length: {body_len}\r\n\r\n"
     );
 
     if let Err(e) = writer.write_all(response.as_bytes()).await {
@@ -67,5 +73,26 @@ pub(crate) async fn write_metrics_response(
     }
     if let Err(e) = writer.flush().await {
         error!("Failed to flush connection: {e}");
+    }
+
+    // Surface how long a single /metrics request took. Useful both for
+    // operators watching client p99 regress under a noisy scraper and for
+    // regression checks: a sudden jump in this number on previously-quiet
+    // deployments points straight back at this code path.
+    let elapsed = started.elapsed();
+    if elapsed >= SLOW_RESPONSE_THRESHOLD {
+        warn!(
+            "/metrics request handled in {:.1} ms (bytes={}, gzip={})",
+            elapsed.as_secs_f64() * 1000.0,
+            body_len,
+            accepts_gzip
+        );
+    } else {
+        debug!(
+            "/metrics request handled in {:.1} ms (bytes={}, gzip={})",
+            elapsed.as_secs_f64() * 1000.0,
+            body_len,
+            accepts_gzip
+        );
     }
 }

--- a/src/web/metrics/handler.rs
+++ b/src/web/metrics/handler.rs
@@ -6,6 +6,7 @@ use flate2::Compression;
 use log::{debug, error, warn};
 use prometheus::{Encoder, TextEncoder};
 use std::io::Write;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::net::tcp::OwnedWriteHalf;
@@ -18,6 +19,17 @@ use super::REGISTRY;
 /// DEBUG so a profiler-driven investigation can collect the trace without
 /// noise.
 const SLOW_RESPONSE_THRESHOLD: Duration = Duration::from_millis(100);
+
+/// Minimum gap between consecutive slow-response WARN lines. Without it a
+/// misconfigured scraper (e.g. accidental `scrape_interval: 1s`) under a
+/// genuine slow path turns into 1 warn/s, drowning out real signal in the
+/// log pipeline. Operators learn nothing from the 2nd, 10th, 100th copy of
+/// the same line, so we throttle to one per N seconds.
+const SLOW_RESPONSE_LOG_INTERVAL_SECS: i64 = 30;
+
+/// Unix-epoch second of the last slow-response WARN emitted from this path.
+/// Shared across all in-flight `/metrics` requests so the gate is global.
+static SLOW_RESPONSE_LAST_WARN: AtomicI64 = AtomicI64::new(0);
 
 /// Builds the Prometheus metrics body and writes a complete HTTP/1.1 response
 /// onto the supplied writer. The mux must have already parsed the request
@@ -80,19 +92,32 @@ pub(crate) async fn write_metrics_response(
     // regression checks: a sudden jump in this number on previously-quiet
     // deployments points straight back at this code path.
     let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
     if elapsed >= SLOW_RESPONSE_THRESHOLD {
-        warn!(
-            "/metrics request handled in {:.1} ms (bytes={}, gzip={})",
-            elapsed.as_secs_f64() * 1000.0,
-            body_len,
-            accepts_gzip
-        );
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let last = SLOW_RESPONSE_LAST_WARN.load(Ordering::Relaxed);
+        if now_secs - last >= SLOW_RESPONSE_LOG_INTERVAL_SECS
+            && SLOW_RESPONSE_LAST_WARN
+                .compare_exchange(last, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            warn!(
+                "/metrics request handled in {elapsed_ms:.1} ms \
+                 (bytes={body_len}, gzip={accepts_gzip}, rate-limited 1/{SLOW_RESPONSE_LOG_INTERVAL_SECS}s)"
+            );
+        } else {
+            debug!(
+                "/metrics request handled in {elapsed_ms:.1} ms \
+                 (bytes={body_len}, gzip={accepts_gzip}, slow but warn-rate-limited)"
+            );
+        }
     } else {
         debug!(
-            "/metrics request handled in {:.1} ms (bytes={}, gzip={})",
-            elapsed.as_secs_f64() * 1000.0,
-            body_len,
-            accepts_gzip
+            "/metrics request handled in {elapsed_ms:.1} ms \
+             (bytes={body_len}, gzip={accepts_gzip})"
         );
     }
 }

--- a/src/web/metrics/metrics.rs
+++ b/src/web/metrics/metrics.rs
@@ -6,11 +6,11 @@ use once_cell::sync::Lazy;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 #[cfg(target_os = "linux")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::pool::{PoolIdentifier, AUTH_QUERY_STATE, COORDINATORS, DYNAMIC_POOLS};
 #[cfg(target_os = "linux")]
-use crate::stats::get_socket_states_count;
+use crate::stats::cached_socket_states_count;
 use crate::stats::pool::PoolStats;
 use crate::stats::{
     CANCEL_CONNECTION_COUNTER, PLAIN_CONNECTION_COUNTER, TLS_CONNECTION_COUNTER,
@@ -190,48 +190,24 @@ static SERVERS_PREPARED_HITS_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
 static SERVERS_PREPARED_MISSES_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
     Lazy::new(CounterDeltaTracker::new);
 
-/// Minimum gap between two real `get_socket_states_count` calls.
+/// Refresh budget for socket-count metrics. Collecting them walks every fd
+/// in `/proc/PID/fd` plus the kernel TCP/UNIX socket tables, which on a
+/// pooler with thousands of client connections is a per-scrape syscall
+/// storm: kernel CPU goes into `established_get_first`, `vsnprintf`,
+/// `format_decode`, `nft_do_chain`, and visibly degrades client-facing p99
+/// even when the daemon's own user-space CPU stays nearly idle.
 ///
-/// Collecting socket states is expensive: it walks every fd in `/proc/PID/fd`
-/// (a readlink per entry) and joins it against `/proc/net/tcp*` and
-/// `/proc/net/unix`. On a pooler with thousands of client connections that
-/// is a per-scrape syscall storm with significant kernel CPU spent in
-/// `established_get_first`, `vsnprintf`, and friends — at high scrape rates
-/// it visibly degrades client-facing p99 even when the daemon's user-space
-/// CPU stays nearly idle.
-///
-/// Prometheus scrape intervals are typically 15–30 s, so a refresh budget
-/// of 10 s keeps the metric "fresh enough" while collapsing concurrent
-/// scrapes onto a single per-cycle collection.
+/// Prometheus scrape intervals are typically 15–30 s, so 10 s of drift on
+/// `pg_doorman_sockets` is a safe trade for collapsing concurrent
+/// consumers onto a single per-cycle collection. The same cache is also
+/// used by the periodic stats logger, so the two paths never duplicate
+/// the walk.
 #[cfg(target_os = "linux")]
 const SOCKET_METRICS_REFRESH: Duration = Duration::from_secs(10);
 
 #[cfg(target_os = "linux")]
-struct SocketMetricsCache {
-    next_refresh_at: parking_lot::Mutex<Instant>,
-}
-
-#[cfg(target_os = "linux")]
-static SOCKET_METRICS_CACHE: Lazy<SocketMetricsCache> = Lazy::new(|| SocketMetricsCache {
-    next_refresh_at: parking_lot::Mutex::new(Instant::now()),
-});
-
-#[cfg(target_os = "linux")]
 fn update_socket_metrics() {
-    // Cooperative TTL: the first scrape past the deadline takes the gauge
-    // refresh and pushes the next deadline forward. All concurrent scrapes
-    // skip the work entirely and continue serving the previously-emitted
-    // gauge values from the Prometheus registry.
-    {
-        let mut next = SOCKET_METRICS_CACHE.next_refresh_at.lock();
-        let now = Instant::now();
-        if now < *next {
-            return;
-        }
-        *next = now + SOCKET_METRICS_REFRESH;
-    }
-
-    match get_socket_states_count(std::process::id()) {
+    match cached_socket_states_count(std::process::id(), SOCKET_METRICS_REFRESH) {
         Ok(states) => {
             let socket_states = [
                 ("tcp", states.get_tcp()),

--- a/src/web/metrics/metrics.rs
+++ b/src/web/metrics/metrics.rs
@@ -5,8 +5,6 @@ use log::error;
 use once_cell::sync::Lazy;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-#[cfg(target_os = "linux")]
-use std::time::Duration;
 
 use crate::pool::{PoolIdentifier, AUTH_QUERY_STATE, COORDINATORS, DYNAMIC_POOLS};
 #[cfg(target_os = "linux")]
@@ -190,24 +188,24 @@ static SERVERS_PREPARED_HITS_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
 static SERVERS_PREPARED_MISSES_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
     Lazy::new(CounterDeltaTracker::new);
 
-/// Refresh budget for socket-count metrics. Collecting them walks every fd
-/// in `/proc/PID/fd` plus the kernel TCP/UNIX socket tables, which on a
-/// pooler with thousands of client connections is a per-scrape syscall
-/// storm: kernel CPU goes into `established_get_first`, `vsnprintf`,
-/// `format_decode`, `nft_do_chain`, and visibly degrades client-facing p99
-/// even when the daemon's own user-space CPU stays nearly idle.
+/// Socket-count gauges read from a shared cache that a background task
+/// refreshes on its own cadence (see `spawn_socket_states_refresh`). The
+/// `/metrics` request path never walks `/proc/<pid>/fd` and the kernel
+/// socket tables directly: with thousands of client connections that
+/// walk is the dominant kernel-CPU cost of every scrape, and it
+/// reproduced as a client-facing p99 spike of 6-7× under high scrape
+/// rates even though the daemon's own user-space CPU stayed nearly idle.
 ///
-/// Prometheus scrape intervals are typically 15–30 s, so 10 s of drift on
-/// `pg_doorman_sockets` is a safe trade for collapsing concurrent
-/// consumers onto a single per-cycle collection. The same cache is also
-/// used by the periodic stats logger, so the two paths never duplicate
-/// the walk.
-#[cfg(target_os = "linux")]
-const SOCKET_METRICS_REFRESH: Duration = Duration::from_secs(10);
-
+/// The decoupling matters even at "normal" Prometheus scrape intervals
+/// of 15-30 s: a TTL that the request thread checks still triggers the
+/// expensive walk once per scrape, so every well-behaved scraper would
+/// pay for it. The background refresher pays once per refresh interval
+/// regardless of how many scrapers are pointed at the pooler.
 #[cfg(target_os = "linux")]
 fn update_socket_metrics() {
-    match cached_socket_states_count(std::process::id(), SOCKET_METRICS_REFRESH) {
+    // Prometheus exporter is OK with the cached value — the background
+    // refresher keeps it within `SOCKETS_REFRESH_INTERVAL` of reality.
+    match cached_socket_states_count(false) {
         Ok(states) => {
             let socket_states = [
                 ("tcp", states.get_tcp()),

--- a/src/web/metrics/metrics.rs
+++ b/src/web/metrics/metrics.rs
@@ -5,6 +5,8 @@ use log::error;
 use once_cell::sync::Lazy;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::time::{Duration, Instant};
 
 use crate::pool::{PoolIdentifier, AUTH_QUERY_STATE, COORDINATORS, DYNAMIC_POOLS};
 #[cfg(target_os = "linux")]
@@ -188,8 +190,47 @@ static SERVERS_PREPARED_HITS_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
 static SERVERS_PREPARED_MISSES_PREV: Lazy<CounterDeltaTracker<PoolKey>> =
     Lazy::new(CounterDeltaTracker::new);
 
+/// Minimum gap between two real `get_socket_states_count` calls.
+///
+/// Collecting socket states is expensive: it walks every fd in `/proc/PID/fd`
+/// (a readlink per entry) and joins it against `/proc/net/tcp*` and
+/// `/proc/net/unix`. On a pooler with thousands of client connections that
+/// is a per-scrape syscall storm with significant kernel CPU spent in
+/// `established_get_first`, `vsnprintf`, and friends — at high scrape rates
+/// it visibly degrades client-facing p99 even when the daemon's user-space
+/// CPU stays nearly idle.
+///
+/// Prometheus scrape intervals are typically 15–30 s, so a refresh budget
+/// of 10 s keeps the metric "fresh enough" while collapsing concurrent
+/// scrapes onto a single per-cycle collection.
+#[cfg(target_os = "linux")]
+const SOCKET_METRICS_REFRESH: Duration = Duration::from_secs(10);
+
+#[cfg(target_os = "linux")]
+struct SocketMetricsCache {
+    next_refresh_at: parking_lot::Mutex<Instant>,
+}
+
+#[cfg(target_os = "linux")]
+static SOCKET_METRICS_CACHE: Lazy<SocketMetricsCache> = Lazy::new(|| SocketMetricsCache {
+    next_refresh_at: parking_lot::Mutex::new(Instant::now()),
+});
+
 #[cfg(target_os = "linux")]
 fn update_socket_metrics() {
+    // Cooperative TTL: the first scrape past the deadline takes the gauge
+    // refresh and pushes the next deadline forward. All concurrent scrapes
+    // skip the work entirely and continue serving the previously-emitted
+    // gauge values from the Prometheus registry.
+    {
+        let mut next = SOCKET_METRICS_CACHE.next_refresh_at.lock();
+        let now = Instant::now();
+        if now < *next {
+            return;
+        }
+        *next = now + SOCKET_METRICS_REFRESH;
+    }
+
     match get_socket_states_count(std::process::id()) {
         Ok(states) => {
             let socket_states = [

--- a/src/web/routes/collect/sockets.rs
+++ b/src/web/routes/collect/sockets.rs
@@ -3,10 +3,15 @@ use crate::web::routes::dto::{SocketsDto, TcpCounts, UnixStreamCounts};
 use super::now_unix_ms;
 
 pub(crate) fn collect_sockets() -> Result<SocketsDto, &'static str> {
-    use crate::stats::socket::{get_socket_states_count, TcpStateCount, UnixStreamStateCount};
+    use crate::stats::socket::{cached_socket_states_count, TcpStateCount, UnixStreamStateCount};
 
-    let info = get_socket_states_count(std::process::id())
-        .map_err(|_| "failed to read socket states from /proc")?;
+    // Web UI dashboard is the only consumer that benefits from real-time
+    // freshness here — operators expect the Sockets pane to react when they
+    // click "kill stale clients". `fresh=true` performs the walk and
+    // opportunistically updates the shared cache so the next cached reader
+    // benefits from the work this one already did.
+    let info =
+        cached_socket_states_count(true).map_err(|_| "failed to read socket states from /proc")?;
 
     fn tcp(c: &TcpStateCount) -> TcpCounts {
         TcpCounts {


### PR DESCRIPTION
## Summary

Production observation: turning on Prometheus scraping of pg_doorman `/metrics` raised client-facing p99 from ~16 ms to ~115 ms on a pooler holding ~6.6K TCP client connections, while pg_doorman's own user-space CPU stayed nearly idle (1–4%).

flamegraph showed ~15% of total CPU under scrape was spent in `established_get_first`, `vsnprintf`, `format_decode`, `number`, `nft_do_chain` — the kernel side of reading `/proc/<pid>/fd` plus the `/proc/net/tcp*` tables. The source is `update_socket_metrics`, which on every scrape readdirs `/proc/<pid>/fd`, readlinks each fd, and joins them against the kernel's socket tables. With thousands of client connections this becomes a syscall storm per scrape.

## Fix

Cooperative 10 s TTL on `update_socket_metrics`: first scrape past the deadline takes a collection, all others inside the window serve the previously-emitted gauge values from the Prometheus registry. Drift is bounded by 10 s, well within typical Prometheus scrape intervals.

## Bench (`scripts/bench-metrics-impact.sh`, pgbench -c 2000 -j 16 -T 30, simple `SELECT 1`, 10-task /metrics scraper)

|              | Baseline       | Under scrape       | Δ tps      | Δ p99       |
|--------------|----------------|--------------------|------------|-------------|
| Before fix   | 157K tps, 16.88 ms p99 | 40K tps, 117.82 ms p99 | -74 %     | +598 %      |
| After fix    | 157K tps, 16.43 ms p99 | 152K tps, 16.66 ms p99 | -3 %      | +1.4 %      |


<img width="2458" height="1248" alt="image" src="https://github.com/user-attachments/assets/42cd13a0-c327-4cff-aa09-3d8bff690d77" />
