### PR TITLE
fix: prevent fd leaks across binary upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.10.5"
+version = "3.10.6"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.10.5"
+version = "3.10.6"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,37 @@
 # Changelog
 
+### 3.10.6
+
+#### Binary upgrade no longer carries migrated client fds into the next generation
+
+Client fds received over the SIGUSR2 migration socket are now marked
+close-on-exec in the new process. A chained binary upgrade used to inherit
+stale copies of already-migrated client sockets, so every generation could
+start with extra fds and eventually fail with `Too many open files` under
+load.
+
+The foreground upgrade path also marks inherited service fds close-on-exec
+after startup and cleans up unexpected inherited descriptors before config
+load when the process starts as a binary-upgrade child. This lets an upgraded
+binary recover from a parent that was already polluted by older non-CLOEXEC
+fds instead of preserving that fd garbage forever.
+
+#### Local fd exhaustion no longer enters Patroni-assisted fallback
+
+Backend connection failures caused by pg_doorman's own `EMFILE`/`ENFILE`
+state are now classified as local resource exhaustion, not as PostgreSQL
+unreachability. Those errors no longer blacklist the local backend or enter
+the Patroni-assisted fallback discovery path, so fd pressure does not amplify
+itself with fallback connection attempts and noisy discovery failures.
+
+#### Web admin sockets use the safe TCP policy
+
+Accepted Web UI and `/metrics` TCP sockets now receive the same low-risk TCP
+keepalive, buffer-size and user-timeout configuration as other TCP sockets,
+but do not inherit the pooler client `SO_LINGER` policy. This avoids abortive
+HTTP closes when `general.tcp_so_linger = 0` while still bounding web socket
+resource usage.
+
 ### 3.10.5
 
 #### Binary upgrade survives a tight `RLIMIT_NOFILE`

--- a/pg_doorman.toml
+++ b/pg_doorman.toml
@@ -111,7 +111,7 @@ tcp_no_delay = true
 # Default: 60
 tcp_user_timeout = 60
 
-# Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets and outbound backend TCP sockets.
+# Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets, accepted web TCP sockets, and outbound backend TCP sockets.
 # `0` (default) keeps Linux TCP autotuning active.
 # A non-zero value sets fixed send/receive buffer limits and disables autotuning for the socket.
 # Linux applies/reports doubled values and may clamp them by net.core.rmem_max/net.core.wmem_max.

--- a/pg_doorman.yaml
+++ b/pg_doorman.yaml
@@ -147,7 +147,7 @@ general:
   # Default: 60
   tcp_user_timeout: 60
 
-  # Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets and outbound backend TCP sockets.
+  # Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets, accepted web TCP sockets, and outbound backend TCP sockets.
   # `0` (default) keeps Linux TCP autotuning active.
   # A non-zero value sets fixed send/receive buffer limits and disables autotuning for the socket.
   # Linux applies/reports doubled values and may clamp them by net.core.rmem_max/net.core.wmem_max.

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -11,6 +11,9 @@ pub enum Error {
     /// `connect()` failed: backend unreachable. Distinct from `SocketError`,
     /// which fires on read/write of an already established connection.
     ConnectError(String),
+    /// `connect()` failed because pg_doorman itself cannot allocate another fd.
+    /// This is local resource exhaustion, not evidence that PostgreSQL is down.
+    ConnectResourceExhausted(String),
     ClientBadStartup,
     ProtocolSyncError(String),
     BadQuery(String),
@@ -140,6 +143,9 @@ impl std::fmt::Display for Error {
         match &self {
             Error::SocketError(msg) => write!(f, "Socket connection error: {msg}"),
             Error::ConnectError(msg) => write!(f, "Backend connect error: {msg}"),
+            Error::ConnectResourceExhausted(msg) => {
+                write!(f, "Backend connect local resource exhausted: {msg}")
+            }
             Error::ClientBadStartup => write!(f, "Client sent an invalid startup message"),
             Error::ProtocolSyncError(msg) => write!(f, "Protocol synchronization error: {msg}"),
             Error::BadQuery(msg) => write!(f, "Invalid query: {msg}"),

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -11,8 +11,7 @@ pub enum Error {
     /// `connect()` failed: backend unreachable. Distinct from `SocketError`,
     /// which fires on read/write of an already established connection.
     ConnectError(String),
-    /// `connect()` failed because pg_doorman itself cannot allocate another fd.
-    /// This is local resource exhaustion, not evidence that PostgreSQL is down.
+    /// Local fd exhaustion while opening a backend connection.
     ConnectResourceExhausted(String),
     ClientBadStartup,
     ProtocolSyncError(String),

--- a/src/app/generate/fields.yaml
+++ b/src/app/generate/fields.yaml
@@ -488,29 +488,29 @@ fields:
     tcp_socket_buffer_size:
       config:
         en: |
-          Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets and outbound backend TCP sockets.
+          Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets, accepted web TCP sockets, and outbound backend TCP sockets.
           `0` (default) keeps Linux TCP autotuning active.
           A non-zero value sets fixed send/receive buffer limits and disables autotuning for the socket.
           Linux applies/reports doubled values and may clamp them by net.core.rmem_max/net.core.wmem_max.
           Start with 64KB–256KB for OLTP in one datacenter; measure before going lower, higher, or over WAN.
         ru: |
-          Лимиты буферов ядра SO_RCVBUF/SO_SNDBUF для клиентских TCP-сокетов после accept() и исходящих TCP-сокетов к PostgreSQL.
+          Лимиты буферов ядра SO_RCVBUF/SO_SNDBUF для клиентских TCP-сокетов после accept(), web TCP-сокетов после accept() и исходящих TCP-сокетов к PostgreSQL.
           `0` (по умолчанию) оставляет включённой автонастройку TCP в Linux.
           Ненулевое значение задаёт фиксированные лимиты буферов отправки и приёма и отключает автонастройку для сокета.
           Linux применяет и возвращает удвоенные значения; верхний предел задают net.core.rmem_max и net.core.wmem_max.
           Для OLTP в одном датацентре начните с 64KB–256KB. Значения ниже или выше этого диапазона, а также работу через WAN проверяйте нагрузочными замерами.
       doc: |
-        Kernel `SO_RCVBUF`/`SO_SNDBUF` limits for accepted client TCP sockets and outbound backend TCP sockets.
+        Kernel `SO_RCVBUF`/`SO_SNDBUF` limits for accepted client TCP sockets, accepted web TCP sockets, and outbound backend TCP sockets.
 
         With the default `0`, pg_doorman does not call `setsockopt(SO_RCVBUF/SO_SNDBUF)` and Linux TCP autotuning stays in charge. Per-connection receive buffers can grow on demand up to `net.ipv4.tcp_rmem[2]` (commonly 6 MiB on Ubuntu/RHEL). That memory is not process RSS; depending on kernel and cgroup mode it may appear separately as socket memory, for example as `sock` in cgroup v2 `memory.stat`, or mostly as host-level kernel memory. If `MemFree` jumps after a pg_doorman restart, confirm the source with `ss -m`, `/proc/net/sockstat`, cgroup v2 `memory.current`, and `memory.stat` key `sock`.
 
         Setting a non-zero value calls `setsockopt(SO_RCVBUF/SO_SNDBUF)` once per configured TCP socket. This disables autotuning for that socket and sets fixed send/receive buffer limits. Linux internally doubles the requested values — see `man 7 socket` — and may clamp them by `net.core.rmem_max` / `net.core.wmem_max`. Check `/proc/sys/net/core/rmem_max` and `/proc/sys/net/core/wmem_max` before choosing values above the OS default. `getsockopt`, `ss -m`, and pg_doorman `DEBUG` logs show the kernel-applied values.
 
-        The rough Linux limit is `4 * tcp_socket_buffer_size * tcp_socket_count`: send and receive buffers are both configured, and Linux doubles each requested value internally. For example, `tcp_socket_buffer_size = 65536` sets about 256 KiB of send+receive limits per TCP socket, so 60 TCP sockets have about 15 MiB of configured kernel buffer limits before `sk_buff` overhead. Count both client TCP sockets and backend TCP sockets. Actual resident memory still depends on queued data.
+        The rough Linux limit is `4 * tcp_socket_buffer_size * tcp_socket_count`: send and receive buffers are both configured, and Linux doubles each requested value internally. For example, `tcp_socket_buffer_size = 65536` sets about 256 KiB of send+receive limits per TCP socket, so 60 TCP sockets have about 15 MiB of configured kernel buffer limits before `sk_buff` overhead. Count client TCP sockets, web TCP sockets, and backend TCP sockets. Actual resident memory still depends on queued data.
 
         This setting is primarily a memory cap. Suggested starting range for OLTP traffic inside one datacenter: **64 KiB – 256 KiB**. Do not set less than 64 KiB unless measurements show it is safe. WAN links, cross-zone traffic, large result sets, and bulk transfers may need a larger value or the default autotuning behaviour.
 
-        The value is applied when pg_doorman configures a TCP socket: on accepted client sockets, outbound backend sockets, and migrated client sockets reconstructed during binary upgrade. `SIGHUP` reload does not revisit already-open sockets. To apply a new value to existing sessions, use binary upgrade for migrated clients, reconnect/drain pools for backend sockets, or restart when reconnects are acceptable.
+        The value is applied when pg_doorman configures a TCP socket: on accepted client sockets, accepted web sockets, outbound backend sockets, and migrated client sockets reconstructed during binary upgrade. `SIGHUP` reload does not revisit already-open sockets. To apply a new value to existing sessions, use binary upgrade for migrated clients, reconnect/drain pools for backend sockets, or restart when reconnects are acceptable.
 
         Equivalent of PgBouncer's `tcp_socket_buffer` parameter. Odyssey and PgCat have no analogue and inherit the kernel autotuner's behaviour.
       default: "0"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,6 +11,7 @@ pub mod tls;
 pub use config::init_config;
 pub use logger::init_logging;
 pub use panic::install_panic_hook;
+pub use server::cleanup_inherited_upgrade_fds;
 pub use server::run_server;
 
 pub use args::{parse, Args, Commands, GenerateConfig, LogFormat, OutputFormat};

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -39,9 +39,7 @@ use crate::client::migration::{migration_receiver_task, migration_sender_task};
 /// Global counter for clients currently connected to the pg_doorman
 pub static CURRENT_CLIENT_COUNT: AtomicI64 = AtomicI64::new(0);
 
-/// Unix-epoch second of the last EMFILE/ENFILE error logged from the
-/// listener accept loop. Used to rate-limit the message so an exhausted
-/// fd table does not produce hundreds of identical lines per second.
+/// Unix-epoch second of the last accept-loop EMFILE/ENFILE log.
 static ACCEPT_RESOURCE_LOG_LAST: AtomicI64 = AtomicI64::new(0);
 
 /// Global flag indicating graceful shutdown is in progress
@@ -53,19 +51,11 @@ pub static CLIENTS_IN_TRANSACTIONS: AtomicI64 = AtomicI64::new(0);
 /// Global flag: migration to new process is active. Clients should self-migrate at idle points.
 pub static MIGRATION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
-/// Process start time. Captured the first time `STARTED_AT` is read (i.e.
-/// during the first poll into `OverviewDto.uptime_seconds`); for the
-/// foreground listener path that happens within a few hundred milliseconds
-/// of `main()` so the value approximates the binary's real boot time
-/// closely enough for an operator console.
+/// Process start time for API uptime reporting.
 pub static STARTED_AT: std::sync::LazyLock<std::time::SystemTime> =
     std::sync::LazyLock::new(std::time::SystemTime::now);
 
-/// `STARTED_AT` rendered as milliseconds since the Unix epoch. Mirrors
-/// the wall-clock format the Web UI consumes via `OverviewDto.started_at_ms`
-/// and `ProcessDto.started_at_ms`; computing it once and sharing the
-/// `LazyLock` keeps the two endpoints in lockstep without repeating the
-/// `duration_since(UNIX_EPOCH)` call on every poll.
+/// `STARTED_AT` rendered as Unix epoch milliseconds.
 pub static STARTED_AT_MS: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
     STARTED_AT
         .duration_since(std::time::UNIX_EPOCH)
@@ -77,28 +67,14 @@ pub static STARTED_AT_MS: std::sync::LazyLock<u64> = std::sync::LazyLock::new(||
 pub static MIGRATION_TX: std::sync::OnceLock<mpsc::Sender<MigrationPayload>> =
     std::sync::OnceLock::new();
 
-/// Upper bound on the migration channel capacity. Past this we stop
-/// growing the buffer regardless of how generous the nofile limit is —
-/// the parent does not need more than a few thousand pending dup'd fds
-/// in flight; beyond that the sender is the bottleneck, not the buffer.
+/// Hard cap for queued migration fd duplicates.
 const MIGRATION_CHANNEL_CAPACITY_MAX: usize = 4096;
 
-/// Fds the migration step needs beyond whatever the parent already has
-/// open at the moment `safe_migration_capacity` runs: the parent half
-/// of the migration socketpair stays open until the sender task drains
-/// it, the readiness pipe consumes one parent-side fd until the new
-/// process signals back, and `migration_sender_task` itself opens a
-/// short-lived dirfd on `/proc/PID/net/tcp` per migrated client. The
-/// reserve keeps a margin between the channel queue and the soft limit
-/// so those concurrent fds do not push the parent over the edge during
-/// migration.
+/// Parent-side fd reserve for spawn, readiness, and migration drain work.
 const MIGRATION_SPAWN_RESERVE_FDS: u64 = 16;
 
-/// Count file descriptors currently open by this process by walking
-/// `/proc/self/fd`. SIGUSR2 binary upgrade is a rare event, so the O(N)
-/// readdir cost is acceptable; in exchange we get a true live measurement
-/// instead of a guess from `RLIMIT_NOFILE` alone. Returns `None` on
-/// platforms without `/proc` so callers can fall back.
+/// Live fd count for sizing the SIGUSR2 migration queue.
+/// Returns `None` outside Linux so callers can fall back conservatively.
 #[cfg(target_os = "linux")]
 fn count_open_fds() -> Option<u64> {
     std::fs::read_dir("/proc/self/fd")
@@ -111,40 +87,20 @@ fn count_open_fds() -> Option<u64> {
     None
 }
 
-/// Compute a migration channel capacity that fits inside whatever fd
-/// budget the parent has *right now*. Each pending entry on the channel
-/// is a `dup`'d fd held in the parent until `migration_sender_task`
-/// drains it — without an upper bound the queue can grow past
-/// `RLIMIT_NOFILE` and turn the parent into a self-induced EMFILE
-/// generator.
-///
-/// `live_count + queued_dups + spawn_reserve` ≤ soft_limit must hold at
-/// every moment of migration. `live_count` is already on the books when
-/// we count `/proc/self/fd`, so the available headroom after reserving
-/// the spawn fds is exactly the budget we can hand to the queue without
-/// any further `/N` math.
-///
-/// Returns `None` when the headroom is zero — the caller treats that as
-/// "skip migration, run a normal graceful shutdown". Better to drop
-/// in-flight session continuity than to drive the parent over the limit.
+/// Capacity for dup'd client fds waiting on the migration socket.
+/// Returns `None` when there is no safe headroom under `RLIMIT_NOFILE`.
 #[cfg(unix)]
 fn safe_migration_capacity() -> Option<usize> {
-    // SAFETY: `getrlimit` is async-signal-safe and writes only into the
-    // local `rl` buffer we pass in. No global state involved.
+    // SAFETY: getrlimit writes only to the stack-local rlimit struct.
     let soft_limit = unsafe {
         let mut rl: libc::rlimit = std::mem::zeroed();
         if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 {
             rl.rlim_cur as u64
         } else {
-            // getrlimit cannot really fail for RLIMIT_NOFILE on Linux, but
-            // if it does (foreign kernel, sandbox), fall back to the hard
-            // ceiling so we behave like the previous hard-coded version.
             MIGRATION_CHANNEL_CAPACITY_MAX as u64
         }
     };
-    // No /proc/self/fd: pessimistic guess so we don't oversubscribe.
-    // Halfway between zero and the soft limit is the worst that a
-    // running pooler could realistically be at.
+    // No /proc/self/fd: assume half the limit is already in use.
     let open_fds = count_open_fds().unwrap_or(soft_limit / 2);
     let headroom = soft_limit
         .saturating_sub(open_fds)
@@ -163,11 +119,7 @@ fn safe_migration_capacity() -> Option<usize> {
 /// Minimum gap between two consecutive accept-loop EMFILE/ENFILE log lines.
 const ACCEPT_RESOURCE_LOG_INTERVAL_SECS: i64 = 5;
 
-/// Returns `true` when an `io::Error` from the accept syscall reflects a
-/// fully booked fd table (EMFILE or ENFILE). Both the TCP and Unix
-/// accept arms, and the pre-flight validator launch in
-/// `binary_upgrade_and_shutdown`, branch on the same condition and the
-/// shared check keeps that classification in one place.
+/// Accept/spawn failed because the process or host fd table is exhausted.
 #[cfg(unix)]
 fn is_fd_exhaustion_io(e: &std::io::Error) -> bool {
     matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE),)
@@ -267,9 +219,8 @@ where
         if keep.binary_search(&fd).is_ok() {
             continue;
         }
-        // SAFETY: closing an fd affects only this child process. EBADF just
-        // means the slot was already empty; other errors are non-actionable
-        // during best-effort inherited-fd cleanup.
+        // SAFETY: runs during process startup before Tokio is initialized.
+        // EBADF means the slot was empty; cleanup ignores it.
         if unsafe { libc::close(fd) } == 0 {
             closed += 1;
         }
@@ -290,19 +241,8 @@ fn fd_cleanup_upper_bound() -> libc::c_int {
     65_536
 }
 
-/// Single-flight throttle for the listener's "fd table exhausted" log
-/// line. Returns `true` only when the previous successful emission is
-/// at least `ACCEPT_RESOURCE_LOG_INTERVAL_SECS` in the past.
-///
-/// Uses `compare_exchange` rather than `swap` so a suppressed attempt
-/// does *not* slide the throttle window forward. With `swap` the very
-/// first EMFILE updates the last-seen timestamp; every subsequent error
-/// in the same second computes `now - last ≈ 0` and stays silent — even
-/// after five minutes of unbroken storm — because the timestamp keeps
-/// being refreshed by attempts that themselves never logged. CAS keeps
-/// `last` frozen at the timestamp of the most recent *emitted* line, so
-/// the next line is guaranteed to appear once that line is older than
-/// the interval.
+/// Rate-limit accept-loop fd-exhaustion logs without moving the window
+/// on suppressed attempts.
 fn should_log_accept_resource_now() -> bool {
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1185,13 +1125,8 @@ async fn binary_upgrade_and_shutdown(
                 info!("Configuration validation successful");
             }
             Err(e) => {
-                // EMFILE/ENFILE here means the local fd table is full, so
-                // `Command::output()` can't even spawn the validator. That
-                // is a local resource state, not a config problem; aborting
-                // the upgrade keeps the parent stuck in the same exhausted
-                // state. Skip the pre-flight check, log a WARN, and let the
-                // upgrade proceed so the child can take over and the
-                // parent's fds drain through client migration.
+                // Local fd exhaustion means the validator cannot spawn.
+                // It is not a config failure; let the child drain clients.
                 if is_fd_exhaustion_io(&e) {
                     warn!(
                         "Skipping pre-flight configuration validation: local fd \
@@ -1233,10 +1168,7 @@ async fn binary_upgrade_and_shutdown(
         }
     }
 
-    // Set MIGRATION_IN_PROGRESS before SHUTDOWN_IN_PROGRESS so that
-    // idle clients in the handle() loop see migration=true and wait
-    // to migrate instead of disconnecting with "pooler is shut down".
-    // If the upgrade fails later (spawn error), we clear the flag.
+    // Mark migration before shutdown so idle clients choose the migration path.
     if !admin_only {
         MIGRATION_IN_PROGRESS.store(true, Ordering::Relaxed);
     }
@@ -1244,11 +1176,7 @@ async fn binary_upgrade_and_shutdown(
 
     let mut migration_handles: Option<MigrationHandles> = None;
 
-    // Drain idle server connections — but only when there is no client
-    // migration. During migration, in-transaction clients still need
-    // their server connections to finish the current query and COMMIT.
-    // Draining here would mark those servers bad, causing "pooler is
-    // shut down" errors before clients get a chance to migrate.
+    // During migration, in-transaction clients still need checked-out servers.
     if admin_only {
         retain::drain_all_pools();
     }
@@ -1376,9 +1304,7 @@ async fn binary_upgrade_and_shutdown(
                             }
                             info!("New process signaled readiness");
 
-                            // Tell systemd the new process is now the main PID.
-                            // systemd stops tracking the old process and won't
-                            // restart the service when we exit.
+                            // Hand systemd tracking over to the ready child.
                             if let Err(e) = sd_notify::notify(
                                 false,
                                 &[sd_notify::NotifyState::MainPid(child_pid)],
@@ -1386,14 +1312,8 @@ async fn binary_upgrade_and_shutdown(
                                 warn!("sd_notify MAINPID failed: {e}. systemd may restart the service after old process exits.");
                             }
                         } else {
-                            // No POLLIN within the deadline. Either the
-                            // 10s timer elapsed, or the child closed the
-                            // pipe before writing the readiness byte
-                            // (poll reports POLLHUP without POLLIN, and
-                            // `wait_for_pipe_readiness` filters those
-                            // out). Either way the new process did not
-                            // confirm it is serving, so keep the
-                            // listener and skip the MainPID handoff.
+                            // Timeout or EOF without a readiness byte: keep
+                            // the current parent as listener owner.
                             warn!("New process did not signal readiness within 10s (timeout or early exit)");
                             unsafe {
                                 libc::close(pipe_read_fd);
@@ -1430,15 +1350,8 @@ async fn binary_upgrade_and_shutdown(
                         }
                         *listener = None;
 
-                        // Start client migration if socketpair was created
-                        // *and* the live nofile budget has room for the queue.
-                        // safe_migration_capacity returns None when current fd
-                        // usage plus the spawn reserve already meet the soft
-                        // limit; pushing dup'd fds onto a channel in that
-                        // condition would drive the parent over the limit and
-                        // is precisely the failure mode this PR was opened to
-                        // prevent. Better to drop session continuity than to
-                        // induce EMFILE on the way to a graceful shutdown.
+                        // Queue migration only while live fd headroom can
+                        // absorb the dup'd client sockets.
                         if migration_ok {
                             match safe_migration_capacity() {
                                 Some(capacity) => {
@@ -1469,9 +1382,8 @@ async fn binary_upgrade_and_shutdown(
                                          will reconnect to the new process instead of \
                                          migrating sessions"
                                     );
-                                    // Close the unused migration socketpair half
-                                    // we still hold so it doesn't sit in the fd
-                                    // table during the graceful shutdown.
+                                    // Close the unused parent half while
+                                    // graceful shutdown continues.
                                     unsafe { libc::close(migration_parent_fd) };
                                 }
                             }
@@ -1506,25 +1418,10 @@ async fn binary_upgrade_and_shutdown(
     migration_handles
 }
 
-/// Wait up to `timeout_ms` for `pipe_read_fd` to become readable.
+/// Wait for the child readiness byte using `poll(2)`.
 ///
-/// Uses `poll(2)`, not `select(2)`. select's `fd_set` is a 1024-bit
-/// bitmap; `libc::FD_SET` indexes a fixed-size array (16 longs on
-/// x86_64) and any fd >= 1024 panics with `index out of bounds`,
-/// taking the parent process down before it can drain clients or
-/// hand `MainPID` off to systemd. With `LimitNOFILE` well above
-/// 1024 in production, the readiness pipe created during a binary
-/// upgrade routinely lands above that cap. poll takes a `pollfd`
-/// array and accepts any fd.
-///
-/// The predicate is strict on `POLLIN`: if the child closes the
-/// write end without writing the readiness byte, poll reports
-/// `POLLHUP` alone and the function returns `false`. This is a
-/// deliberate change from the previous `select(2)` implementation,
-/// which treated "ready to read EOF" as "ready" and forwarded
-/// `sd_notify(MAINPID=child)` to systemd for an already-dead child.
-/// Returning `false` keeps systemd tracking the still-living parent
-/// until the next upgrade attempt.
+/// `poll` handles fds above `FD_SETSIZE`; requiring `POLLIN` rejects
+/// EOF-only readiness from a child that exited before writing.
 #[cfg(not(windows))]
 fn wait_for_pipe_readiness(pipe_read_fd: libc::c_int, timeout_ms: libc::c_int) -> bool {
     let mut pfd = libc::pollfd {
@@ -2136,8 +2033,7 @@ mod inherited_fd_cleanup_tests {
 mod wait_for_pipe_readiness_tests {
     use super::wait_for_pipe_readiness;
 
-    /// Build a pipe and reserve any fd we are handed so the test
-    /// always closes both ends, even when `dup2` to a high fd fails.
+    /// Pipe wrapper that closes both ends, including high-fd dup tests.
     struct Pipe {
         read: libc::c_int,
         write: libc::c_int,
@@ -2169,7 +2065,7 @@ mod wait_for_pipe_readiness_tests {
     #[test]
     fn returns_false_on_timeout() {
         let pipe = Pipe::new();
-        // 50 ms timeout, nothing was written — poll must return 0.
+        // 50 ms timeout, nothing was written.
         assert!(!wait_for_pipe_readiness(pipe.read, 50));
     }
 
@@ -2183,13 +2079,7 @@ mod wait_for_pipe_readiness_tests {
         assert!(wait_for_pipe_readiness(pipe.read, 1_000));
     }
 
-    /// POLLHUP without POLLIN: the child closes the pipe before
-    /// writing the readiness byte. The previous `select(2)` code
-    /// considered the fd "ready", read 0 bytes, and forwarded
-    /// `sd_notify(MAINPID=child)` for an already-dead child;
-    /// the poll-based predicate requires `POLLIN` and returns false.
-    /// Guards against a future "simplification" that drops the
-    /// `POLLIN` mask in the predicate.
+    /// EOF-only readiness must not count as child readiness.
     #[test]
     fn returns_false_when_writer_closes_without_writing() {
         let mut pipe = Pipe::new();
@@ -2198,22 +2088,15 @@ mod wait_for_pipe_readiness_tests {
         assert!(!wait_for_pipe_readiness(pipe.read, 1_000));
     }
 
-    /// Regression: select(2) on `fd >= 1024` panics inside
-    /// `libc::FD_SET` (`index out of bounds: the len is 16 but the
-    /// index is 16`) and kills the parent of the binary-upgrade
-    /// handshake. poll(2) accepts any fd, so the same scenario must
-    /// resolve as "ready" without panicking.
+    /// Readiness polling must work for fds above `FD_SETSIZE`.
     #[test]
     fn handles_fd_above_fd_setsize() {
         let pipe = Pipe::new();
-        // Pick a target fd well above the 1023 cap select(2)
-        // tolerates. dup2 closes the destination if it was open.
+        // Pick a descriptor above select(2)'s usual 1023 ceiling.
         let target_fd: libc::c_int = 1500;
         let dup_result = unsafe { libc::dup2(pipe.read, target_fd) };
         if dup_result == -1 {
-            // CI sandbox without enough RLIMIT_NOFILE headroom: skip.
-            // The default soft limit on GitHub-hosted runners is well
-            // above 1500, so this should rarely trigger.
+            // Not enough RLIMIT_NOFILE headroom in this runner.
             eprintln!(
                 "skipping handles_fd_above_fd_setsize: dup2 to {target_fd} failed ({})",
                 std::io::Error::last_os_error()

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -173,6 +173,27 @@ fn is_fd_exhaustion_io(e: &std::io::Error) -> bool {
     matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE),)
 }
 
+#[cfg(not(windows))]
+fn set_fd_close_on_exec(fd: libc::c_int, label: &str) {
+    // SAFETY: fcntl reads and writes descriptor flags for the supplied fd only.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFD);
+        if flags < 0 {
+            warn!(
+                "Failed to read close-on-exec flag for {label} fd={fd}: {}",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        if libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) < 0 {
+            warn!(
+                "Failed to set close-on-exec flag for {label} fd={fd}: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+}
+
 /// Single-flight throttle for the listener's "fd table exhausted" log
 /// line. Returns `true` only when the previous successful emission is
 /// at least `ACCEPT_RESOURCE_LOG_INTERVAL_SECS` in the past.
@@ -286,6 +307,7 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
             // Inherit listener from parent process (binary upgrade in foreground mode)
             info!("Inheriting listener from parent process (fd={})", fd);
             let std_listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
+            set_fd_close_on_exec(std_listener.as_raw_fd(), "inherited listener");
             std_listener.set_nonblocking(true).expect("can't set nonblocking");
             tokio::net::TcpListener::from_std(std_listener).expect("can't create TcpListener from inherited fd")
         } else {
@@ -651,6 +673,7 @@ pub fn run_server(args: Args, config: Config) -> Result<(), Box<dyn std::error::
                     "Migration socket received from parent (fd={})",
                     migration_fd
                 );
+                set_fd_close_on_exec(migration_fd, "migration receiver socket");
                 std::env::remove_var("PG_DOORMAN_MIGRATION_FD");
                 tokio::spawn(migration_receiver_task(
                     migration_fd,
@@ -1187,9 +1210,13 @@ async fn binary_upgrade_and_shutdown(
             let mut pipe_fds: [libc::c_int; 2] = [0; 2];
             if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } != 0 {
                 error!("Failed to create pipe for binary upgrade");
+                MIGRATION_IN_PROGRESS.store(false, Ordering::Relaxed);
+                SHUTDOWN_IN_PROGRESS.store(false, Ordering::SeqCst);
+                return None;
             } else {
                 let pipe_read_fd = pipe_fds[0];
                 let pipe_write_fd = pipe_fds[1];
+                set_fd_close_on_exec(pipe_read_fd, "readiness pipe read end");
 
                 // Create a Unix socketpair for client migration
                 let mut migration_fds: [libc::c_int; 2] = [0; 2];
@@ -1206,6 +1233,9 @@ async fn binary_upgrade_and_shutdown(
                 }
                 let migration_parent_fd = migration_fds[0]; // kept by old process
                 let migration_child_fd = migration_fds[1]; // passed to new process
+                if migration_ok {
+                    set_fd_close_on_exec(migration_parent_fd, "migration parent socket");
+                }
 
                 // Spawn child process with inherited listener fd, pipe, and migration socket
                 let child_result = unsafe {
@@ -1231,7 +1261,7 @@ async fn binary_upgrade_and_shutdown(
                 };
 
                 match child_result {
-                    Ok(child) => {
+                    Ok(mut child) => {
                         let child_pid = child.id();
                         unsafe {
                             libc::close(pipe_write_fd);
@@ -1268,6 +1298,34 @@ async fn binary_upgrade_and_shutdown(
                             // confirm it is serving, so keep the
                             // listener and skip the MainPID handoff.
                             warn!("New process did not signal readiness within 10s (timeout or early exit)");
+                            unsafe {
+                                libc::close(pipe_read_fd);
+                                if migration_ok {
+                                    libc::close(migration_parent_fd);
+                                }
+                            }
+                            match child.try_wait() {
+                                Ok(Some(status)) => {
+                                    warn!("New process exited before readiness: {status}");
+                                }
+                                Ok(None) => {
+                                    if let Err(e) = child.kill() {
+                                        warn!(
+                                            "Failed to kill unready child process {child_pid}: {e}"
+                                        );
+                                    } else {
+                                        let _ = child.wait();
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to inspect unready child process {child_pid}: {e}"
+                                    );
+                                }
+                            }
+                            MIGRATION_IN_PROGRESS.store(false, Ordering::Relaxed);
+                            SHUTDOWN_IN_PROGRESS.store(false, Ordering::SeqCst);
+                            return None;
                         }
 
                         unsafe {
@@ -1327,6 +1385,7 @@ async fn binary_upgrade_and_shutdown(
                     Err(e) => {
                         error!("Failed to spawn new process: {}", e);
                         MIGRATION_IN_PROGRESS.store(false, Ordering::Relaxed);
+                        SHUTDOWN_IN_PROGRESS.store(false, Ordering::SeqCst);
                         unsafe {
                             libc::close(pipe_read_fd);
                             libc::close(pipe_write_fd);

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -194,6 +194,102 @@ fn set_fd_close_on_exec(fd: libc::c_int, label: &str) {
     }
 }
 
+#[cfg(not(windows))]
+pub fn cleanup_inherited_upgrade_fds(args: &Args) {
+    let Some(mut keep) = inherited_upgrade_fd_allowlist(args) else {
+        return;
+    };
+    keep.sort_unstable();
+    keep.dedup();
+
+    let closed = close_unexpected_fds_below_limit(&keep);
+    if closed > 0 {
+        eprintln!(
+            "binary upgrade: closed {closed} unexpected inherited file descriptor(s) before startup"
+        );
+    }
+}
+
+#[cfg(windows)]
+pub fn cleanup_inherited_upgrade_fds(_args: &Args) {}
+
+#[cfg(not(windows))]
+fn inherited_upgrade_fd_allowlist(args: &Args) -> Option<Vec<libc::c_int>> {
+    let forced_cleanup = std::env::var("PG_DOORMAN_CLOSE_INHERITED_FDS")
+        .map(|value| value == "1")
+        .unwrap_or(false);
+    if !forced_cleanup && args.inherit_fd.is_none() {
+        return None;
+    }
+    std::env::remove_var("PG_DOORMAN_CLOSE_INHERITED_FDS");
+
+    let mut keep = vec![0, 1, 2];
+
+    if let Some(listener_fd) = args.inherit_fd {
+        keep.push(listener_fd);
+    }
+
+    if let Some(fd) = parse_fd_env("PG_DOORMAN_READY_FD") {
+        keep.push(fd);
+    }
+    if let Some(fd) = parse_fd_env("PG_DOORMAN_MIGRATION_FD") {
+        keep.push(fd);
+    }
+
+    Some(keep)
+}
+
+#[cfg(not(windows))]
+fn parse_fd_env(name: &str) -> Option<libc::c_int> {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<libc::c_int>().ok())
+        .filter(|fd| *fd >= 0)
+}
+
+#[cfg(not(windows))]
+fn close_unexpected_fds_below_limit(keep: &[libc::c_int]) -> usize {
+    let upper = fd_cleanup_upper_bound();
+    close_unexpected_fds(3..upper, keep)
+}
+
+#[cfg(not(windows))]
+fn close_unexpected_fds<I>(fds: I, keep: &[libc::c_int]) -> usize
+where
+    I: IntoIterator<Item = libc::c_int>,
+{
+    let mut closed = 0usize;
+
+    for fd in fds {
+        if fd <= 2 {
+            continue;
+        }
+        if keep.binary_search(&fd).is_ok() {
+            continue;
+        }
+        // SAFETY: closing an fd affects only this child process. EBADF just
+        // means the slot was already empty; other errors are non-actionable
+        // during best-effort inherited-fd cleanup.
+        if unsafe { libc::close(fd) } == 0 {
+            closed += 1;
+        }
+    }
+
+    closed
+}
+
+#[cfg(not(windows))]
+fn fd_cleanup_upper_bound() -> libc::c_int {
+    // SAFETY: getrlimit writes to the stack-local rlimit struct only.
+    unsafe {
+        let mut rl: libc::rlimit = std::mem::zeroed();
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 {
+            return (rl.rlim_cur as u64).min(libc::c_int::MAX as u64) as libc::c_int;
+        }
+    }
+    65_536
+}
+
 /// Single-flight throttle for the listener's "fd table exhausted" log
 /// line. Returns `true` only when the previous successful emission is
 /// at least `ACCEPT_RESOURCE_LOG_INTERVAL_SECS` in the past.
@@ -1035,6 +1131,7 @@ async fn binary_upgrade_and_shutdown(
         let config_test_result = process::Command::new(exe_path)
             .arg("-t")
             .arg(&config_file)
+            .env("PG_DOORMAN_CLOSE_INHERITED_FDS", "1")
             .stdout(process::Stdio::piped())
             .stderr(process::Stdio::piped())
             .output();
@@ -1978,6 +2075,60 @@ mod umask_guard_tests {
             assert_eq!(inside & 0o077, 0o077);
         }
         unsafe { libc::umask(prior) };
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod inherited_fd_cleanup_tests {
+    use super::close_unexpected_fds;
+
+    fn fd_is_open(fd: libc::c_int) -> bool {
+        unsafe { libc::fcntl(fd, libc::F_GETFD) >= 0 }
+    }
+
+    struct Pipe {
+        read: libc::c_int,
+        write: libc::c_int,
+    }
+
+    impl Pipe {
+        fn new() -> Self {
+            let mut fds = [0_i32; 2];
+            let r = unsafe { libc::pipe(fds.as_mut_ptr()) };
+            assert_eq!(r, 0, "pipe(2) failed: {}", std::io::Error::last_os_error());
+            Self {
+                read: fds[0],
+                write: fds[1],
+            }
+        }
+    }
+
+    impl Drop for Pipe {
+        fn drop(&mut self) {
+            if fd_is_open(self.read) {
+                unsafe { libc::close(self.read) };
+            }
+            if fd_is_open(self.write) {
+                unsafe { libc::close(self.write) };
+            }
+        }
+    }
+
+    #[test]
+    fn close_unexpected_fds_preserves_allowlist() {
+        let keep = Pipe::new();
+        let leaked = Pipe::new();
+
+        let mut allow = vec![0, 1, 2, keep.read, keep.write];
+        allow.sort_unstable();
+        let closed =
+            close_unexpected_fds([keep.read, keep.write, leaked.read, leaked.write], &allow);
+
+        assert!(closed >= 2, "expected to close the leaked pipe fds");
+        assert!(fd_is_open(keep.read), "allowlisted read fd must survive");
+        assert!(fd_is_open(keep.write), "allowlisted write fd must survive");
+        assert!(!fd_is_open(leaked.read), "unexpected read fd must close");
+        assert!(!fd_is_open(leaked.write), "unexpected write fd must close");
     }
 }
 

--- a/src/client/error_handling.rs
+++ b/src/client/error_handling.rs
@@ -42,6 +42,12 @@ where
                 let message = format!("Network connection error: {msg}. Please check your network connection.");
                 self.send_error_response(&message, "08006", err).await
             }
+            Error::ConnectResourceExhausted(ref msg) => {
+                let message = format!(
+                    "Connection pooler local resource exhausted: {msg}. Please try again later."
+                );
+                self.send_error_response(&message, "53000", err).await
+            }
             Error::ServerUnavailableError(ref msg, _) => {
                 let message = format!("Server unavailable: {msg}. Please try again later.");
                 self.send_error_response(&message, "08006", err).await

--- a/src/client/migration.rs
+++ b/src/client/migration.rs
@@ -56,6 +56,40 @@ const MAX_PREPARED_ENTRIES: usize = 100_000;
 const MAX_QUERY_LEN: usize = 10 * 1024 * 1024; // 10 MB
 const MAX_RECV_BUF: usize = 64 * 1024;
 
+#[cfg(target_os = "linux")]
+fn recvmsg_cloexec_flags() -> libc::c_int {
+    libc::MSG_CMSG_CLOEXEC
+}
+
+#[cfg(not(target_os = "linux"))]
+fn recvmsg_cloexec_flags() -> libc::c_int {
+    0
+}
+
+fn set_close_on_exec(fd: RawFd) -> Result<(), Error> {
+    // SAFETY: fcntl operates on the received fd only. F_GETFD reads descriptor
+    // flags, F_SETFD writes the same flags with FD_CLOEXEC added.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFD);
+        if flags < 0 {
+            return Err(Error::SocketError(format!(
+                "fcntl(F_GETFD): {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        if flags & libc::FD_CLOEXEC != 0 {
+            return Ok(());
+        }
+        if libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) < 0 {
+            return Err(Error::SocketError(format!(
+                "fcntl(F_SETFD FD_CLOEXEC): {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+    }
+    Ok(())
+}
+
 // FFI for our patched OpenSSL migration functions.
 // Only available with the tls-migration feature (vendored patched OpenSSL).
 #[cfg(feature = "tls-migration")]
@@ -775,7 +809,7 @@ pub fn recv_migration_fd(socket_fd: RawFd) -> Result<(RawFd, BytesMut, Option<Ve
     msghdr.msg_controllen = cmsg_space as _;
 
     // SAFETY: msghdr points to valid iov and cmsg buffers. recvmsg fills them.
-    let n = unsafe { libc::recvmsg(socket_fd, &mut msghdr, 0) };
+    let n = unsafe { libc::recvmsg(socket_fd, &mut msghdr, recvmsg_cloexec_flags()) };
     if n <= 0 {
         return Err(Error::SocketError(if n == 0 {
             "migration socket closed".to_string()
@@ -805,6 +839,11 @@ pub fn recv_migration_fd(socket_fd: RawFd) -> Result<(RawFd, BytesMut, Option<Ve
 
     if received_fd < 0 {
         return Err(Error::SocketError("migration: no fd in cmsg".to_string()));
+    }
+    if let Err(err) = set_close_on_exec(received_fd) {
+        // SAFETY: received_fd is a valid fd from cmsg, close it to avoid leak.
+        unsafe { libc::close(received_fd) };
+        return Err(err);
     }
 
     if n < 4 {
@@ -1088,6 +1127,7 @@ pub async fn migration_receiver_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
 
     #[test]
     fn put_str_get_str_roundtrip() {
@@ -1255,6 +1295,59 @@ mod tests {
         assert_eq!(state.prepared_entries[0].hash, 0xABCD);
         assert_eq!(state.prepared_entries[0].query, "SELECT 1");
         assert_eq!(state.prepared_entries[0].param_types, vec![23]);
+    }
+
+    #[test]
+    fn recv_migration_fd_marks_received_fd_close_on_exec() {
+        let mut sockets: [libc::c_int; 2] = [-1, -1];
+        // SAFETY: socketpair writes two valid fds into sockets on success.
+        let rc =
+            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, sockets.as_mut_ptr()) };
+        assert_eq!(
+            rc,
+            0,
+            "socketpair failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let file = File::open("/dev/null").unwrap();
+        // SAFETY: file.as_raw_fd() is valid for the lifetime of file.
+        let send_fd = unsafe { libc::dup(file.as_raw_fd()) };
+        assert!(
+            send_fd >= 0,
+            "dup failed: {}",
+            std::io::Error::last_os_error()
+        );
+        // Force the sender-side descriptor to be inheritable. The receiver must
+        // not depend on the incoming fd already having FD_CLOEXEC set.
+        unsafe {
+            let flags = libc::fcntl(send_fd, libc::F_GETFD);
+            assert!(flags >= 0, "F_GETFD failed");
+            assert_eq!(
+                libc::fcntl(send_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC),
+                0
+            );
+        }
+
+        let mut payload = MigrationPayload {
+            state: BytesMut::from(&b"state"[..]),
+            fd: send_fd,
+            tls_state: None,
+        };
+        send_migration_fd(sockets[0], &mut payload).unwrap();
+
+        let (received_fd, state, tls_state) = recv_migration_fd(sockets[1]).unwrap();
+        assert_eq!(&state[..], b"state");
+        assert!(tls_state.is_none());
+
+        unsafe {
+            let flags = libc::fcntl(received_fd, libc::F_GETFD);
+            assert!(flags >= 0, "F_GETFD on received fd failed");
+            assert_ne!(flags & libc::FD_CLOEXEC, 0);
+            libc::close(received_fd);
+            libc::close(sockets[0]);
+            libc::close(sockets[1]);
+        }
     }
 
     #[test]

--- a/src/client/migration.rs
+++ b/src/client/migration.rs
@@ -22,12 +22,7 @@ use crate::stats::ClientStats;
 
 use super::core::PreparedStatementState;
 
-/// Restore backend auth state (e.g. SCRAM ClientKey) from a migrated client
-/// so the new process can authenticate to PostgreSQL via passthrough without
-/// waiting for a fresh client SCRAM handshake.
-///
-/// Only overwrites if the current state is `ScramPending` — avoids clobbering
-/// a valid auth state already established by an earlier migrated client.
+/// Restore migrated SCRAM state when backend auth is still pending.
 fn restore_backend_auth_if_pending(
     pool: Option<&ConnectionPool>,
     migrated_auth: Option<&BackendAuthMethod>,
@@ -67,8 +62,7 @@ fn recvmsg_cloexec_flags() -> libc::c_int {
 }
 
 fn set_close_on_exec(fd: RawFd) -> Result<(), Error> {
-    // SAFETY: fcntl operates on the received fd only. F_GETFD reads descriptor
-    // flags, F_SETFD writes the same flags with FD_CLOEXEC added.
+    // SAFETY: fcntl reads and writes descriptor flags for this fd.
     unsafe {
         let flags = libc::fcntl(fd, libc::F_GETFD);
         if flags < 0 {
@@ -114,8 +108,7 @@ fn export_tls_state_from_ptr(ssl_ptr: *mut c_void) -> Result<Vec<u8>, Error> {
     unsafe {
         let mut out: *mut u8 = std::ptr::null_mut();
         let mut out_len: usize = 0;
-        // SAFETY: ssl_ptr is a valid SSL* from the TlsStream, which is still alive
-        // at the idle point when migration runs.
+        // SAFETY: ssl_ptr belongs to the live TlsStream at the migration idle point.
         let ret = SSL_export_migration_state(ssl_ptr, &mut out, &mut out_len);
         if ret != 1 || out.is_null() {
             return Err(Error::ClientError(
@@ -141,8 +134,7 @@ pub struct MigrationPayload {
 impl Drop for MigrationPayload {
     fn drop(&mut self) {
         if self.fd >= 0 {
-            // SAFETY: fd was obtained via libc::dup() in prepare_migration and is
-            // owned exclusively by this struct. Closing a valid owned fd is safe.
+            // SAFETY: this struct owns the dup'd fd from prepare_migration.
             unsafe { libc::close(self.fd) };
         }
     }
@@ -186,10 +178,7 @@ where
     S: tokio::io::AsyncRead + std::marker::Unpin,
     T: tokio::io::AsyncWrite + std::marker::Unpin,
 {
-    /// Serialize client state and dup the fd for migration.
-    /// Called at the idle point in handle() — no server checked out,
-    /// no pending begin, no buffered reads.
-    /// If ssl_ptr is set, exports TLS cipher state via SSL_export_migration_state.
+    /// Serialize idle client state and dup its socket fd for migration.
     pub fn prepare_migration(&self) -> Result<MigrationPayload, Error> {
         let raw_fd = self
             .raw_fd
@@ -1318,8 +1307,7 @@ mod tests {
             "dup failed: {}",
             std::io::Error::last_os_error()
         );
-        // Force the sender-side descriptor to be inheritable. The receiver must
-        // not depend on the incoming fd already having FD_CLOEXEC set.
+        // Force sender-side inheritance; the receiver must set CLOEXEC itself.
         unsafe {
             let flags = libc::fcntl(send_fd, libc::F_GETFD);
             assert!(flags >= 0, "F_GETFD failed");

--- a/src/client/transaction.rs
+++ b/src/client/transaction.rs
@@ -879,6 +879,33 @@ where
                             // buffered state on 'S', error_response, log,
                             // return), only the SQLSTATE and message differ.
                             if let crate::pool::PoolError::Backend(
+                                Error::ConnectResourceExhausted(msg),
+                            ) = &err
+                            {
+                                current_pool.address.stats.error_with_sqlstate("53000");
+                                self.stats.checkout_error();
+
+                                if message[0] as char == 'S' {
+                                    self.reset_buffered_state();
+                                }
+
+                                error_response(
+                                    &mut self.write,
+                                    &format!(
+                                        "Connection pooler local resource exhausted: {msg}. Please try again later."
+                                    ),
+                                    "53000",
+                                )
+                                .await?;
+
+                                error!(
+                                    "[{}@{} #c{}] local resource exhausted while getting server connection: {err}",
+                                    self.username, self.pool_name, self.connection_id,
+                                );
+                                return Err(Error::AllServersDown);
+                            }
+
+                            if let crate::pool::PoolError::Backend(
                                 Error::ServerStartupParameterRejection {
                                     sqlstate,
                                     message: pg_message,

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -53,11 +53,12 @@ pub struct General {
     #[serde(default = "General::default_unix_socket_buffer_size")]
     pub unix_socket_buffer_size: ByteSize,
 
-    /// Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets
-    /// and outbound backend TCP sockets. `0` (default) keeps Linux TCP
-    /// autotuning active. A non-zero value sets fixed send/receive buffer
-    /// limits for the socket and disables autotuning. Linux internally
-    /// doubles the requested values and may clamp them by
+    /// Kernel SO_RCVBUF/SO_SNDBUF limits for accepted client TCP sockets,
+    /// accepted web TCP sockets, and outbound backend TCP sockets. `0`
+    /// (default) keeps Linux TCP autotuning active. A non-zero value sets
+    /// fixed send/receive buffer limits for the socket and disables
+    /// autotuning. Linux internally doubles the requested values and may
+    /// clamp them by
     /// `net.core.rmem_max` / `net.core.wmem_max`. Use 64 KiB-256 KiB as
     /// a starting range for OLTP in one datacenter; measure before using
     /// smaller values, larger values, or WAN links.

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = app::parse_args()?;
+    app::cleanup_inherited_upgrade_fds(&args);
     let config = app::init_config(&args)?;
 
     if args.test_config {

--- a/src/messages/config_socket.rs
+++ b/src/messages/config_socket.rs
@@ -7,7 +7,7 @@ use socket2::{SockRef, TcpKeepalive};
 use tokio::net::{TcpStream, UnixStream};
 
 // Internal crate imports
-use crate::config::get_config;
+use crate::config::{get_config, Config};
 
 /// Configure Unix socket parameters.
 pub fn configure_unix_socket(stream: &UnixStream) {
@@ -55,14 +55,38 @@ pub fn configure_tcp_socket(stream: &TcpStream) {
         Err(err) => error!("failed to set TCP_NODELAY on TCP socket: {err}"),
     }
 
+    configure_tcp_socket_without_linger(&sock_ref, &conf, "TCP socket");
+}
+
+/// Configure accepted web TCP socket parameters.
+///
+/// Web connections are plain HTTP and may be closed immediately after a
+/// response. Do not apply the pooler client `SO_LINGER` policy here: with
+/// `tcp_so_linger = 0`, close(2) becomes abortive and can make HTTP clients
+/// observe connection resets after a valid response. The low-risk options below
+/// still cap per-connection buffer memory and enable dead-peer detection.
+pub fn configure_web_tcp_socket(stream: &TcpStream) {
+    let sock_ref = SockRef::from(stream);
+    let conf = get_config();
+
+    match sock_ref.set_tcp_nodelay(conf.general.tcp_no_delay) {
+        Ok(_) => {}
+        Err(err) => error!("failed to set TCP_NODELAY on web TCP socket: {err}"),
+    }
+
+    configure_tcp_socket_without_linger(&sock_ref, &conf, "web TCP socket");
+}
+
+fn configure_tcp_socket_without_linger(sock_ref: &SockRef<'_>, conf: &Config, label: &str) {
     // Opt-in SO_RCVBUF/SO_SNDBUF. A non-zero value disables Linux TCP
     // autotuning for this socket and sets fixed send/receive buffer
     // limits. Linux doubles the requested values internally and may
     // clamp them by net.core.rmem_max / net.core.wmem_max.
     //
     // This runs for fresh client accepts, outbound backend connects, and
-    // client sockets reconstructed during binary upgrade. SIGHUP reload
-    // alone does not revisit already-open sockets.
+    // client sockets reconstructed during binary upgrade; the web listener
+    // applies the same buffer cap to accepted HTTP sockets. SIGHUP reload alone
+    // does not revisit already-open sockets.
     let buffer_size = conf.general.tcp_socket_buffer_size.as_usize();
     if buffer_size > 0 {
         match sock_ref.set_send_buffer_size(buffer_size) {
@@ -74,26 +98,26 @@ pub fn configure_tcp_socket(stream: &TcpStream) {
                 if log_enabled!(Level::Debug) {
                     if let Ok(applied) = sock_ref.send_buffer_size() {
                         debug!(
-                            "SO_SNDBUF requested={buffer_size} bytes, kernel applied={applied} bytes \
+                            "{label}: SO_SNDBUF requested={buffer_size} bytes, kernel applied={applied} bytes \
                              (kernel doubles; ceiling: net.core.wmem_max)"
                         );
                     }
                 }
             }
-            Err(err) => error!("failed to set SO_SNDBUF on TCP socket: {err}"),
+            Err(err) => error!("failed to set SO_SNDBUF on {label}: {err}"),
         }
         match sock_ref.set_recv_buffer_size(buffer_size) {
             Ok(_) => {
                 if log_enabled!(Level::Debug) {
                     if let Ok(applied) = sock_ref.recv_buffer_size() {
                         debug!(
-                            "SO_RCVBUF requested={buffer_size} bytes, kernel applied={applied} bytes \
+                            "{label}: SO_RCVBUF requested={buffer_size} bytes, kernel applied={applied} bytes \
                              (kernel doubles; ceiling: net.core.rmem_max)"
                         );
                     }
                 }
             }
-            Err(err) => error!("failed to set SO_RCVBUF on TCP socket: {err}"),
+            Err(err) => error!("failed to set SO_RCVBUF on {label}: {err}"),
         }
     }
 
@@ -106,10 +130,10 @@ pub fn configure_tcp_socket(stream: &TcpStream) {
                     .with_time(Duration::from_secs(conf.general.tcp_keepalives_idle)),
             ) {
                 Ok(_) => (),
-                Err(err) => error!("failed to set TCP keepalive parameters on socket: {err}"),
+                Err(err) => error!("failed to set TCP keepalive parameters on {label}: {err}"),
             }
         }
-        Err(err) => error!("failed to enable SO_KEEPALIVE on TCP socket: {err}"),
+        Err(err) => error!("failed to enable SO_KEEPALIVE on {label}: {err}"),
     }
 
     // TCP_USER_TIMEOUT is only supported on Linux
@@ -119,7 +143,7 @@ pub fn configure_tcp_socket(stream: &TcpStream) {
             .set_tcp_user_timeout(Some(Duration::from_secs(conf.general.tcp_user_timeout)))
         {
             Ok(_) => (),
-            Err(err) => error!("failed to set TCP_USER_TIMEOUT on socket: {err}"),
+            Err(err) => error!("failed to set TCP_USER_TIMEOUT on {label}: {err}"),
         }
     }
 }

--- a/src/messages/config_socket.rs
+++ b/src/messages/config_socket.rs
@@ -60,11 +60,8 @@ pub fn configure_tcp_socket(stream: &TcpStream) {
 
 /// Configure accepted web TCP socket parameters.
 ///
-/// Web connections are plain HTTP and may be closed immediately after a
-/// response. Do not apply the pooler client `SO_LINGER` policy here: with
-/// `tcp_so_linger = 0`, close(2) becomes abortive and can make HTTP clients
-/// observe connection resets after a valid response. The low-risk options below
-/// still cap per-connection buffer memory and enable dead-peer detection.
+/// Web HTTP sockets must not inherit the pooler client `SO_LINGER` policy:
+/// `tcp_so_linger = 0` can turn a normal HTTP close into a reset.
 pub fn configure_web_tcp_socket(stream: &TcpStream) {
     let sock_ref = SockRef::from(stream);
     let conf = get_config();
@@ -83,10 +80,7 @@ fn configure_tcp_socket_without_linger(sock_ref: &SockRef<'_>, conf: &Config, la
     // limits. Linux doubles the requested values internally and may
     // clamp them by net.core.rmem_max / net.core.wmem_max.
     //
-    // This runs for fresh client accepts, outbound backend connects, and
-    // client sockets reconstructed during binary upgrade; the web listener
-    // applies the same buffer cap to accepted HTTP sockets. SIGHUP reload alone
-    // does not revisit already-open sockets.
+    // SIGHUP does not resize sockets that are already open.
     let buffer_size = conf.general.tcp_socket_buffer_size.as_usize();
     if buffer_size > 0 {
         match sock_ref.set_send_buffer_size(buffer_size) {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -17,7 +17,7 @@ pub mod socket;
 pub mod types;
 
 // Re-export public items
-pub use config_socket::{configure_tcp_socket, configure_unix_socket};
+pub use config_socket::{configure_tcp_socket, configure_unix_socket, configure_web_tcp_socket};
 pub use error::PgErrorMsg;
 pub use extended::{close_complete, Bind, Close, Describe, ExtendedProtocolData, Parse};
 pub use protocol::{

--- a/src/pool/fallback.rs
+++ b/src/pool/fallback.rs
@@ -45,6 +45,9 @@ pub enum FailureReason {
     /// Couldn't reach the candidate at the transport layer (TCP refuse,
     /// network unreachable, DNS).
     ConnectError,
+    /// pg_doorman itself could not allocate another fd while trying to connect.
+    /// This is local resource exhaustion, not candidate host health.
+    ResourceExhausted,
     /// Server was reached but responded with FATAL during startup
     /// (auth, pg_hba, missing database).
     StartupError,
@@ -67,6 +70,7 @@ impl FailureReason {
     pub fn as_str(self) -> &'static str {
         match self {
             FailureReason::ConnectError => "connect_error",
+            FailureReason::ResourceExhausted => "resource_exhausted",
             FailureReason::StartupError => "startup_error",
             FailureReason::ServerUnavailable => "server_unavailable",
             FailureReason::Timeout => "timeout",
@@ -76,9 +80,13 @@ impl FailureReason {
     }
 
     /// Whether `mark_unhealthy` should record a cooldown entry. Operator
-    /// config errors must not blacklist a healthy candidate.
+    /// config errors and local fd exhaustion must not blacklist a healthy
+    /// candidate.
     pub fn warrants_host_cooldown(self) -> bool {
-        !matches!(self, FailureReason::StartupParameterRejection)
+        !matches!(
+            self,
+            FailureReason::StartupParameterRejection | FailureReason::ResourceExhausted
+        )
     }
 }
 
@@ -92,6 +100,7 @@ impl From<&Error> for FailureReason {
                 FailureReason::Timeout
             }
             Error::ConnectError(_) => FailureReason::ConnectError,
+            Error::ConnectResourceExhausted(_) => FailureReason::ResourceExhausted,
             Error::ServerUnavailableError(_, _) => FailureReason::ServerUnavailable,
             Error::ServerStartupError(_, _) => FailureReason::StartupError,
             Error::ServerStartupParameterRejection { .. } => {
@@ -312,9 +321,10 @@ impl FallbackState {
             .with_label_values(&[self.pool_name.as_str(), reason.as_str()])
             .inc();
 
-        // Operator config errors (e.g. invalid startup_parameter) must not
-        // blacklist a healthy candidate — the same misconfiguration will
-        // fail against every host until the operator fixes the config.
+        // Operator config errors (e.g. invalid startup_parameter) and local
+        // resource exhaustion must not blacklist a healthy candidate. The
+        // former fails against every host until the operator fixes the config;
+        // the latter is pg_doorman's fd table, not the candidate.
         // Count it in the failure metric (above), then return.
         if !reason.warrants_host_cooldown() {
             return;
@@ -895,6 +905,12 @@ mod tests {
             FailureReason::ConnectError
         );
         assert_eq!(
+            FailureReason::from(&Error::ConnectResourceExhausted(
+                "too many open files".into()
+            )),
+            FailureReason::ResourceExhausted
+        );
+        assert_eq!(
             FailureReason::from(&Error::ConnectError(
                 "server startup timed out to 1.2.3.4:5432 after 3000ms".into()
             )),
@@ -922,15 +938,17 @@ mod tests {
     }
 
     #[test]
-    fn warrants_host_cooldown_skips_only_startup_parameter_rejection() {
+    fn warrants_host_cooldown_skips_non_host_failures() {
         // The whole point of the new helper: every host-related failure
-        // still cools the host down, only operator-config errors do not.
+        // still cools the host down. Operator-config errors and local
+        // pg_doorman resource exhaustion are not host health signals.
         assert!(FailureReason::ConnectError.warrants_host_cooldown());
         assert!(FailureReason::StartupError.warrants_host_cooldown());
         assert!(FailureReason::ServerUnavailable.warrants_host_cooldown());
         assert!(FailureReason::Timeout.warrants_host_cooldown());
         assert!(FailureReason::Other.warrants_host_cooldown());
         assert!(!FailureReason::StartupParameterRejection.warrants_host_cooldown());
+        assert!(!FailureReason::ResourceExhausted.warrants_host_cooldown());
     }
 
     #[test]

--- a/src/pool/fallback.rs
+++ b/src/pool/fallback.rs
@@ -45,8 +45,7 @@ pub enum FailureReason {
     /// Couldn't reach the candidate at the transport layer (TCP refuse,
     /// network unreachable, DNS).
     ConnectError,
-    /// pg_doorman itself could not allocate another fd while trying to connect.
-    /// This is local resource exhaustion, not candidate host health.
+    /// Local pg_doorman fd exhaustion while connecting.
     ResourceExhausted,
     /// Server was reached but responded with FATAL during startup
     /// (auth, pg_hba, missing database).
@@ -56,11 +55,8 @@ pub enum FailureReason {
     ServerUnavailable,
     /// `startup_with_timeout` deadline elapsed.
     Timeout,
-    /// PostgreSQL rejected an operator-supplied startup parameter (the
-    /// real SQLSTATE lives in the carried Error). Distinct from
-    /// StartupError because the candidate host is healthy — only the
-    /// operator config is wrong — so it must not enter the per-host
-    /// cooldown that StartupError implies.
+    /// PostgreSQL rejected an operator-supplied startup parameter.
+    /// The candidate host is healthy; do not put it in cooldown.
     StartupParameterRejection,
     /// Anything else — should normally not happen on the fallback path.
     Other,
@@ -79,9 +75,7 @@ impl FailureReason {
         }
     }
 
-    /// Whether `mark_unhealthy` should record a cooldown entry. Operator
-    /// config errors and local fd exhaustion must not blacklist a healthy
-    /// candidate.
+    /// Whether this failure says anything about candidate health.
     pub fn warrants_host_cooldown(self) -> bool {
         !matches!(
             self,
@@ -93,9 +87,7 @@ impl FailureReason {
 impl From<&Error> for FailureReason {
     fn from(err: &Error) -> Self {
         match err {
-            // `startup_with_timeout` produces ConnectError with a literal
-            // "startup timed out" prefix; promote it to its own bucket so
-            // operators distinguish "couldn't connect" from "stuck postgres".
+            // `startup_with_timeout` tags its ConnectError with this prefix.
             Error::ConnectError(msg) if msg.starts_with("server startup timed out") => {
                 FailureReason::Timeout
             }
@@ -303,29 +295,15 @@ impl FallbackState {
     /// Mark a candidate unhealthy. The next `get_fallback_targets` call will
     /// skip this `(host, port)` until the cooldown window elapses.
     ///
-    /// Cooldown grows exponentially on consecutive failures: base for the
-    /// first miss, then doubles each subsequent failure while the cooldown
-    /// is still active, capped at `COOLDOWN_MAX`. Once the cooldown expires
-    /// (lazily cleaned on `is_unhealthy` miss or on `prune_expired_unhealthy`
-    /// at the start of discovery), the counter resets — a candidate that
-    /// came back healthy and failed again later starts fresh, not at its
-    /// old penalty.
-    ///
-    /// Also records the failure reason in the per-pool Prometheus counter.
-    /// The map is unbounded: realistic Patroni clusters have under a dozen
-    /// members, expired entries are pruned at every discovery cycle, and
-    /// `COOLDOWN_MAX = 60s` puts a hard ceiling on how long any one entry
-    /// stays active.
+    /// Also records the reason in metrics. Host-independent errors increment
+    /// the metric but do not create a cooldown entry.
     pub fn mark_unhealthy(&self, host: &str, port: u16, reason: FailureReason) {
         crate::web::metrics::FALLBACK_CANDIDATE_FAILURES_TOTAL
             .with_label_values(&[self.pool_name.as_str(), reason.as_str()])
             .inc();
 
-        // Operator config errors (e.g. invalid startup_parameter) and local
-        // resource exhaustion must not blacklist a healthy candidate. The
-        // former fails against every host until the operator fixes the config;
-        // the latter is pg_doorman's fd table, not the candidate.
-        // Count it in the failure metric (above), then return.
+        // Keep the metric, but do not blacklist a healthy host for
+        // operator config errors or local pg_doorman fd exhaustion.
         if !reason.warrants_host_cooldown() {
             return;
         }

--- a/src/pool/server_pool.rs
+++ b/src/pool/server_pool.rs
@@ -463,6 +463,7 @@ impl ServerPool {
             Err(err) if self.address.server_tls.mode.retries_with_tls() => !matches!(
                 err,
                 Error::ConnectError(_)
+                    | Error::ConnectResourceExhausted(_)
                     | Error::ServerUnavailableError(_, _)
                     | Error::ServerStartupParameterRejection { .. }
             ),
@@ -868,9 +869,11 @@ impl ServerPool {
     /// there's nothing to race against.
     ///
     /// On exhaustion: returns `ConnectError("all fallback candidates
-    /// rejected (...)")` with a deterministic per-reason summary. Each
-    /// failed candidate is also marked unhealthy (with exponential
-    /// backoff) and logged at WARN (rate-limited) or DEBUG.
+    /// rejected (...)")` with a deterministic per-reason summary, unless a
+    /// host-independent typed error (startup-parameter rejection or local fd
+    /// exhaustion) should be preserved for the caller. Each host-related failed
+    /// candidate is also marked unhealthy (with exponential backoff) and logged
+    /// at WARN (rate-limited) or DEBUG.
     async fn run_fallback_round(
         &self,
         fallback: &super::fallback::FallbackState,
@@ -1030,7 +1033,15 @@ impl ServerPool {
         // so wrapping it in 53300 would just rewrite the actionable
         // error.
         if summary.has_startup_parameter_rejection() {
-            if let Some(err) = summary.into_startup_rejection() {
+            if let Some(err) = summary.startup_rejection() {
+                return (Err(err), source);
+            }
+        }
+        // Local fd exhaustion is a pg_doorman resource problem, not a failed
+        // Patroni target. Preserve the typed error so the caller does not
+        // mistake it for "all backends unreachable".
+        if summary.has_resource_exhaustion() {
+            if let Some(err) = summary.resource_exhaustion() {
                 return (Err(err), source);
             }
         }
@@ -1174,6 +1185,7 @@ impl ServerPool {
             Err(err) if fallback_address.server_tls.mode.retries_with_tls() => !matches!(
                 err,
                 Error::ConnectError(_)
+                    | Error::ConnectResourceExhausted(_)
                     | Error::ServerUnavailableError(_, _)
                     | Error::ServerStartupParameterRejection { .. }
             ),
@@ -1400,6 +1412,11 @@ struct FailureSummary {
     /// transport failures on the rest must still surface the PG
     /// error so the operator sees the actionable cause.
     typed_startup_rejection: Option<Error>,
+    /// First local fd exhaustion seen during a fallback round. This is not a
+    /// host failure and must not be wrapped back into `ConnectError`, otherwise
+    /// callers can mistake pg_doorman resource pressure for backend
+    /// reachability.
+    typed_resource_exhaustion: Option<Error>,
     counts: std::collections::HashMap<super::fallback::FailureReason, u32>,
 }
 
@@ -1427,6 +1444,11 @@ impl FailureSummary {
                 });
             }
         }
+        if matches!(reason, super::fallback::FailureReason::ResourceExhausted)
+            && self.typed_resource_exhaustion.is_none()
+        {
+            self.typed_resource_exhaustion = Some(err.clone());
+        }
         self.last_err = Some(err);
     }
 
@@ -1438,8 +1460,26 @@ impl FailureSummary {
         self.typed_startup_rejection.is_some()
     }
 
+    fn startup_rejection(&self) -> Option<Error> {
+        self.typed_startup_rejection.clone()
+    }
+
+    #[cfg(test)]
     fn into_startup_rejection(self) -> Option<Error> {
         self.typed_startup_rejection
+    }
+
+    fn has_resource_exhaustion(&self) -> bool {
+        self.typed_resource_exhaustion.is_some()
+    }
+
+    fn resource_exhaustion(&self) -> Option<Error> {
+        self.typed_resource_exhaustion.clone()
+    }
+
+    #[cfg(test)]
+    fn into_resource_exhaustion(self) -> Option<Error> {
+        self.typed_resource_exhaustion
     }
 
     /// Kept for the legacy "every failure was rejection" tests. The
@@ -1585,6 +1625,27 @@ mod tests {
         Error::ConnectError("server startup timed out after 5s".to_string())
     }
 
+    fn resource_exhausted_err() -> Error {
+        Error::ConnectResourceExhausted("too many open files".to_string())
+    }
+
+    #[test]
+    fn backend_unreachable_excludes_local_resource_exhaustion() {
+        let id = crate::errors::ServerIdentifier::new("alice".to_string(), "db", "pool_a");
+
+        assert!(is_backend_unreachable(&Error::ConnectError(
+            "connection refused".into()
+        )));
+        assert!(is_backend_unreachable(&Error::ServerUnavailableError(
+            "the database system is starting up".into(),
+            id,
+        )));
+        assert!(
+            !is_backend_unreachable(&resource_exhausted_err()),
+            "EMFILE/ENFILE is pg_doorman resource exhaustion, not backend unreachability"
+        );
+    }
+
     #[test]
     fn all_startup_parameter_rejection_false_when_empty() {
         let s = FailureSummary::default();
@@ -1648,6 +1709,27 @@ mod tests {
                 assert_eq!(sqlstate, "22023")
             }
             other => panic!("expected the retained rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failure_summary_retains_resource_exhaustion() {
+        let mut s = FailureSummary::default();
+        s.record(
+            timeout_err(),
+            super::super::fallback::FailureReason::Timeout,
+        );
+        s.record(
+            resource_exhausted_err(),
+            super::super::fallback::FailureReason::ResourceExhausted,
+        );
+
+        assert!(s.has_resource_exhaustion());
+        match s.into_resource_exhaustion() {
+            Some(Error::ConnectResourceExhausted(msg)) => {
+                assert!(msg.contains("too many open files"), "unexpected msg: {msg}");
+            }
+            other => panic!("expected resource exhaustion, got {other:?}"),
         }
     }
 

--- a/src/pool/server_pool.rs
+++ b/src/pool/server_pool.rs
@@ -818,15 +818,9 @@ impl ServerPool {
         let (result, source) = self.run_fallback_round(fallback).await;
         match result {
             Ok(conn) => Ok(conn),
-            // Host-independent failures short-circuit before the
-            // stale-whitelist retry, and survive the inner-retry
-            // rewrap untouched. Stringifying them into
-            // `ConnectError` would route a local fd exhaustion or a
-            // config rejection through the Patroni cooldown
-            // machinery — exactly the cascade
-            // `fix/binary-upgrade-fd-leak` exists to prevent. See
-            // `is_host_independent_error` for the predicate and the
-            // unit tests that pin it.
+            // Skip the whitelist retry for failures no candidate
+            // switch can fix; the typed variant must survive instead
+            // of being stringified into `ConnectError`.
             Err(err) if is_host_independent_error(&err) => Err(err),
             Err(err) => match source {
                 super::fallback::TargetSource::WhitelistCache => {

--- a/src/pool/server_pool.rs
+++ b/src/pool/server_pool.rs
@@ -818,13 +818,16 @@ impl ServerPool {
         let (result, source) = self.run_fallback_round(fallback).await;
         match result {
             Ok(conn) => Ok(conn),
-            // The startup_parameters preflight is host-independent. If it
-            // rejected the cascade, every candidate would fail with the
-            // same SQLSTATE until the operator fixes the config. Return
-            // the rejection unchanged so the client sees the PG-style
-            // error, and skip the whitelist clear so a healthy whitelist
-            // is not wiped because of a configuration bug.
-            Err(err @ Error::ServerStartupParameterRejection { .. }) => Err(err),
+            // Host-independent failures short-circuit before the
+            // stale-whitelist retry, and survive the inner-retry
+            // rewrap untouched. Stringifying them into
+            // `ConnectError` would route a local fd exhaustion or a
+            // config rejection through the Patroni cooldown
+            // machinery — exactly the cascade
+            // `fix/binary-upgrade-fd-leak` exists to prevent. See
+            // `is_host_independent_error` for the predicate and the
+            // unit tests that pin it.
+            Err(err) if is_host_independent_error(&err) => Err(err),
             Err(err) => match source {
                 super::fallback::TargetSource::WhitelistCache => {
                     // Cached host was stale; wipe it and try with full
@@ -837,9 +840,13 @@ impl ServerPool {
                     fallback.clear_whitelist();
                     let (retry_result, _) = self.run_fallback_round(fallback).await;
                     retry_result.map_err(|e2| {
-                        Error::ConnectError(format!(
-                            "fallback exhausted (whitelist round: {err}; discovery round: {e2})"
-                        ))
+                        if is_host_independent_error(&e2) {
+                            e2
+                        } else {
+                            Error::ConnectError(format!(
+                                "fallback exhausted (whitelist round: {err}; discovery round: {e2})"
+                            ))
+                        }
                     })
                 }
                 super::fallback::TargetSource::Discovery => Err(err),
@@ -1586,6 +1593,32 @@ where
 /// disabled (`lifetime_ms == 0`), or the connection is still within budget.
 ///
 /// Pulled out of `recycle()` so the lifetime decision can be exercised
+/// Whether the failure is host-independent — i.e. switching
+/// candidates within the Patroni cluster cannot fix it. Used by the
+/// fallback wrapper to skip the stale-whitelist retry and to preserve
+/// the typed variant when the inner retry path would otherwise
+/// stringify the error into `ConnectError`.
+///
+/// Two classes today:
+///
+/// - `ServerStartupParameterRejection`: every member would reject the
+///   same way until the operator fixes the config.
+/// - `ConnectResourceExhausted`: pg_doorman ran out of fds locally;
+///   no Patroni member is broken, so there is no point clearing the
+///   whitelist or accusing a candidate.
+///
+/// Anything classified as host-independent here must also be excluded
+/// from `is_backend_unreachable` and from `warrants_host_cooldown` in
+/// `super::fallback`; the three predicates work together. Adding a
+/// new variant here without updating those locations would leak the
+/// typed error back into Patroni cooldown bookkeeping.
+fn is_host_independent_error(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::ServerStartupParameterRejection { .. } | Error::ConnectResourceExhausted(_)
+    )
+}
+
 /// without constructing a real `Server` connection in tests.
 fn lifetime_exceeded(metrics: &Metrics, skip_lifetime: bool) -> Option<u64> {
     if skip_lifetime || metrics.lifetime_ms == 0 {
@@ -1627,6 +1660,38 @@ mod tests {
 
     fn resource_exhausted_err() -> Error {
         Error::ConnectResourceExhausted("too many open files".to_string())
+    }
+
+    #[test]
+    fn is_host_independent_error_covers_resource_exhaustion_and_startup_rejection() {
+        assert!(
+            is_host_independent_error(&resource_exhausted_err()),
+            "local fd exhaustion is host-independent: clearing the whitelist and rediscovering will not free fds in this process"
+        );
+        assert!(
+            is_host_independent_error(&rejection_err()),
+            "PostgreSQL startup_parameter rejection is host-independent: every member would reject the same way until the operator fixes the config"
+        );
+    }
+
+    #[test]
+    fn is_host_independent_error_excludes_transport_failures() {
+        let id = crate::errors::ServerIdentifier::new("alice".to_string(), "db", "pool_a");
+        assert!(
+            !is_host_independent_error(&Error::ConnectError("connection refused".into())),
+            "`ConnectError` is the candidate-fault signal that drives Patroni cooldown"
+        );
+        assert!(
+            !is_host_independent_error(&timeout_err()),
+            "a startup timeout against one candidate may succeed against another"
+        );
+        assert!(
+            !is_host_independent_error(&Error::ServerUnavailableError(
+                "the database system is starting up".into(),
+                id,
+            )),
+            "an unavailable candidate is still candidate-specific; switching members can recover"
+        );
     }
 
     #[test]

--- a/src/pool/server_pool.rs
+++ b/src/pool/server_pool.rs
@@ -603,20 +603,12 @@ impl ServerPool {
             &pool_params,
             auth_query_params.as_ref(),
         );
-        // Use the pure classifier so this admin/API path does not
-        // increment STARTUP_PARAMETERS_DROPPED_TOTAL or emit warn logs
-        // — both are side effects of the spawn path
-        // (resolved_startup_parameters). SHOW polling and /api/pools
-        // page refreshes are safe to call repeatedly.
+        // Use the pure classifier so admin/API polling has no metric or log
+        // side effects.
         let (wire_cow, decision) = self.classify_startup_parameters();
         let wire = wire_cow.as_ref();
-        // If an auth_query overlay would push the cascade over budget,
-        // every overlay key is dropped due to budget, even when the
-        // baseline carries the same key with another value. Both
-        // over-budget decisions reject backend startup, so the admin/API
-        // view must show that no configured key reaches PostgreSQL.
-        // Reporting those keys as `Applied` or `Stale` would point the
-        // operator at RELOAD/refetch, which cannot fix a budget failure.
+        // If the cascade was rejected for budget, report every configured
+        // key as dropped.
         let cascade_rejected = matches!(
             decision,
             BudgetDecision::OverlayDroppedBaselineKept { .. }
@@ -644,13 +636,8 @@ impl ServerPool {
                 (k, (v, src, state))
             })
             .collect();
-        // Surface wire-only keys: a key that the live config no longer
-        // mentions but that the pool's frozen baseline / overlay still
-        // ships is invisible without this loop. The operator needs to
-        // see that "I deleted plan_cache_mode from pool.startup_parameters
-        // but my backends are still getting force_custom_plan" — that is
-        // exactly the stale snapshot RELOAD has not yet recycled (or that
-        // the auth_query cache has not yet refetched).
+        // Surface wire-only stale keys from the frozen baseline or auth_query
+        // overlay.
         let wire_state = if cascade_rejected {
             ApplicationState::DroppedDueToBudget
         } else {
@@ -669,13 +656,7 @@ impl ServerPool {
         out
     }
 
-    /// Pure classifier shared between the spawn path and the read-only
-    /// admin/API views. Returns the wire-ready map and the budget
-    /// decision the runtime would make for this spawn, **without**
-    /// touching `STARTUP_PARAMETERS_DROPPED_TOTAL`. Both fields are
-    /// precomputed at pool construction (`build_resolved_startup`), so
-    /// every call hands back a borrow of the cached `Arc` instead of
-    /// cloning and re-validating the merge.
+    /// Read-only startup-parameter classifier shared by spawn and admin/API.
     fn classify_startup_parameters(
         &self,
     ) -> (
@@ -688,18 +669,10 @@ impl ServerPool {
         )
     }
 
-    /// will hand to `Server::startup` for one backend spawn.
+    /// Startup parameters for one backend spawn.
     ///
-    /// Without a per-user auth_query overlay, this borrows the cached base
-    /// map. With an overlay, it clones the base map and applies the user
-    /// values.
-    ///
-    /// The merged map is checked against the operator budget and the full
-    /// PostgreSQL startup-packet limit. Any overflow, whether caused by
-    /// the auth_query overlay, the general/pool baseline, or the full
-    /// StartupMessage, becomes a PG-style
-    /// `ServerStartupParameterRejection`. That gives the client a clear
-    /// error instead of silently dropping configured startup parameters.
+    /// Overflow becomes `ServerStartupParameterRejection` instead of
+    /// silently dropping configured parameters.
     fn resolved_startup_parameters(
         &self,
     ) -> Result<std::borrow::Cow<'_, BTreeMap<String, String>>, Error> {
@@ -768,17 +741,9 @@ impl ServerPool {
         }
     }
 
-    /// Establish a fallback connection by iterating through Patroni-discovered
-    /// candidates. Per-candidate failures (auth error, "database is starting up",
-    /// startup timeout, etc.) mark the candidate unhealthy and proceed to the
-    /// next one. Hard-bounded by `query_wait_timeout`: there is no point
-    /// spending more time here than the client itself is willing to wait.
+    /// Establish a fallback connection within `query_wait_timeout`.
     async fn create_fallback_connection(&self) -> Result<Server, Error> {
-        // `query_wait_timeout` is a soft outer deadline: it bounds how long
-        // the client waits, but per-candidate `startup_with_timeout` already
-        // guarantees we cannot block on a single hung node. If the outer
-        // deadline fires we still return a clean `ConnectError` so the
-        // client gets a sanitized FATAL rather than a hang.
+        // Outer deadline bounds total fallback time for this checkout.
         let deadline = self.query_wait_timeout;
         info!(
             "[{}@{}] fallback: local backend unavailable, entering fallback path (deadline={}ms)",
@@ -803,8 +768,7 @@ impl ServerPool {
         }
     }
 
-    /// Inner body so the outer wrapper can apply the `query_wait_timeout`
-    /// guard. Holds the retry-after-stale-whitelist policy.
+    /// Fallback body plus one stale-whitelist retry.
     async fn create_fallback_connection_inner(&self) -> Result<Server, Error> {
         let fallback = match self.fallback_state.as_ref() {
             Some(fb) => fb,
@@ -818,15 +782,11 @@ impl ServerPool {
         let (result, source) = self.run_fallback_round(fallback).await;
         match result {
             Ok(conn) => Ok(conn),
-            // Skip the whitelist retry for failures no candidate
-            // switch can fix; the typed variant must survive instead
-            // of being stringified into `ConnectError`.
+            // Failures that no candidate switch can fix keep their typed error.
             Err(err) if is_host_independent_error(&err) => Err(err),
             Err(err) => match source {
                 super::fallback::TargetSource::WhitelistCache => {
-                    // Cached host was stale; wipe it and try with full
-                    // discovery exactly once more. If discovery fails
-                    // too, return that failure without a third attempt.
+                    // Cached host may be stale; retry once with discovery.
                     info!(
                         "[{}@{}] fallback: whitelist round failed ({err}), retrying with fresh discovery",
                         self.address.username, self.address.pool_name,
@@ -848,33 +808,11 @@ impl ServerPool {
         }
     }
 
-    /// Run a single fallback round and produce a connection.
+    /// Run one fallback round.
     ///
-    /// **Two-wave priority race.** Discovery returns every alive member
-    /// from `/cluster`; we partition by role and run two waves serially:
-    /// 1. **Wave 1 — sync_standby.** Race `Server::startup` against every
-    ///    sync_standby in parallel under per-candidate
-    ///    `fallback_connect_timeout`. The first Ok wins immediately. The
-    ///    user-facing requirement is "sync wins if it's alive at all";
-    ///    we do not consider replica/leader while any sync candidate is
-    ///    still in-flight, even if a replica would have answered faster.
-    /// 2. **Wave 2 — replica + leader.** Only entered if every sync_standby
-    ///    failed (or none existed). Race the rest in parallel; first Ok
-    ///    wins. Among non-sync candidates we do not preserve replica >
-    ///    leader sub-priority — under fallback the system is already in
-    ///    a degraded state, fastest live answer is more useful than
-    ///    role-based ordering.
-    ///
-    /// Whitelist-cache hits (`source = WhitelistCache`) skip the wave
-    /// machinery and run a single startup against the cached host, since
-    /// there's nothing to race against.
-    ///
-    /// On exhaustion: returns `ConnectError("all fallback candidates
-    /// rejected (...)")` with a deterministic per-reason summary, unless a
-    /// host-independent typed error (startup-parameter rejection or local fd
-    /// exhaustion) should be preserved for the caller. Each host-related failed
-    /// candidate is also marked unhealthy (with exponential backoff) and logged
-    /// at WARN (rate-limited) or DEBUG.
+    /// Discovery races sync_standby first, then every other candidate.
+    /// Whitelist-cache hits run a single target. Host-independent typed errors
+    /// are preserved.
     async fn run_fallback_round(
         &self,
         fallback: &super::fallback::FallbackState,
@@ -893,23 +831,13 @@ impl ServerPool {
                     Err(Error::ConnectError(format!(
                         "fallback discovery failed: {e}"
                     ))),
-                    // Discovery itself failed: no source to speak of, but the
-                    // caller treats Discovery as "no retry" — which is what
-                    // we want here, the next attempt will be a fresh client
-                    // request, not an automatic retry.
+                    // No automatic retry after discovery failure.
                     super::fallback::TargetSource::Discovery,
                 );
             }
         };
 
-        // Resolve the startup_parameters cascade once for the whole
-        // fallback round. Without this, a wave of N candidates would
-        // do N×{auth_query peek, BTreeMap clone, validation walk}
-        // for one client checkout — and the merge result is host-
-        // independent, so the per-candidate work was pure waste.
-        // `try_fallback_target` borrows this map for both the plain
-        // attempt and the optional sslmode=allow TLS retry. An
-        // over-budget cascade fails the whole fallback round here.
+        // Startup parameters are host-independent; resolve once per round.
         let startup_parameters_round = match self.resolved_startup_parameters() {
             Ok(map) => map,
             Err(err) => return (Err(err), source),
@@ -1025,22 +953,13 @@ impl ServerPool {
             "[{}@{}] fallback: all fallback candidates rejected ({summary_str})",
             self.address.username, self.address.pool_name,
         );
-        // If at least one fallback candidate reached PG's StartupMessage
-        // stage and got rejected for an operator-supplied startup
-        // parameter, surface PG's actual sqlstate/message. The
-        // misconfiguration is host-independent — every other reachable
-        // candidate would fail the same way once we got past transport
-        // issues — and healthy hosts are not blacklisted on this reason,
-        // so wrapping it in 53300 would just rewrite the actionable
-        // error.
+        // Surface typed startup-parameter rejection; another host cannot fix it.
         if summary.has_startup_parameter_rejection() {
             if let Some(err) = summary.startup_rejection() {
                 return (Err(err), source);
             }
         }
-        // Local fd exhaustion is a pg_doorman resource problem, not a failed
-        // Patroni target. Preserve the typed error so the caller does not
-        // mistake it for "all backends unreachable".
+        // Preserve local fd exhaustion as a pooler resource error.
         if summary.has_resource_exhaustion() {
             if let Some(err) = summary.resource_exhaustion() {
                 return (Err(err), source);
@@ -1054,11 +973,7 @@ impl ServerPool {
         )
     }
 
-    /// Race `Server::startup` against `targets` in parallel. On first Ok
-    /// return `Some(server)` (winner is whitelisted as a side effect). On
-    /// full exhaustion mark every loser unhealthy, record reasons into
-    /// `summary`, and return `None`; the caller advances to the next wave or
-    /// returns the aggregate error.
+    /// Race a fallback wave; whitelist winner, record loser failures.
     async fn race_wave(
         &self,
         fallback: &super::fallback::FallbackState,
@@ -1067,10 +982,7 @@ impl ServerPool {
         source: super::fallback::TargetSource,
         startup_parameters: &BTreeMap<String, String>,
     ) -> Option<Server> {
-        // We only count "we attempted to use fallback" once per wave, on
-        // entry — not per candidate. The metric measures fallback usage
-        // pressure, not per-host attempt counts (those live in
-        // `_candidate_failures_total`).
+        // Count one fallback use per wave, not per candidate.
         crate::web::metrics::FALLBACK_CONNECTIONS_TOTAL
             .with_label_values(&[&self.address.pool_name])
             .inc();
@@ -1126,16 +1038,13 @@ impl ServerPool {
         }
     }
 
-    /// Attempt a single fallback target with optional sslmode=allow TLS retry.
-    /// Returns Ok with a ready Server, or Err mapped from `Server::startup`
-    /// (including `ConnectError` on `startup_with_timeout` deadline).
+    /// Try one fallback target with optional sslmode=allow TLS retry.
     async fn try_fallback_target(
         &self,
         target: &super::fallback::FallbackTarget,
         startup_parameters: &BTreeMap<String, String>,
     ) -> Result<Server, Error> {
-        // Use the fallback_connect_timeout for fallback startup deadlines —
-        // the same scale as the TCP-probe and per-candidate cooldown window.
+        // Use the fallback per-candidate startup timeout.
         let fallback_timeout = self
             .fallback_state
             .as_ref()
@@ -1152,12 +1061,8 @@ impl ServerPool {
         ));
         stats.register(stats.clone());
 
-        // `startup_parameters` is resolved once per fallback round by
-        // the caller (`run_fallback_round` / `race_wave`), so a wave
-        // of N candidates does N×0 cascade resolves and merges instead
-        // of N×1. The fallback target's pool name matches `self`, so
-        // the per-pool cascade still applies even though we are talking
-        // to a different physical host than `self.address.host`.
+        // Startup parameters are resolved once per fallback round; each
+        // candidate reuses the same per-pool cascade.
 
         let result = startup_with_timeout(
             fallback_timeout,
@@ -1312,16 +1217,10 @@ impl ServerPool {
         }
     }
 
-    /// Checks if the connection can be recycled.
-    /// Performs lifetime check and alive check for idle connections.
+    /// Checks whether a server connection can be reused.
     ///
-    /// `skip_lifetime` lets the caller suppress the `server_lifetime`
-    /// expiration check when the pool is under client pressure (no spare
-    /// permits, queue forming). Lifetime is housekeeping, not safety: closing
-    /// an aged-but-working connection mid-storm forces a `connect()` round-trip
-    /// onto the wait path of every queued client. Bad-connection, RECONNECT
-    /// epoch and idle-alive checks always run regardless of the flag — those
-    /// are correctness, not housekeeping.
+    /// `skip_lifetime` suppresses only `server_lifetime` under client
+    /// pressure. Bad-connection, reconnect-epoch, and alive checks still run.
     pub async fn recycle(
         &self,
         conn: &mut Server,
@@ -1341,9 +1240,7 @@ impl ServerPool {
             ));
         }
 
-        // Check server_lifetime - applies to all connections, not just idle
-        // Uses per-connection lifetime with jitter to prevent mass closures.
-        // Skipped when the pool is under pressure: see doc-comment above.
+        // Lifetime cleanup is skipped while the pool is under pressure.
         if let Some(age_ms) = lifetime_exceeded(metrics, skip_lifetime) {
             conn.close_reason = Some(format!(
                 "lifetime exceeded (age={}, limit={})",
@@ -1353,7 +1250,7 @@ impl ServerPool {
             return Err(RecycleError::StaticMessage("Connection exceeded lifetime"));
         }
 
-        // Check if connection was idle too long and needs alive check
+        // Probe long-idle connections before reuse.
         if self.idle_check_timeout_ms > 0 {
             if let Some(recycled) = metrics.recycled {
                 let idle_time_ms = recycled.elapsed().as_millis() as u64;
@@ -1378,9 +1275,7 @@ impl ServerPool {
     }
 }
 
-/// Compact "host:port(role)" list for log lines that summarise a wave's
-/// candidate set. Keeps the message readable when the wave has 5+
-/// candidates without splitting into multiple lines.
+/// Compact "host:port(role)" list for fallback wave logs.
 fn format_target_list(targets: &[super::fallback::FallbackTarget]) -> String {
     targets
         .iter()
@@ -1396,27 +1291,13 @@ fn is_backend_unreachable(err: &Error) -> bool {
     )
 }
 
-/// Aggregator for per-candidate failure reasons inside one fallback round.
-/// Lets `run_fallback_round` build a categorical summary like "3
-/// startup_error, 1 timeout" instead of leaking only the last error to the
-/// client — operators can tell apart "kernel-level connectivity broken" from
-/// "everyone refused on auth" at a glance.
+/// Per-candidate failure counters and typed host-independent errors.
 #[derive(Default)]
 struct FailureSummary {
     last_err: Option<Error>,
-    /// The first `ServerStartupParameterRejection` observed in the
-    /// round. PG rejection of an operator startup_parameter is a
-    /// host-independent config error: even one PG candidate that
-    /// reached the StartupMessage stage and rejected the cascade
-    /// means the same SQLSTATE/message will repeat on every other
-    /// reachable PG. Mixed-failure rounds with one PG rejection plus
-    /// transport failures on the rest must still surface the PG
-    /// error so the operator sees the actionable cause.
+    /// First startup-parameter rejection seen in this fallback round.
     typed_startup_rejection: Option<Error>,
-    /// First local fd exhaustion seen during a fallback round. This is not a
-    /// host failure and must not be wrapped back into `ConnectError`, otherwise
-    /// callers can mistake pg_doorman resource pressure for backend
-    /// reachability.
+    /// First local fd exhaustion seen in this fallback round.
     typed_resource_exhaustion: Option<Error>,
     counts: std::collections::HashMap<super::fallback::FailureReason, u32>,
 }
@@ -1429,9 +1310,7 @@ impl FailureSummary {
             super::fallback::FailureReason::StartupParameterRejection
         ) && self.typed_startup_rejection.is_none()
         {
-            // Clone the rejection — the original moves into `last_err`
-            // so the aggregate `format()` and surrounding code keep
-            // working unchanged.
+            // Keep a typed copy; the original moves into `last_err`.
             if let Error::ServerStartupParameterRejection {
                 sqlstate,
                 message,
@@ -1453,10 +1332,7 @@ impl FailureSummary {
         self.last_err = Some(err);
     }
 
-    /// Was at least one fallback candidate rejected by PG specifically
-    /// for an operator-supplied startup_parameter? Mixed-failure rounds
-    /// use this to keep the typed PG error from being wrapped in the
-    /// generic transport-aggregate message.
+    /// Whether the round saw a typed startup-parameter rejection.
     fn has_startup_parameter_rejection(&self) -> bool {
         self.typed_startup_rejection.is_some()
     }
@@ -1483,9 +1359,7 @@ impl FailureSummary {
         self.typed_resource_exhaustion
     }
 
-    /// Kept for the legacy "every failure was rejection" tests. The
-    /// production path uses `has_startup_parameter_rejection` and only
-    /// needs the typed copy retained separately.
+    /// Legacy helper for tests that require every failure to be a rejection.
     #[cfg(test)]
     fn all_startup_parameter_rejection(&self) -> bool {
         !self.counts.is_empty()
@@ -1516,16 +1390,8 @@ impl FailureSummary {
     }
 }
 
-/// Race `futures` and return the first `Ok`, together with its index in the
-/// input slice. If every future yields `Err`, return all errors with their
-/// original indices; the caller decides how to use them for per-host cooldown
-/// and log aggregation. Pending futures are dropped on first
-/// success, which cancels the in-flight `Server::startup` for the losing
-/// candidates: their TCP sockets go away under us; the kernel finishes the
-/// half-open handshake asynchronously. The user-facing requirement is
-/// "first successful sync wins", and chasing
-/// graceful disconnect on every loser would gate the winner on the slowest
-/// loser.
+/// Return the first success with its original index.
+/// If every future fails, return all indexed errors.
 async fn race_first_success<'a, T: 'a, E: 'a>(
     futures: Vec<futures::future::BoxFuture<'a, Result<T, E>>>,
 ) -> Result<(T, usize), Vec<(usize, E)>> {
@@ -1533,9 +1399,7 @@ async fn race_first_success<'a, T: 'a, E: 'a>(
         return Err(Vec::new());
     }
 
-    // Bake the original index into each future's output so `select_all`'s
-    // own ephemeral index — which renumbers as `rest` shrinks — is not
-    // load-bearing.
+    // Keep original indices; select_all renumbers as `rest` shrinks.
     let mut indexed: Vec<futures::future::BoxFuture<'a, (usize, Result<T, E>)>> = futures
         .into_iter()
         .enumerate()
@@ -1555,12 +1419,8 @@ async fn race_first_success<'a, T: 'a, E: 'a>(
     Err(errors)
 }
 
-/// Wraps a `Server::startup` call in a hard deadline. On timeout returns
-/// `Error::ConnectError`, which is treated as transport-level failure: on the
-/// main path it triggers fallback, on the fallback path it lets the caller
-/// mark the candidate unhealthy and try the next one. Without this, a postgres
-/// that opened a TCP socket but never replies to StartupMessage would keep
-/// pg_doorman blocked on `read_u8` forever.
+/// Wrap server startup in the fallback connect timeout.
+/// Timeouts become `ConnectError` so fallback can try another candidate.
 async fn startup_with_timeout<F>(
     timeout_duration: Duration,
     host: &str,
@@ -1581,39 +1441,7 @@ where
     }
 }
 
-/// Returns `Some(age_ms)` when a connection should be closed because it
-/// crossed its per-connection `lifetime_ms` budget. Returns `None` when the
-/// caller asked to skip the check (`skip_lifetime`), the lifetime budget is
-/// disabled (`lifetime_ms == 0`), or the connection is still within budget.
-///
-/// Pulled out of `recycle()` so the lifetime decision can be exercised
-/// Whether the failure is host-independent — i.e. switching
-/// candidates within the Patroni cluster cannot fix it. Used by the
-/// fallback wrapper to skip the stale-whitelist retry and to preserve
-/// the typed variant when the inner retry path would otherwise
-/// stringify the error into `ConnectError`.
-///
-/// Two classes today:
-///
-/// - `ServerStartupParameterRejection`: every member would reject the
-///   same way until the operator fixes the config.
-/// - `ConnectResourceExhausted`: pg_doorman ran out of fds locally;
-///   no Patroni member is broken, so there is no point clearing the
-///   whitelist or accusing a candidate.
-///
-/// Anything classified as host-independent here must also be excluded
-/// from `is_backend_unreachable` and from `warrants_host_cooldown` in
-/// `super::fallback`; the three predicates work together. Adding a
-/// new variant here without updating those locations would leak the
-/// typed error back into Patroni cooldown bookkeeping.
-fn is_host_independent_error(e: &Error) -> bool {
-    matches!(
-        e,
-        Error::ServerStartupParameterRejection { .. } | Error::ConnectResourceExhausted(_)
-    )
-}
-
-/// without constructing a real `Server` connection in tests.
+/// Return age when per-connection lifetime is exceeded and not skipped.
 fn lifetime_exceeded(metrics: &Metrics, skip_lifetime: bool) -> Option<u64> {
     if skip_lifetime || metrics.lifetime_ms == 0 {
         return None;
@@ -1624,6 +1452,19 @@ fn lifetime_exceeded(metrics: &Metrics, skip_lifetime: bool) -> Option<u64> {
     } else {
         None
     }
+}
+
+/// Error classes that a different Patroni member cannot fix.
+///
+/// Keep this predicate aligned with `is_backend_unreachable` and
+/// `FailureReason::warrants_host_cooldown`: local fd exhaustion and
+/// operator startup-parameter errors must not clear the whitelist or
+/// enter host cooldown bookkeeping.
+fn is_host_independent_error(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::ServerStartupParameterRejection { .. } | Error::ConnectResourceExhausted(_)
+    )
 }
 
 #[cfg(test)]
@@ -1658,14 +1499,8 @@ mod tests {
 
     #[test]
     fn is_host_independent_error_covers_resource_exhaustion_and_startup_rejection() {
-        assert!(
-            is_host_independent_error(&resource_exhausted_err()),
-            "local fd exhaustion is host-independent: clearing the whitelist and rediscovering will not free fds in this process"
-        );
-        assert!(
-            is_host_independent_error(&rejection_err()),
-            "PostgreSQL startup_parameter rejection is host-independent: every member would reject the same way until the operator fixes the config"
-        );
+        assert!(is_host_independent_error(&resource_exhausted_err()));
+        assert!(is_host_independent_error(&rejection_err()));
     }
 
     #[test]
@@ -1673,18 +1508,18 @@ mod tests {
         let id = crate::errors::ServerIdentifier::new("alice".to_string(), "db", "pool_a");
         assert!(
             !is_host_independent_error(&Error::ConnectError("connection refused".into())),
-            "`ConnectError` is the candidate-fault signal that drives Patroni cooldown"
+            "transport failures are candidate-specific"
         );
         assert!(
             !is_host_independent_error(&timeout_err()),
-            "a startup timeout against one candidate may succeed against another"
+            "startup timeout is candidate-specific"
         );
         assert!(
             !is_host_independent_error(&Error::ServerUnavailableError(
                 "the database system is starting up".into(),
                 id,
             )),
-            "an unavailable candidate is still candidate-specific; switching members can recover"
+            "server unavailable is candidate-specific"
         );
     }
 

--- a/src/server/stream.rs
+++ b/src/server/stream.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::time::Instant;
 
 use crate::config::tls::ServerTlsConfig;
@@ -147,9 +148,10 @@ pub(crate) async fn create_unix_stream_inner(host: &str, port: u16) -> Result<St
         Ok(s) => s,
         Err(err) => {
             log::error!("Failed to connect to Unix socket {host}:{port}: {err}");
-            return Err(Error::ConnectError(format!(
-                "Failed to connect to Unix socket {host}:{port}: {err}"
-            )));
+            return Err(connect_error_from_io(
+                &format!("Unix socket {host}:{port}"),
+                err,
+            ));
         }
     };
 
@@ -174,9 +176,7 @@ pub(crate) async fn create_tcp_stream_inner(
         Ok(stream) => stream,
         Err(err) => {
             log::error!("Failed to connect to TCP {host}:{port}: {err}");
-            return Err(Error::ConnectError(format!(
-                "Could not connect to {host}:{port}: {err}"
-            )));
+            return Err(connect_error_from_io(&format!("{host}:{port}"), err));
         }
     };
 
@@ -294,5 +294,55 @@ pub(crate) async fn create_tcp_stream_inner(
             "unexpected tls negotiation response={} (0x{:02x}) host={host} port={port}",
             other, other as u8
         ))),
+    }
+}
+
+fn connect_error_from_io(target: &str, err: io::Error) -> Error {
+    let msg = format!("Could not connect to {target}: {err}");
+    if is_fd_exhaustion_io(&err) {
+        Error::ConnectResourceExhausted(msg)
+    } else {
+        Error::ConnectError(msg)
+    }
+}
+
+#[cfg(unix)]
+fn is_fd_exhaustion_io(err: &io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE))
+}
+
+#[cfg(not(unix))]
+fn is_fd_exhaustion_io(_err: &io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn connect_error_from_io_keeps_fd_exhaustion_typed() {
+        let err = io::Error::from_raw_os_error(libc::EMFILE);
+
+        match connect_error_from_io("127.0.0.1:5432", err) {
+            Error::ConnectResourceExhausted(msg) => {
+                assert!(msg.contains("127.0.0.1:5432"), "unexpected msg: {msg}");
+            }
+            other => panic!("expected ConnectResourceExhausted, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn connect_error_from_io_keeps_regular_connect_errors_unreachable() {
+        let err = io::Error::from_raw_os_error(libc::ECONNREFUSED);
+
+        match connect_error_from_io("127.0.0.1:5432", err) {
+            Error::ConnectError(msg) => {
+                assert!(msg.contains("127.0.0.1:5432"), "unexpected msg: {msg}");
+            }
+            other => panic!("expected ConnectError, got {other:?}"),
+        }
     }
 }

--- a/src/web/server/listener.rs
+++ b/src/web/server/listener.rs
@@ -4,13 +4,40 @@
 //! [`current_options`].
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use log::{error, info};
 use tokio::net::{TcpListener, TcpSocket};
 
 use super::http::handle_connection;
 use super::state::{current_options, install_options, WebServerOptions};
+
+static WEB_ACCEPT_RESOURCE_LOG_LAST: AtomicI64 = AtomicI64::new(0);
+const WEB_ACCEPT_RESOURCE_LOG_INTERVAL_SECS: i64 = 5;
+
+#[cfg(unix)]
+fn is_fd_exhaustion_io(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE),)
+}
+
+#[cfg(not(unix))]
+fn is_fd_exhaustion_io(_e: &std::io::Error) -> bool {
+    false
+}
+
+fn should_log_web_accept_resource_now() -> bool {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let last = WEB_ACCEPT_RESOURCE_LOG_LAST.load(Ordering::Relaxed);
+    now_secs.saturating_sub(last) >= WEB_ACCEPT_RESOURCE_LOG_INTERVAL_SECS
+        && WEB_ACCEPT_RESOURCE_LOG_LAST
+            .compare_exchange(last, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+}
 
 /// Bind the listener synchronously and return it. Used by callers that
 /// want to fail fast when the configured port is taken: the daemon's
@@ -55,7 +82,17 @@ pub async fn serve_on(listener: TcpListener, opts: WebServerOptions) {
                 });
             }
             Err(e) => {
-                error!("Failed to accept connection: {e}");
+                if is_fd_exhaustion_io(&e) {
+                    if should_log_web_accept_resource_now() {
+                        error!(
+                            "Failed to accept connection: {e} \
+                             (process fd table exhausted; backing off)"
+                        );
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                } else {
+                    error!("Failed to accept connection: {e}");
+                }
             }
         }
     }

--- a/src/web/server/listener.rs
+++ b/src/web/server/listener.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 use log::{error, info};
 use tokio::net::{TcpListener, TcpSocket};
 
+use crate::messages::configure_web_tcp_socket;
+
 use super::http::handle_connection;
 use super::state::{current_options, install_options, WebServerOptions};
 
@@ -76,6 +78,7 @@ pub async fn serve_on(listener: TcpListener, opts: WebServerOptions) {
     loop {
         match listener.accept().await {
             Ok((stream, _)) => {
+                configure_web_tcp_socket(&stream);
                 let opts = current_options();
                 tokio::spawn(async move {
                     handle_connection(stream, opts).await;

--- a/src/web/server/listener.rs
+++ b/src/web/server/listener.rs
@@ -41,11 +41,7 @@ fn should_log_web_accept_resource_now() -> bool {
             .is_ok()
 }
 
-/// Bind the listener synchronously and return it. Used by callers that
-/// want to fail fast when the configured port is taken: the daemon's
-/// readiness signal must wait until the web subsystem is verifiably
-/// listening, otherwise systemd / a binary-upgrade parent treats the
-/// pooler as healthy while `/metrics` and the UI are silently down.
+/// Bind synchronously so startup/readiness fails if the web port cannot bind.
 pub fn bind_web_listener(host: &str) -> std::io::Result<TcpListener> {
     info!("binding web listener on {host}");
     let addr: SocketAddr = host.parse().map_err(|e| {
@@ -69,9 +65,7 @@ pub fn bind_web_listener(host: &str) -> std::io::Result<TcpListener> {
     Ok(listener)
 }
 
-/// Drive the accept loop on a pre-bound listener. Used by both
-/// [`start_web_server`] and the production startup path that binds
-/// synchronously before spawning.
+/// Drive the accept loop on a pre-bound listener.
 pub async fn serve_on(listener: TcpListener, opts: WebServerOptions) {
     install_options(Arc::new(opts));
 

--- a/tests/bdd/binary_upgrade_fd_helper.rs
+++ b/tests/bdd/binary_upgrade_fd_helper.rs
@@ -1,0 +1,181 @@
+//! BDD steps for the binary-upgrade fd-leak coverage.
+//!
+//! Three operations:
+//! 1. Discover the current pg_doorman PID from outside the process
+//!    (parses `/proc/net/tcp` for the LISTEN inode on `doorman_port`,
+//!    then maps that inode to a process via `/proc/<pid>/fd`).
+//! 2. Capture an `FdInventory` snapshot for a stored PID and stash the
+//!    socket / total / non-listener-socket counters in `world.vars`
+//!    under a caller-named key. Two of those snapshots form the input
+//!    to the delta assertion that catches the FD_CLOEXEC migration
+//!    leak across chained SIGUSR2 upgrades.
+//! 3. Universal FD_CLOEXEC assertion across every non-listener socket
+//!    fd of a stored PID.
+//!
+//! All inspection runs from the test process. `pg_doorman` is never
+//! asked to introspect its own fd table — the leak we are catching is
+//! exactly the kind that masks `/proc/self/fd` reads under EMFILE.
+
+use crate::proc_inspect::{find_pid_owning_listener, inventory, summary, FdInventory};
+use crate::world::DoormanWorld;
+use cucumber::{then, when};
+use log::info;
+
+/// Key used in `world.named_backend_pids` for PIDs discovered via the
+/// external `/proc` walker. We piggy-back on the existing PID hashmap
+/// instead of introducing a new field so existing PID-comparison steps
+/// (`foreground pg_doorman PID should be different from stored ...`)
+/// keep working unchanged against names we store here.
+fn pid_slot(name: &str) -> (String, String) {
+    (name.to_string(), "foreground_pid".to_string())
+}
+
+#[when(regex = r#"^we discover the current pg_doorman PID externally and store as "([^"]+)"$"#)]
+pub async fn discover_pid_externally(world: &mut DoormanWorld, name: String) {
+    let port = world
+        .doorman_port
+        .expect("doorman_port not set — pg_doorman must be started first");
+    let pid = find_pid_owning_listener(port)
+        .unwrap_or_else(|e| panic!("discover pid for port {port}: {e}"));
+    info!(
+        "[binary-upgrade-fd] discovered pid={} for listener on port {} (storing as '{}')",
+        pid, port, name
+    );
+    world.named_backend_pids.insert(pid_slot(&name), pid as i32);
+}
+
+fn captured_pid(world: &DoormanWorld, name: &str) -> u32 {
+    *world
+        .named_backend_pids
+        .get(&pid_slot(name))
+        .unwrap_or_else(|| panic!("no PID stored under name '{name}' — call `discover the current pg_doorman PID externally and store as \"{name}\"` first"))
+        as u32
+}
+
+fn store_inventory_counters(world: &mut DoormanWorld, key: &str, inv: &FdInventory) {
+    let summary_line = summary(inv);
+    info!("[binary-upgrade-fd] capture '{}': {}", key, summary_line);
+    world
+        .vars
+        .insert(format!("{key}_summary"), summary_line.clone());
+    world
+        .vars
+        .insert(format!("{key}_total"), inv.total_fds().to_string());
+    world
+        .vars
+        .insert(format!("{key}_sockets"), inv.socket_fd_count().to_string());
+    world.vars.insert(
+        format!("{key}_non_listener_sockets"),
+        inv.non_listener_socket_fds().len().to_string(),
+    );
+}
+
+fn read_counter(world: &DoormanWorld, key: &str) -> usize {
+    let raw = world.vars.get(key).unwrap_or_else(|| {
+        panic!("no captured counter '{key}' in world.vars — capture an inventory first")
+    });
+    raw.parse::<usize>()
+        .unwrap_or_else(|e| panic!("counter '{key}' = {raw:?} is not numeric: {e}"))
+}
+
+#[when(regex = r#"^we capture the fd inventory for stored PID "([^"]+)" as "([^"]+)"$"#)]
+pub async fn capture_fd_inventory(world: &mut DoormanWorld, pid_name: String, key: String) {
+    let pid = captured_pid(world, &pid_name);
+    let port = world.doorman_port.expect("doorman_port not set");
+    let inv =
+        inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid} port={port}: {e}"));
+    store_inventory_counters(world, &key, &inv);
+}
+
+#[then(
+    regex = r#"^the non-listener socket fd count delta from "([^"]+)" to "([^"]+)" should be at most (\d+)$"#
+)]
+pub async fn non_listener_socket_delta_at_most(
+    world: &mut DoormanWorld,
+    before: String,
+    after: String,
+    slack: usize,
+) {
+    let before_n = read_counter(world, &format!("{before}_non_listener_sockets"));
+    let after_n = read_counter(world, &format!("{after}_non_listener_sockets"));
+    let summary_before = world
+        .vars
+        .get(&format!("{before}_summary"))
+        .cloned()
+        .unwrap_or_default();
+    let summary_after = world
+        .vars
+        .get(&format!("{after}_summary"))
+        .cloned()
+        .unwrap_or_default();
+    let delta = after_n as isize - before_n as isize;
+    assert!(
+        delta <= slack as isize,
+        "non-listener socket fd count grew by {delta} (from {before_n} to {after_n}); allowed slack {slack}\n  before: {summary_before}\n  after:  {summary_after}"
+    );
+}
+
+#[then(regex = r#"^the socket fd count for stored PID "([^"]+)" should be at most (\d+)$"#)]
+pub async fn socket_count_at_most(world: &mut DoormanWorld, pid_name: String, max: usize) {
+    let pid = captured_pid(world, &pid_name);
+    let port = world.doorman_port.expect("doorman_port not set");
+    let inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
+    let n = inv.socket_fd_count();
+    assert!(
+        n <= max,
+        "pid={pid} has {n} socket fd(s); allowed at most {max}\n  {}",
+        summary(&inv)
+    );
+}
+
+#[then(regex = r#"^every non-listener socket fd of stored PID "([^"]+)" has FD_CLOEXEC set$"#)]
+pub async fn every_non_listener_socket_is_cloexec(world: &mut DoormanWorld, pid_name: String) {
+    let pid = captured_pid(world, &pid_name);
+    let port = world.doorman_port.expect("doorman_port not set");
+    let inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
+    let offenders = inv.non_listener_sockets_without_cloexec();
+    assert!(
+        offenders.is_empty(),
+        "pid={pid}: {} non-listener socket fd(s) missing FD_CLOEXEC out of {} checked\n  {}\n{}",
+        offenders.len(),
+        inv.non_listener_socket_fds().len(),
+        summary(&inv),
+        inv.format_offender_lines(&offenders)
+    );
+}
+
+#[then(regex = r#"^stored PID "([^"]+)" should be different from stored PID "([^"]+)"$"#)]
+pub async fn stored_pids_differ(world: &mut DoormanWorld, a: String, b: String) {
+    let pa = captured_pid(world, &a);
+    let pb = captured_pid(world, &b);
+    assert_ne!(
+        pa, pb,
+        "expected different PIDs but '{a}' and '{b}' both = {pa}"
+    );
+}
+
+/// Targets the process at a name previously captured by
+/// `we discover the current pg_doorman PID externally and store as "<NAME>"`.
+/// Needed for chained binary upgrades: after the first `SIGUSR2`, the
+/// original `world.doorman_process` handle no longer points at the
+/// process that owns the listener, so the default
+/// `we send SIGUSR2 to foreground pg_doorman` step (which uses that
+/// handle) would deliver the signal to the dead parent.
+#[when(regex = r#"^we send SIGUSR2 to pg_doorman process at stored PID "([^"]+)"$"#)]
+pub async fn send_sigusr2_to_stored_pid(world: &mut DoormanWorld, name: String) {
+    let pid = captured_pid(world, &name);
+    info!(
+        "[binary-upgrade-fd] sending SIGUSR2 to stored PID '{}' = {}",
+        name, pid
+    );
+    // SAFETY: kill(2) with a non-zero pid signals that process by id.
+    // We just looked the PID up from /proc and verified it owns the
+    // doorman listener inode, so it cannot be a stale dead PID.
+    let rc = unsafe { libc::kill(pid as i32, libc::SIGUSR2) };
+    assert_eq!(
+        rc,
+        0,
+        "kill(pid={pid}, SIGUSR2) failed: {}",
+        std::io::Error::last_os_error()
+    );
+}

--- a/tests/bdd/binary_upgrade_fd_helper.rs
+++ b/tests/bdd/binary_upgrade_fd_helper.rs
@@ -183,8 +183,21 @@ pub async fn pipe_count_at_most(world: &mut DoormanWorld, pid_name: String, max:
 pub async fn every_non_listener_socket_is_cloexec(world: &mut DoormanWorld, pid_name: String) {
     let pid = captured_pid(world, &pid_name);
     let port = world.doorman_port.expect("doorman_port not set");
-    let inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
-    let offenders = inv.non_listener_sockets_without_cloexec();
+
+    // Re-inventory once on a first miss to tolerate transient races
+    // where `/proc/<pid>/fdinfo/<fd>` is unreadable for a moment
+    // (e.g. the fd closed between readlink and the flags read). If a
+    // fd reappears as a non-listener socket but its CLOEXEC state is
+    // still unknown on the second sample, fail — we'd rather flag an
+    // unknowable fd than silently call it safe.
+    let mut inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
+    let mut offenders = inv.non_listener_sockets_without_cloexec();
+    if !offenders.is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        inv = inventory(pid, port).unwrap_or_else(|e| panic!("re-inventory pid={pid}: {e}"));
+        offenders = inv.non_listener_sockets_without_cloexec();
+    }
+
     assert!(
         offenders.is_empty(),
         "pid={pid}: {} non-listener socket fd(s) missing FD_CLOEXEC out of {} checked\n  {}\n{}",

--- a/tests/bdd/binary_upgrade_fd_helper.rs
+++ b/tests/bdd/binary_upgrade_fd_helper.rs
@@ -38,8 +38,7 @@ pub async fn discover_pid_externally(world: &mut DoormanWorld, name: String) {
     let pid = find_pid_owning_listener(port)
         .unwrap_or_else(|e| panic!("discover pid for port {port}: {e}"));
     info!(
-        "[binary-upgrade-fd] discovered pid={} for listener on port {} (storing as '{}')",
-        pid, port, name
+        "[binary-upgrade-fd] discovered pid={pid} for listener on port {port} (storing as '{name}')"
     );
     world.named_backend_pids.insert(pid_slot(&name), pid as i32);
 }
@@ -126,6 +125,58 @@ pub async fn socket_count_at_most(world: &mut DoormanWorld, pid_name: String, ma
         "pid={pid} has {n} socket fd(s); allowed at most {max}\n  {}",
         summary(&inv)
     );
+}
+
+/// Counts fds whose `readlink` target starts with `pipe:[`. Used by
+/// the polluted-parent scenario: the test seeds the parent with N
+/// pairs of pipe fds before exec, then asserts the count went down
+/// across the binary-upgrade boundary because the child's cleanup
+/// pass should have closed them.
+fn pipe_fd_count(inv: &crate::proc_inspect::FdInventory) -> usize {
+    inv.fds.iter().filter(|f| f.kind() == "pipe").count()
+}
+
+#[then(regex = r#"^the pipe fd count for stored PID "([^"]+)" should be at least (\d+)$"#)]
+pub async fn pipe_count_at_least(world: &mut DoormanWorld, pid_name: String, min: usize) {
+    let pid = captured_pid(world, &pid_name);
+    let port = world.doorman_port.expect("doorman_port not set");
+    let inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
+    let n = pipe_fd_count(&inv);
+    assert!(
+        n >= min,
+        "pid={pid} has {n} pipe fd(s); expected at least {min}\n  {}",
+        summary(&inv)
+    );
+}
+
+#[then(regex = r#"^the pipe fd count for stored PID "([^"]+)" should be at most (\d+)$"#)]
+pub async fn pipe_count_at_most(world: &mut DoormanWorld, pid_name: String, max: usize) {
+    let pid = captured_pid(world, &pid_name);
+    let port = world.doorman_port.expect("doorman_port not set");
+    let inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
+    let n = pipe_fd_count(&inv);
+    if n > max {
+        let log_excerpt = world
+            .doorman_log_path
+            .as_ref()
+            .map(|p| {
+                std::fs::read_to_string(p)
+                    .map(|s| {
+                        let lines: Vec<&str> = s.lines().collect();
+                        let tail: Vec<&str> = lines.iter().rev().take(60).rev().copied().collect();
+                        tail.join("\n")
+                    })
+                    .unwrap_or_else(|e| format!("(failed to read log: {e})"))
+            })
+            .unwrap_or_else(|| "(no log capture path)".to_string());
+        let cmdline = std::fs::read_to_string(format!("/proc/{pid}/cmdline"))
+            .map(|s| s.replace('\0', " ").trim().to_string())
+            .unwrap_or_else(|e| format!("(no cmdline: {e})"));
+        panic!(
+            "pid={pid} has {n} pipe fd(s); allowed at most {max}\n  {}\n  cmdline: {cmdline}\n  -- doorman log tail (60 lines) --\n{log_excerpt}\n  -- end log --",
+            summary(&inv)
+        );
+    }
 }
 
 #[then(regex = r#"^every non-listener socket fd of stored PID "([^"]+)" has FD_CLOEXEC set$"#)]

--- a/tests/bdd/binary_upgrade_fd_helper.rs
+++ b/tests/bdd/binary_upgrade_fd_helper.rs
@@ -1,31 +1,13 @@
-//! BDD steps for the binary-upgrade fd-leak coverage.
-//!
-//! Three operations:
-//! 1. Discover the current pg_doorman PID from outside the process
-//!    (parses `/proc/net/tcp` for the LISTEN inode on `doorman_port`,
-//!    then maps that inode to a process via `/proc/<pid>/fd`).
-//! 2. Capture an `FdInventory` snapshot for a stored PID and stash the
-//!    socket / total / non-listener-socket counters in `world.vars`
-//!    under a caller-named key. Two of those snapshots form the input
-//!    to the delta assertion that catches the FD_CLOEXEC migration
-//!    leak across chained SIGUSR2 upgrades.
-//! 3. Universal FD_CLOEXEC assertion across every non-listener socket
-//!    fd of a stored PID.
-//!
-//! All inspection runs from the test process. `pg_doorman` is never
-//! asked to introspect its own fd table — the leak we are catching is
-//! exactly the kind that masks `/proc/self/fd` reads under EMFILE.
+//! BDD steps for binary-upgrade fd checks.
+//! Inspection runs from the test process, not from pg_doorman under
+//! fd pressure.
 
 use crate::proc_inspect::{find_pid_owning_listener, inventory, summary, FdInventory};
 use crate::world::DoormanWorld;
 use cucumber::{then, when};
 use log::info;
 
-/// Key used in `world.named_backend_pids` for PIDs discovered via the
-/// external `/proc` walker. We piggy-back on the existing PID hashmap
-/// instead of introducing a new field so existing PID-comparison steps
-/// (`foreground pg_doorman PID should be different from stored ...`)
-/// keep working unchanged against names we store here.
+/// Store externally discovered pg_doorman PIDs in the existing PID map.
 fn pid_slot(name: &str) -> (String, String) {
     (name.to_string(), "foreground_pid".to_string())
 }
@@ -129,11 +111,7 @@ pub async fn socket_count_at_most(world: &mut DoormanWorld, pid_name: String, ma
     );
 }
 
-/// Counts fds whose `readlink` target starts with `pipe:[`. Used by
-/// the polluted-parent scenario: the test seeds the parent with N
-/// pairs of pipe fds before exec, then asserts the count went down
-/// across the binary-upgrade boundary because the child's cleanup
-/// pass should have closed them.
+/// Pipe fds are the pollution marker in the inherited-fd cleanup scenario.
 fn pipe_fd_count(inv: &crate::proc_inspect::FdInventory) -> usize {
     inv.fds.iter().filter(|f| f.kind() == "pipe").count()
 }
@@ -151,15 +129,7 @@ pub async fn pipe_count_at_least(world: &mut DoormanWorld, pid_name: String, min
     );
 }
 
-/// Asserts that the pipe fd count *dropped* by at least `min` between
-/// two captured inventories. Pairs naturally with the
-/// `pre_exec`-seeded inheritable pipes: 16 pipe pairs = 32 fds, so a
-/// working `c891054` cleanup is expected to close at least 20 of
-/// them (5 slack covers tokio/jemalloc internal pipe churn during
-/// the process replacement). This is the delta form of the older
-/// `pipe fd count ... should be at most N` assertion, which depended
-/// on an absolute pipe-count number that drifts with runtime
-/// internals.
+/// Assert that upgrade cleanup removed most of the seeded inheritable pipes.
 #[then(regex = r#"^the pipe fd count drop from "([^"]+)" to "([^"]+)" should be at least (\d+)$"#)]
 pub async fn pipe_count_drop_at_least(
     world: &mut DoormanWorld,
@@ -221,12 +191,8 @@ pub async fn every_non_listener_socket_is_cloexec(world: &mut DoormanWorld, pid_
     let pid = captured_pid(world, &pid_name);
     let port = world.doorman_port.expect("doorman_port not set");
 
-    // Re-inventory once on a first miss to tolerate transient races
-    // where `/proc/<pid>/fdinfo/<fd>` is unreadable for a moment
-    // (e.g. the fd closed between readlink and the flags read). If a
-    // fd reappears as a non-listener socket but its CLOEXEC state is
-    // still unknown on the second sample, fail — we'd rather flag an
-    // unknowable fd than silently call it safe.
+    // Retry once for fd close/readlink races. A remaining unknown
+    // CLOEXEC state is a failure.
     let mut inv = inventory(pid, port).unwrap_or_else(|e| panic!("inventory pid={pid}: {e}"));
     let mut offenders = inv.non_listener_sockets_without_cloexec();
     if !offenders.is_empty() {
@@ -255,13 +221,7 @@ pub async fn stored_pids_differ(world: &mut DoormanWorld, a: String, b: String) 
     );
 }
 
-/// Targets the process at a name previously captured by
-/// `we discover the current pg_doorman PID externally and store as "<NAME>"`.
-/// Needed for chained binary upgrades: after the first `SIGUSR2`, the
-/// original `world.doorman_process` handle no longer points at the
-/// process that owns the listener, so the default
-/// `we send SIGUSR2 to foreground pg_doorman` step (which uses that
-/// handle) would deliver the signal to the dead parent.
+/// Send SIGUSR2 to a PID discovered after the previous upgrade.
 #[when(regex = r#"^we send SIGUSR2 to pg_doorman process at stored PID "([^"]+)"$"#)]
 pub async fn send_sigusr2_to_stored_pid(world: &mut DoormanWorld, name: String) {
     let pid = captured_pid(world, &name);
@@ -269,9 +229,8 @@ pub async fn send_sigusr2_to_stored_pid(world: &mut DoormanWorld, name: String) 
         "[binary-upgrade-fd] sending SIGUSR2 to stored PID '{}' = {}",
         name, pid
     );
-    // SAFETY: kill(2) with a non-zero pid signals that process by id.
-    // We just looked the PID up from /proc and verified it owns the
-    // doorman listener inode, so it cannot be a stale dead PID.
+    // SAFETY: kill(2) with a non-zero pid signals that process id.
+    // The scenario stores this PID immediately after external listener discovery.
     let rc = unsafe { libc::kill(pid as i32, libc::SIGUSR2) };
     assert_eq!(
         rc,

--- a/tests/bdd/binary_upgrade_fd_helper.rs
+++ b/tests/bdd/binary_upgrade_fd_helper.rs
@@ -67,6 +67,8 @@ fn store_inventory_counters(world: &mut DoormanWorld, key: &str, inv: &FdInvento
         format!("{key}_non_listener_sockets"),
         inv.non_listener_socket_fds().len().to_string(),
     );
+    let pipes = inv.fds.iter().filter(|f| f.kind() == "pipe").count();
+    world.vars.insert(format!("{key}_pipes"), pipes.to_string());
 }
 
 fn read_counter(world: &DoormanWorld, key: &str) -> usize {
@@ -146,6 +148,41 @@ pub async fn pipe_count_at_least(world: &mut DoormanWorld, pid_name: String, min
         n >= min,
         "pid={pid} has {n} pipe fd(s); expected at least {min}\n  {}",
         summary(&inv)
+    );
+}
+
+/// Asserts that the pipe fd count *dropped* by at least `min` between
+/// two captured inventories. Pairs naturally with the
+/// `pre_exec`-seeded inheritable pipes: 16 pipe pairs = 32 fds, so a
+/// working `c891054` cleanup is expected to close at least 20 of
+/// them (5 slack covers tokio/jemalloc internal pipe churn during
+/// the process replacement). This is the delta form of the older
+/// `pipe fd count ... should be at most N` assertion, which depended
+/// on an absolute pipe-count number that drifts with runtime
+/// internals.
+#[then(regex = r#"^the pipe fd count drop from "([^"]+)" to "([^"]+)" should be at least (\d+)$"#)]
+pub async fn pipe_count_drop_at_least(
+    world: &mut DoormanWorld,
+    before: String,
+    after: String,
+    min: usize,
+) {
+    let before_n = read_counter(world, &format!("{before}_pipes"));
+    let after_n = read_counter(world, &format!("{after}_pipes"));
+    let drop = before_n as isize - after_n as isize;
+    let summary_before = world
+        .vars
+        .get(&format!("{before}_summary"))
+        .cloned()
+        .unwrap_or_default();
+    let summary_after = world
+        .vars
+        .get(&format!("{after}_summary"))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        drop >= min as isize,
+        "pipe fd count dropped by {drop} (from {before_n} to {after_n}); required at least {min}\n  before: {summary_before}\n  after:  {summary_after}"
     );
 }
 

--- a/tests/bdd/doorman_helper.rs
+++ b/tests/bdd/doorman_helper.rs
@@ -311,15 +311,10 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
         use std::os::unix::process::CommandExt;
         let nofile_limit = world.doorman_nofile_limit;
         let extra_pipes = world.doorman_extra_inheritable_pipes.unwrap_or(0);
-        // SAFETY: pre_exec runs between fork and exec in the child.
-        // - setrlimit is async-signal-safe per POSIX.
-        // - pipe(2) and fcntl(2) are both listed as async-signal-safe
-        //   in `signal-safety(7)`. The default `pipe(2)` opens fds
-        //   without `O_CLOEXEC`, so they survive `exec` without
-        //   needing a follow-up fcntl. We still defensively
-        //   re-confirm with `fcntl(F_GETFD/F_SETFD)` because a future
-        //   libc switch to `pipe2(2)` with `O_CLOEXEC` default would
-        //   silently break the polluted-parent invariant otherwise.
+        // SAFETY: pre_exec runs after fork and before exec. Keep this
+        // closure to async-signal-safe libc calls only.
+        // pipe(2) fds are inheritable by default; fcntl clears CLOEXEC
+        // defensively to preserve the polluted-parent fixture.
         unsafe {
             cmd.pre_exec(move || {
                 if let Some(limit) = nofile_limit {
@@ -378,17 +373,8 @@ pub async fn start_doorman_with_nofile_limit_and_config(
     start_doorman_with_config(world, step).await;
 }
 
-/// Spawns pg_doorman with `N` extra inheritable pipe pairs seeded via
-/// `pre_exec`. Each pair contributes two fds that DO NOT carry
-/// `FD_CLOEXEC`, so they survive the `exec` and become real "polluted
-/// parent" leftovers in the running pg_doorman.
-///
-/// The point of this setup is to drive the `c891054` close-by-range
-/// cleanup on the SIGUSR2 child: when the child sees its
-/// `--inherit-fd` argument it inventories every fd outside the
-/// allowlist (stdio, listener, readiness pipe, migration socketpair)
-/// and closes it. Without this seed the child has nothing to close,
-/// and the regression check would be vacuous.
+/// Seed pg_doorman with inheritable pipe pairs so the SIGUSR2 child
+/// has unexpected fds to close.
 #[given(expr = "pg_doorman started with {int} extra inheritable pipes and config:")]
 pub async fn start_doorman_with_extra_inheritable_pipes(
     world: &mut DoormanWorld,
@@ -399,14 +385,8 @@ pub async fn start_doorman_with_extra_inheritable_pipes(
     start_doorman_with_config(world, step).await;
 }
 
-/// Combined form of `with NOFILE limit N` and `with M extra
-/// inheritable pipes`. The NOFILE cap matters here because the
-/// SIGUSR2 child's inherited-fd cleanup walks every slot up to
-/// `RLIMIT_NOFILE`; on the default container limit (~1M) that walk
-/// can run for seconds and starves the pre-flight validator that
-/// the parent is waiting on. NOFILE=200 keeps the cleanup loop
-/// short enough for the validator to return before the BDD
-/// assertion window expires.
+/// Combined NOFILE + pipe pollution start. The low NOFILE keeps the
+/// inherited-fd cleanup range small enough for BDD.
 #[given(
     expr = "pg_doorman started with NOFILE limit {int} and {int} extra inheritable pipes and config:"
 )]

--- a/tests/bdd/doorman_helper.rs
+++ b/tests/bdd/doorman_helper.rs
@@ -313,12 +313,13 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
         let extra_pipes = world.doorman_extra_inheritable_pipes.unwrap_or(0);
         // SAFETY: pre_exec runs between fork and exec in the child.
         // - setrlimit is async-signal-safe per POSIX.
-        // - pipe2(2) is async-signal-safe; we explicitly do NOT pass
-        //   O_CLOEXEC, then strip FD_CLOEXEC via fcntl (which is also
-        //   async-signal-safe). The resulting fds survive exec, which
-        //   is exactly the "polluted parent" condition we need to
-        //   simulate so the child of a later SIGUSR2 has something
-        //   to clean up via the c891054 close-by-range pass.
+        // - pipe(2) and fcntl(2) are both listed as async-signal-safe
+        //   in `signal-safety(7)`. The default `pipe(2)` opens fds
+        //   without `O_CLOEXEC`, so they survive `exec` without
+        //   needing a follow-up fcntl. We still defensively
+        //   re-confirm with `fcntl(F_GETFD/F_SETFD)` because a future
+        //   libc switch to `pipe2(2)` with `O_CLOEXEC` default would
+        //   silently break the polluted-parent invariant otherwise.
         unsafe {
             cmd.pre_exec(move || {
                 if let Some(limit) = nofile_limit {

--- a/tests/bdd/doorman_helper.rs
+++ b/tests/bdd/doorman_helper.rs
@@ -307,18 +307,43 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
         .stdout(stdout_cfg)
         .stderr(stderr_cfg);
 
-    if let Some(nofile_limit) = world.doorman_nofile_limit {
+    if world.doorman_nofile_limit.is_some() || world.doorman_extra_inheritable_pipes.is_some() {
         use std::os::unix::process::CommandExt;
-        // SAFETY: pre_exec runs between fork and exec in the child. setrlimit
-        // is async-signal-safe per POSIX. The closure captures only a primitive.
+        let nofile_limit = world.doorman_nofile_limit;
+        let extra_pipes = world.doorman_extra_inheritable_pipes.unwrap_or(0);
+        // SAFETY: pre_exec runs between fork and exec in the child.
+        // - setrlimit is async-signal-safe per POSIX.
+        // - pipe2(2) is async-signal-safe; we explicitly do NOT pass
+        //   O_CLOEXEC, then strip FD_CLOEXEC via fcntl (which is also
+        //   async-signal-safe). The resulting fds survive exec, which
+        //   is exactly the "polluted parent" condition we need to
+        //   simulate so the child of a later SIGUSR2 has something
+        //   to clean up via the c891054 close-by-range pass.
         unsafe {
             cmd.pre_exec(move || {
-                let rl = libc::rlimit {
-                    rlim_cur: nofile_limit as libc::rlim_t,
-                    rlim_max: nofile_limit as libc::rlim_t,
-                };
-                if libc::setrlimit(libc::RLIMIT_NOFILE, &rl) != 0 {
-                    return Err(std::io::Error::last_os_error());
+                if let Some(limit) = nofile_limit {
+                    let rl = libc::rlimit {
+                        rlim_cur: limit as libc::rlim_t,
+                        rlim_max: limit as libc::rlim_t,
+                    };
+                    if libc::setrlimit(libc::RLIMIT_NOFILE, &rl) != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                }
+                for _ in 0..extra_pipes {
+                    let mut fds: [libc::c_int; 2] = [-1, -1];
+                    if libc::pipe(fds.as_mut_ptr()) != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    for fd in fds {
+                        let flags = libc::fcntl(fd, libc::F_GETFD);
+                        if flags < 0 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        if libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                    }
                 }
                 Ok(())
             });
@@ -349,6 +374,49 @@ pub async fn start_doorman_with_nofile_limit_and_config(
     step: &Step,
 ) {
     world.doorman_nofile_limit = Some(nofile_limit);
+    start_doorman_with_config(world, step).await;
+}
+
+/// Spawns pg_doorman with `N` extra inheritable pipe pairs seeded via
+/// `pre_exec`. Each pair contributes two fds that DO NOT carry
+/// `FD_CLOEXEC`, so they survive the `exec` and become real "polluted
+/// parent" leftovers in the running pg_doorman.
+///
+/// The point of this setup is to drive the `c891054` close-by-range
+/// cleanup on the SIGUSR2 child: when the child sees its
+/// `--inherit-fd` argument it inventories every fd outside the
+/// allowlist (stdio, listener, readiness pipe, migration socketpair)
+/// and closes it. Without this seed the child has nothing to close,
+/// and the regression check would be vacuous.
+#[given(expr = "pg_doorman started with {int} extra inheritable pipes and config:")]
+pub async fn start_doorman_with_extra_inheritable_pipes(
+    world: &mut DoormanWorld,
+    pipes: usize,
+    step: &Step,
+) {
+    world.doorman_extra_inheritable_pipes = Some(pipes);
+    start_doorman_with_config(world, step).await;
+}
+
+/// Combined form of `with NOFILE limit N` and `with M extra
+/// inheritable pipes`. The NOFILE cap matters here because the
+/// SIGUSR2 child's inherited-fd cleanup walks every slot up to
+/// `RLIMIT_NOFILE`; on the default container limit (~1M) that walk
+/// can run for seconds and starves the pre-flight validator that
+/// the parent is waiting on. NOFILE=200 keeps the cleanup loop
+/// short enough for the validator to return before the BDD
+/// assertion window expires.
+#[given(
+    expr = "pg_doorman started with NOFILE limit {int} and {int} extra inheritable pipes and config:"
+)]
+pub async fn start_doorman_with_nofile_limit_and_extra_inheritable_pipes(
+    world: &mut DoormanWorld,
+    nofile_limit: u64,
+    pipes: usize,
+    step: &Step,
+) {
+    world.doorman_nofile_limit = Some(nofile_limit);
+    world.doorman_extra_inheritable_pipes = Some(pipes);
     start_doorman_with_config(world, step).await;
 }
 

--- a/tests/bdd/extended/session_management.rs
+++ b/tests/bdd/extended/session_management.rs
@@ -6,32 +6,11 @@ use std::time::Duration;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 
-/// Key under which `attempt_create_idle_sessions` records the number of
-/// sessions it actually opened. Read back by
-/// `at least N sessions with prefix "idle-" should be open` so the
-/// scenario can assert that the parent pooler did not silently drop
-/// everyone to zero (which would make the post-upgrade SELECT vacuous).
+/// Count recorded by `attempt_create_idle_sessions`.
 const ACCEPTED_VAR_KEY: &str = "last_idle_attempt_accepted";
 
-/// Concurrent best-effort batch session creation. Used by
-/// migration-fd-budget scenarios where the daemon's nofile limit is
-/// intentionally tight, so a subset of connect attempts is expected to
-/// be rejected.
-///
-/// Why parallel rather than sequential: a sequential loop replays the
-/// failure mode poorly. The original loop awaited each spawn before
-/// starting the next, so the accept loop processed one SYN at a time
-/// with the previous client already closed before the next arrived —
-/// the kernel's fd table never saw the simultaneous pressure that the
-/// production incident produced (~3K clients reconnecting after
-/// SIGUSR2). `JoinSet::spawn` releases every attempt onto the runtime
-/// before any joining starts; the daemon sees a true thundering herd.
-///
-/// Each spawn is wrapped in a short timeout so a refusing daemon (or
-/// the kernel still retransmitting SYN on an unacked TCP open) does
-/// not stall the scenario for minutes. Successful sessions are stored
-/// under names `idle-0`, `idle-1`, ... so later steps can address them
-/// individually if needed.
+/// Concurrent best-effort session creation for fd-pressure scenarios.
+/// Some attempts may fail; successes are stored as `idle-N`.
 #[when(
     regex = r#"^we attempt to create (\d+) idle sessions to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)"$"#
 )]
@@ -47,11 +26,8 @@ pub async fn attempt_create_idle_sessions(
 
     let step_timeout = Duration::from_millis(2000);
 
-    // PgConnection::authenticate panics on protocol-level FATAL (e.g.
-    // SQLSTATE 53300 "too many clients already") which is exactly what
-    // the server returns under overload — and the whole point of this
-    // step is to tolerate that. JoinSet captures the panic as JoinError
-    // instead of letting it abort the scenario.
+    // Protocol FATAL can panic inside helper auth; JoinSet counts it
+    // instead of aborting the scenario.
     let mut set: JoinSet<Result<(usize, PgConnection), &'static str>> = JoinSet::new();
     for idx in 0..count {
         let user = user.clone();
@@ -108,16 +84,7 @@ pub async fn attempt_create_idle_sessions(
     );
 }
 
-/// Assert that the previous `attempt_create_idle_sessions` step left at
-/// least `min` sessions open. A scenario that asserts "the daemon
-/// stayed inside its fd budget" without also pinning down a minimum
-/// number of open sessions can pass with zero accepted clients — the
-/// post-upgrade `SELECT` would then have nothing to run against and
-/// the scenario silently degrades into a smoke test. Tying the count
-/// to `pool_size` makes the assertion meaningful: under
-/// `pool_size = 10` we always expect at least 10 sessions to make it
-/// through, otherwise the pool was the bottleneck rather than the
-/// listener.
+/// Require retained idle clients so fd checks cannot pass with zero sessions.
 #[then(regex = r#"^at least (\d+) idle sessions should be open from the last batch attempt$"#)]
 pub async fn at_least_n_idle_sessions_open(world: &mut DoormanWorld, min: usize) {
     let accepted: usize = world
@@ -131,27 +98,8 @@ pub async fn at_least_n_idle_sessions_open(world: &mut DoormanWorld, min: usize)
     );
 }
 
-/// Verify the new pg_doorman process is actually servicing PostgreSQL
-/// protocol traffic, not just accepting TCP. A bare `TcpStream::connect`
-/// succeeds against either the old or the new process during the
-/// hand-off — both inherit the listening socket via SCM_RIGHTS and both
-/// may briefly answer SYNs in parallel — so we need a higher-level
-/// signal. A full `Startup → Authenticate → CloseSession` sequence
-/// fails if the new process is still booting (port routed but no
-/// async listener), if config validation aborted the spawn, or if the
-/// hand-off socketpair never closed cleanly. The connection is
-/// dropped immediately after a successful auth; this step asserts
-/// reachability, not durability.
-///
-/// Retries inside a fixed overall budget because the new process is
-/// in a brief stutter window right after
-/// `wait_for_foreground_binary_upgrade` returns: it has the listening
-/// fd but is still draining migration RX from the parent and
-/// bootstrapping its pool workers, so the first post-upgrade auth
-/// attempt can time out even though TCP `connect` already succeeded.
-/// Retrying keeps the assertion strict (we still demand a healthy
-/// session, not just an open socket) while avoiding a flake on the
-/// boundary case.
+/// Verify the new process can complete PostgreSQL startup/auth after upgrade.
+/// Retry because listener readiness can precede migration drain.
 #[then(
     regex = r#"^a fresh PostgreSQL session to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)" succeeds$"#
 )]
@@ -203,22 +151,8 @@ pub async fn fresh_pg_session_succeeds(
     }
 }
 
-/// Run a real SimpleQuery on the first surviving session from a batch
-/// created with prefix `idle-`. Used after `we wait for foreground
-/// binary upgrade to complete` to prove the session is still alive,
-/// migrated, and able to round-trip a query through whichever process
-/// is now servicing the port — not just answer a TCP `connect`.
-/// Stores the response under the chosen session's name so the standard
-/// `session "..." should receive DataRow with "..."` assertion picks
-/// it up unchanged.
-/// Round-trips a SimpleQuery on every `idle-N` session that the batch
-/// step left in the world, asserts a minimum number of those responses
-/// contain a DataRow with the expected value, and drops any session
-/// whose connection has been closed (so subsequent steps see a clean
-/// world). Used by the chained-SIGUSR2 scenario to prove that the
-/// previous-generation migrated clients survived the second upgrade —
-/// without this assertion the fd-delta check passes vacuously if the
-/// second upgrade simply drops everyone.
+/// Round-trip every retained `idle-N` session and store the success count.
+/// Prevents a socket-count pass after dropping migrated clients.
 #[when(
     regex = r#"^we send SimpleQuery "([^"]+)" to every open idle session and count successes as "([^"]+)"$"#
 )]
@@ -247,9 +181,7 @@ pub async fn send_query_to_every_idle_session(
     let mut successes: usize = 0;
     let mut failures: Vec<(String, String)> = Vec::new();
     for name in sorted {
-        // Get session by name; if it isn't there any more (e.g. the
-        // batch step already dropped it on a prior failed iteration)
-        // count as a failure rather than a panic.
+        // Missing sessions count as continuity failures, not harness panics.
         let Some(conn) = world.named_sessions.get_mut(&name) else {
             failures.push((name.clone(), "session missing".into()));
             continue;
@@ -341,6 +273,7 @@ pub async fn stored_count_at_least(world: &mut DoormanWorld, key: String, min: u
     );
 }
 
+/// Run a SimpleQuery on the first retained `idle-N` session.
 #[when(
     regex = r#"^we send SimpleQuery "([^"]+)" to the first open idle session and store response as "([^"]+)"$"#
 )]

--- a/tests/bdd/extended/session_management.rs
+++ b/tests/bdd/extended/session_management.rs
@@ -211,6 +211,136 @@ pub async fn fresh_pg_session_succeeds(
 /// Stores the response under the chosen session's name so the standard
 /// `session "..." should receive DataRow with "..."` assertion picks
 /// it up unchanged.
+/// Round-trips a SimpleQuery on every `idle-N` session that the batch
+/// step left in the world, asserts a minimum number of those responses
+/// contain a DataRow with the expected value, and drops any session
+/// whose connection has been closed (so subsequent steps see a clean
+/// world). Used by the chained-SIGUSR2 scenario to prove that the
+/// previous-generation migrated clients survived the second upgrade —
+/// without this assertion the fd-delta check passes vacuously if the
+/// second upgrade simply drops everyone.
+#[when(
+    regex = r#"^we send SimpleQuery "([^"]+)" to every open idle session and count successes as "([^"]+)"$"#
+)]
+pub async fn send_query_to_every_idle_session(
+    world: &mut DoormanWorld,
+    query: String,
+    out_count_key: String,
+) {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let names: Vec<String> = world
+        .named_sessions
+        .keys()
+        .filter(|k| k.starts_with("idle-"))
+        .cloned()
+        .collect();
+    let mut sorted = names;
+    sorted.sort_by_key(|k| {
+        k.strip_prefix("idle-")
+            .and_then(|n| n.parse::<usize>().ok())
+            .unwrap_or(usize::MAX)
+    });
+
+    let step_timeout = Duration::from_secs(3);
+    let mut successes: usize = 0;
+    let mut failures: Vec<(String, String)> = Vec::new();
+    for name in sorted {
+        // Get session by name; if it isn't there any more (e.g. the
+        // batch step already dropped it on a prior failed iteration)
+        // count as a failure rather than a panic.
+        let Some(conn) = world.named_sessions.get_mut(&name) else {
+            failures.push((name.clone(), "session missing".into()));
+            continue;
+        };
+        let send = timeout(step_timeout, conn.send_simple_query(&query)).await;
+        match send {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                failures.push((name.clone(), format!("send_simple_query: {e}")));
+                world.named_sessions.remove(&name);
+                continue;
+            }
+            Err(_) => {
+                failures.push((name.clone(), "send_simple_query timed out".into()));
+                world.named_sessions.remove(&name);
+                continue;
+            }
+        }
+        let read = timeout(step_timeout, conn.read_all_messages_until_ready()).await;
+        let messages = match read {
+            Ok(Ok(m)) => m,
+            Ok(Err(e)) => {
+                failures.push((name.clone(), format!("read response: {e}")));
+                world.named_sessions.remove(&name);
+                continue;
+            }
+            Err(_) => {
+                failures.push((name.clone(), "read response timed out".into()));
+                world.named_sessions.remove(&name);
+                continue;
+            }
+        };
+        let mut found_row = false;
+        for (msg_type, data) in &messages {
+            if *msg_type == 'D' {
+                let fields = super::helpers::parse_datarow_fields(data);
+                if fields.into_iter().next().is_some() {
+                    found_row = true;
+                    break;
+                }
+            } else if *msg_type == 'E' {
+                failures.push((
+                    name.clone(),
+                    format!("ErrorResponse: {}", String::from_utf8_lossy(data)),
+                ));
+                break;
+            }
+        }
+        if found_row {
+            successes += 1;
+        } else {
+            failures.push((name.clone(), "no DataRow in response".into()));
+            world.named_sessions.remove(&name);
+        }
+    }
+    log::info!(
+        "[binary-upgrade-fd] round-tripped {} session(s), {} succeeded, {} failed",
+        successes + failures.len(),
+        successes,
+        failures.len()
+    );
+    if !failures.is_empty() {
+        let preview: Vec<String> = failures
+            .iter()
+            .take(10)
+            .map(|(s, e)| format!("{s}: {e}"))
+            .collect();
+        log::info!(
+            "[binary-upgrade-fd] failure preview: {}",
+            preview.join("; ")
+        );
+    }
+    world.vars.insert(out_count_key, successes.to_string());
+}
+
+#[then(regex = r#"^the stored count "([^"]+)" should be at least (\d+)$"#)]
+pub async fn stored_count_at_least(world: &mut DoormanWorld, key: String, min: usize) {
+    let raw = world.vars.get(&key).unwrap_or_else(|| {
+        panic!(
+            "no count stored under key '{key}' — capture it via a prior `count successes as` step"
+        )
+    });
+    let actual: usize = raw
+        .parse()
+        .unwrap_or_else(|e| panic!("count '{key}' = {raw:?} is not numeric: {e}"));
+    assert!(
+        actual >= min,
+        "expected at least {min} successes under '{key}', got {actual}"
+    );
+}
+
 #[when(
     regex = r#"^we send SimpleQuery "([^"]+)" to the first open idle session and store response as "([^"]+)"$"#
 )]

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -137,6 +137,58 @@ Feature: pg_doorman stays within its fd budget
     And every non-listener socket fd of stored PID "gen2" has FD_CLOEXEC set
     And a fresh PostgreSQL session to pg_doorman as "example_user_1" with password "" and database "example_db" succeeds
 
+  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec
+  Scenario: SIGUSR2 child cleans up inheritable fds leaked by a polluted parent
+    # Models the production recovery case for `c891054`: a buggy old
+    # parent has been running long enough to accumulate non-CLOEXEC
+    # inheritable fds (16 here, simulated via `pipe(2)` pairs in
+    # `pre_exec`). On the next SIGUSR2 the new child sees those fds
+    # via `--inherit-fd`-triggered allowlist cleanup, walks the
+    # numeric range up to `RLIMIT_NOFILE`, and closes everything not
+    # in the allowlist. Without that cleanup the inherited pipes
+    # ride along forever in every subsequent child generation.
+    Given pg_doorman log capture enabled
+    And pg_doorman started with NOFILE limit 200 and 16 extra inheritable pipes and config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+      pool_mode = "transaction"
+      shutdown_timeout = 5000
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 10
+      """
+    When we sleep 1000ms
+    And we discover the current pg_doorman PID externally and store as "polluted_parent"
+    # 16 pairs × 2 ends = 32 inheritable pipe fds, plus whatever
+    # tokio/jemalloc opened natively. The 30 lower bound leaves room
+    # for the seeded fds to have been seen even if the runtime
+    # consolidated a few of its own internal pipes.
+    Then the pipe fd count for stored PID "polluted_parent" should be at least 30
+
+    When we send SIGUSR2 to foreground pg_doorman
+    And we wait for foreground binary upgrade to complete
+    And we discover the current pg_doorman PID externally and store as "clean_child"
+    # The cleanup announces itself on stderr; pin that before the
+    # numeric pipe-count assertion so a regression that silently
+    # disables the cleanup pass is reported as "the log line never
+    # showed up" rather than "we still see N pipes".
+    Then pg_doorman log contains "unexpected inherited file descriptor"
+    # The cleanup runs in `main()` before config load, so by the time
+    # the new process is reachable on the listener the seeded pipes
+    # are gone. Anything tokio/jemalloc opens for its own use stays;
+    # the bound of 12 is comfortably above the native pipe count seen
+    # in practice and well below the 30+ a leak would produce.
+    And the pipe fd count for stored PID "clean_child" should be at most 12
+
   @client-migration @migration-fd-budget @fd-overload
   Scenario: 1000 clients on a 50-client cap reject cleanly, accepted clients keep working
     Given pg_doorman log capture enabled

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -60,7 +60,7 @@ Feature: pg_doorman stays within its fd budget
     # lives in the NOFILE=200 scenario below where the budget is wide
     # enough for the new process to settle.
 
-  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec
+  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec @linux-only
   Scenario: Chained binary upgrade with 50 idle clients keeps fd table stable (FD_CLOEXEC + cleanup)
     # Catches the production failure mode that the migration channel
     # reproduces: each migrated client fd was inherited by the next
@@ -135,9 +135,17 @@ Feature: pg_doorman stays within its fd budget
     # the count by ~50, ten times this bound.
     And the non-listener socket fd count delta from "gen1" to "gen2" should be at most 5
     And every non-listener socket fd of stored PID "gen2" has FD_CLOEXEC set
+    # The fd delta on its own can pass vacuously: a regression that
+    # drops migrated clients during the second upgrade also shrinks
+    # the socket count. Round-trip the original sessions to make
+    # sure session continuity actually survived, then assert a
+    # high-watermark of successes. Without this assertion the test
+    # would call "delete every migrated client" a successful fix.
+    When we send SimpleQuery "SELECT 1" to every open idle session and count successes as "survived_after_gen2"
+    Then the stored count "survived_after_gen2" should be at least 45
     And a fresh PostgreSQL session to pg_doorman as "example_user_1" with password "" and database "example_db" succeeds
 
-  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec
+  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec @linux-only
   Scenario: SIGUSR2 child cleans up inheritable fds leaked by a polluted parent
     # Models the production recovery case for `c891054`: a buggy old
     # parent has been running long enough to accumulate non-CLOEXEC

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -60,8 +60,16 @@ Feature: pg_doorman stays within its fd budget
     # lives in the NOFILE=200 scenario below where the budget is wide
     # enough for the new process to settle.
 
-  @client-migration @migration-fd-budget
-  Scenario: Binary upgrade with 50 idle clients under NOFILE=200 completes without EMFILE
+  @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec
+  Scenario: Chained binary upgrade with 50 idle clients keeps fd table stable (FD_CLOEXEC + cleanup)
+    # Catches the production failure mode that the migration channel
+    # reproduces: each migrated client fd was inherited by the next
+    # child generation, doubling the socket fd count on every SIGUSR2.
+    # Without FD_CLOEXEC on the SCM_RIGHTS-received fds the table
+    # grows by ~N each upgrade; with the fix it stays roughly
+    # constant. The assertion that catches the regression is the
+    # non-listener socket fd count *delta* between two consecutive
+    # generations.
     Given pg_doorman log capture enabled
     And pg_doorman started with NOFILE limit 200 and config:
       """
@@ -87,18 +95,46 @@ Feature: pg_doorman stays within its fd budget
     # accept-side bottleneck does not apply here — we expect every
     # client to have settled.
     Then at least 50 idle sessions should be open from the last batch attempt
-    When we store foreground pg_doorman PID as "old_doorman"
+
+    # ----- First SIGUSR2: existing-process → child generation 1 -----
+    When we store foreground pg_doorman PID as "parent"
     And we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
     Then pg_doorman log does not contain "Too many open files"
     And pg_doorman log does not contain "fallback discovery failed"
     And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
+
+    # Pin the new child PID independent of the original spawn handle.
+    # /api/process is intentionally NOT used here: it depends on web
+    # admin being on and would only see whichever copy of the listener
+    # the kernel hashed our request to under SO_REUSEPORT.
+    When we discover the current pg_doorman PID externally and store as "gen1"
+    And we capture the fd inventory for stored PID "gen1" as "gen1"
+    Then every non-listener socket fd of stored PID "gen1" has FD_CLOEXEC set
+
     # Migrated sessions must be able to round-trip a query through
     # whichever process is now servicing them. The MIGRATION_TX path
     # is only useful if the protocol state survived intact; a healthy
     # `SELECT 1` is the cheapest end-to-end check of that.
-    When we send SimpleQuery "SELECT 1" to the first open idle session and store response as "post-upgrade"
-    Then session "post-upgrade" should receive DataRow with "1"
+    When we send SimpleQuery "SELECT 1" to the first open idle session and store response as "post-upgrade-1"
+    Then session "post-upgrade-1" should receive DataRow with "1"
+
+    # ----- Second SIGUSR2: generation 1 → generation 2 -----
+    # If the child of the first upgrade kept the migrated client fds
+    # inheritable, the child of the second upgrade will end up with
+    # both the fork-inherited and SCM_RIGHTS-received copies. The
+    # non-listener socket count would grow by ~50 (one extra fd per
+    # active client).
+    When we send SIGUSR2 to pg_doorman process at stored PID "gen1"
+    And we wait for foreground binary upgrade to complete
+    And we discover the current pg_doorman PID externally and store as "gen2"
+    And we capture the fd inventory for stored PID "gen2" as "gen2"
+    Then stored PID "gen2" should be different from stored PID "gen1"
+    # Slack of 5: tokio and jemalloc occasionally adjust their internal
+    # fd usage during a process replacement; the FD_CLOEXEC bug doubled
+    # the count by ~50, ten times this bound.
+    And the non-listener socket fd count delta from "gen1" to "gen2" should be at most 5
+    And every non-listener socket fd of stored PID "gen2" has FD_CLOEXEC set
     And a fresh PostgreSQL session to pg_doorman as "example_user_1" with password "" and database "example_db" succeeds
 
   @client-migration @migration-fd-budget @fd-overload

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -1,9 +1,6 @@
 Feature: pg_doorman stays within its fd budget
-  Two failure modes for the same root issue — pg_doorman must keep its
-  file-descriptor table inside the configured `LimitNOFILE` and reject
-  clients gracefully when load exceeds `max_connections`, rather than
-  exhaust the fd table and start spamming EMFILE on every new socket
-  (including Patroni-fallback discovery, which then dominates the log).
+  pg_doorman must stay inside `LimitNOFILE`, reject overload at the
+  protocol layer, and avoid routing local fd exhaustion into fallback.
 
   Background:
     Given PostgreSQL started with pg_hba.conf:
@@ -35,41 +32,24 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 100 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    # Under NOFILE=50 the listener cannot service 100 clients, but the
-    # pool itself is sized for 10 backends, so we expect at least the
-    # first 10 clients to have settled into the pool. Anything below
-    # would mean the accept loop or the auth path is dropping clients
-    # the pool could otherwise serve — a regression we must not ship.
+    # NOFILE=50 cannot accept all 100 clients, but pool_size=10 should settle.
     Then at least 10 idle sessions should be open from the last batch attempt
     When we store foreground pg_doorman PID as "old_doorman"
     And we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
-    # accept-loop must be rate-limited: a single backoff line every 5 s is
-    # acceptable, but tight-loop spam (thousands of lines per ms) is the bug
-    # this scenario guards against.
+    # EMFILE in the accept loop must be rate-limited.
     Then pg_doorman log contains "Failed to accept new connection" at most 5 times
     # Patroni fallback must not be triggered on local fd exhaustion.
     And pg_doorman log does not contain "fallback discovery failed"
-    # Binary upgrade must not be aborted by the pre-flight validator just
-    # because the local fd table is full — the upgrade is the recovery path.
+    # Local fd exhaustion must not abort the recovery upgrade.
     And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
-    # Note: at NOFILE=50 the post-upgrade fresh-connection check is
-    # intentionally omitted — under that tight a budget the new process
-    # is still draining migration RX during the assertion window, so a
-    # bare connect/auth round-trip is racy. The fresher-window assertion
-    # lives in the NOFILE=200 scenario below where the budget is wide
-    # enough for the new process to settle.
+    # The fresh-session check lives in the NOFILE=200 scenario; NOFILE=50 is
+    # too tight while the child is still draining migration RX.
 
   @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec @linux-only
   Scenario: Chained binary upgrade with 50 idle clients keeps fd table stable (FD_CLOEXEC + cleanup)
-    # Catches the production failure mode that the migration channel
-    # reproduces: each migrated client fd was inherited by the next
-    # child generation, doubling the socket fd count on every SIGUSR2.
-    # Without FD_CLOEXEC on the SCM_RIGHTS-received fds the table
-    # grows by ~N each upgrade; with the fix it stays roughly
-    # constant. The assertion that catches the regression is the
-    # non-listener socket fd count *delta* between two consecutive
-    # generations.
+    # Regression target: a second SIGUSR2 must not inherit duplicate
+    # migrated client fds from the previous child.
     Given pg_doorman log capture enabled
     And pg_doorman started with NOFILE limit 200 and config:
       """
@@ -91,12 +71,10 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 50 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    # NOFILE=200 has comfortable headroom for 50 clients, so the
-    # accept-side bottleneck does not apply here — we expect every
-    # client to have settled.
+    # NOFILE=200 leaves enough headroom for all 50 clients.
     Then at least 50 idle sessions should be open from the last batch attempt
 
-    # ----- First SIGUSR2: existing-process → child generation 1 -----
+    # First upgrade.
     When we store foreground pg_doorman PID as "parent"
     And we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
@@ -104,57 +82,36 @@ Feature: pg_doorman stays within its fd budget
     And pg_doorman log does not contain "fallback discovery failed"
     And pg_doorman log does not contain "BINARY UPGRADE ABORTED"
 
-    # Pin the new child PID independent of the original spawn handle.
-    # /api/process is intentionally NOT used here: it depends on web
-    # admin being on and would only see whichever copy of the listener
-    # the kernel hashed our request to under SO_REUSEPORT.
+    # Discover PID externally; /api/process is not a stable oracle
+    # while upgrade generations overlap.
     When we discover the current pg_doorman PID externally and store as "gen1"
     And we capture the fd inventory for stored PID "gen1" as "gen1"
     Then every non-listener socket fd of stored PID "gen1" has FD_CLOEXEC set
 
-    # Migrated sessions must be able to round-trip a query through
-    # whichever process is now servicing them. The MIGRATION_TX path
-    # is only useful if the protocol state survived intact; a healthy
-    # `SELECT 1` is the cheapest end-to-end check of that.
+    # One migrated session must still round-trip after gen1.
     When we send SimpleQuery "SELECT 1" to the first open idle session and store response as "post-upgrade-1"
     Then session "post-upgrade-1" should receive DataRow with "1"
 
-    # ----- Second SIGUSR2: generation 1 → generation 2 -----
-    # If the child of the first upgrade kept the migrated client fds
-    # inheritable, the child of the second upgrade will end up with
-    # both the fork-inherited and SCM_RIGHTS-received copies. The
-    # non-listener socket count would grow by ~50 (one extra fd per
-    # active client).
+    # Second upgrade. Missing CLOEXEC would add roughly one extra
+    # socket per active migrated client.
     When we send SIGUSR2 to pg_doorman process at stored PID "gen1"
     And we wait for foreground binary upgrade to complete
     And we discover the current pg_doorman PID externally and store as "gen2"
     And we capture the fd inventory for stored PID "gen2" as "gen2"
     Then stored PID "gen2" should be different from stored PID "gen1"
-    # Slack of 5: tokio and jemalloc occasionally adjust their internal
-    # fd usage during a process replacement; the FD_CLOEXEC bug doubled
-    # the count by ~50, ten times this bound.
+    # Slack 5 covers runtime fd churn; the bug adds about 50.
     And the non-listener socket fd count delta from "gen1" to "gen2" should be at most 5
     And every non-listener socket fd of stored PID "gen2" has FD_CLOEXEC set
-    # The fd delta on its own can pass vacuously: a regression that
-    # drops migrated clients during the second upgrade also shrinks
-    # the socket count. Round-trip the original sessions to make
-    # sure session continuity actually survived, then assert a
-    # high-watermark of successes. Without this assertion the test
-    # would call "delete every migrated client" a successful fix.
+    # Socket stability alone can pass if clients were dropped.
+    # Verify that most original sessions still work.
     When we send SimpleQuery "SELECT 1" to every open idle session and count successes as "survived_after_gen2"
     Then the stored count "survived_after_gen2" should be at least 45
     And a fresh PostgreSQL session to pg_doorman as "example_user_1" with password "" and database "example_db" succeeds
 
   @client-migration @migration-fd-budget @binary-upgrade-fd-cloexec @linux-only
   Scenario: SIGUSR2 child cleans up inheritable fds leaked by a polluted parent
-    # Models the production recovery case for `c891054`: a buggy old
-    # parent has been running long enough to accumulate non-CLOEXEC
-    # inheritable fds (16 here, simulated via `pipe(2)` pairs in
-    # `pre_exec`). On the next SIGUSR2 the new child sees those fds
-    # via `--inherit-fd`-triggered allowlist cleanup, walks the
-    # numeric range up to `RLIMIT_NOFILE`, and closes everything not
-    # in the allowlist. Without that cleanup the inherited pipes
-    # ride along forever in every subsequent child generation.
+    # Start with 32 inheritable pipe fds. The SIGUSR2 child must close
+    # unexpected fds before config load.
     Given pg_doorman log capture enabled
     And pg_doorman started with NOFILE limit 200 and 16 extra inheritable pipes and config:
       """
@@ -177,27 +134,17 @@ Feature: pg_doorman stays within its fd budget
     When we sleep 1000ms
     And we discover the current pg_doorman PID externally and store as "polluted_parent"
     And we capture the fd inventory for stored PID "polluted_parent" as "polluted_parent"
-    # 16 pairs × 2 ends = 32 inheritable pipe fds, plus whatever
-    # tokio/jemalloc opened natively. The 30 lower bound leaves room
-    # for the seeded fds to have been seen even if the runtime
-    # consolidated a few of its own internal pipes.
+    # 16 pipe pairs produce 32 seeded fds; allow a little runtime drift.
     Then the pipe fd count for stored PID "polluted_parent" should be at least 30
 
     When we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
     And we discover the current pg_doorman PID externally and store as "clean_child"
     And we capture the fd inventory for stored PID "clean_child" as "clean_child"
-    # The cleanup announces itself on stderr; pin that before the
-    # numeric pipe-count assertion so a regression that silently
-    # disables the cleanup pass is reported as "the log line never
-    # showed up" rather than "we still see N pipes".
+    # Log proves the startup cleanup ran.
     Then pg_doorman log contains "unexpected inherited file descriptor"
-    # Delta-based assertion is more robust than an absolute pipe
-    # count: tokio/jemalloc pipe usage drifts with toolchain
-    # changes, but the requirement that the cleanup closes at least
-    # 20 of the 32 seeded pipes does not. The 12-pipe slack absorbs
-    # internal pipe churn during process replacement (a worker pool
-    # respawn can momentarily allocate a fresh wakeup pipe pair).
+    # Assert a drop instead of an absolute pipe count; runtime pipe
+    # usage can drift.
     And the pipe fd count drop from "polluted_parent" to "clean_child" should be at least 20
 
   @client-migration @migration-fd-budget @fd-overload
@@ -224,10 +171,7 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we attempt to create 1000 idle sessions to pg_doorman as "example_user_1" with password "" and database "example_db"
-    # `max_connections = 50` is the documented cap: the listener must
-    # admit the first 50 cleanly and reject the rest at the protocol
-    # layer ("too many clients already"). Anything lower means accept
-    # itself is the bottleneck — that's the failure mode we're catching.
+    # max_connections=50 should reject at the protocol layer, not in accept.
     Then at least 50 idle sessions should be open from the last batch attempt
     And pg_doorman log does not contain "Too many open files"
     And pg_doorman log does not contain "fallback discovery failed"

--- a/tests/bdd/features/migration-fd-budget.feature
+++ b/tests/bdd/features/migration-fd-budget.feature
@@ -176,6 +176,7 @@ Feature: pg_doorman stays within its fd budget
       """
     When we sleep 1000ms
     And we discover the current pg_doorman PID externally and store as "polluted_parent"
+    And we capture the fd inventory for stored PID "polluted_parent" as "polluted_parent"
     # 16 pairs × 2 ends = 32 inheritable pipe fds, plus whatever
     # tokio/jemalloc opened natively. The 30 lower bound leaves room
     # for the seeded fds to have been seen even if the runtime
@@ -185,17 +186,19 @@ Feature: pg_doorman stays within its fd budget
     When we send SIGUSR2 to foreground pg_doorman
     And we wait for foreground binary upgrade to complete
     And we discover the current pg_doorman PID externally and store as "clean_child"
+    And we capture the fd inventory for stored PID "clean_child" as "clean_child"
     # The cleanup announces itself on stderr; pin that before the
     # numeric pipe-count assertion so a regression that silently
     # disables the cleanup pass is reported as "the log line never
     # showed up" rather than "we still see N pipes".
     Then pg_doorman log contains "unexpected inherited file descriptor"
-    # The cleanup runs in `main()` before config load, so by the time
-    # the new process is reachable on the listener the seeded pipes
-    # are gone. Anything tokio/jemalloc opens for its own use stays;
-    # the bound of 12 is comfortably above the native pipe count seen
-    # in practice and well below the 30+ a leak would produce.
-    And the pipe fd count for stored PID "clean_child" should be at most 12
+    # Delta-based assertion is more robust than an absolute pipe
+    # count: tokio/jemalloc pipe usage drifts with toolchain
+    # changes, but the requirement that the cleanup closes at least
+    # 20 of the 32 seeded pipes does not. The 12-pipe slack absorbs
+    # internal pipe churn during process replacement (a worker pool
+    # respawn can momentarily allocate a fresh wakeup pipe pair).
+    And the pipe fd count drop from "polluted_parent" to "clean_child" should be at least 20
 
   @client-migration @migration-fd-budget @fd-overload
   Scenario: 1000 clients on a 50-client cap reject cleanly, accepted clients keep working

--- a/tests/bdd/main.rs
+++ b/tests/bdd/main.rs
@@ -1,4 +1,5 @@
 mod auth_query_helper;
+mod binary_upgrade_fd_helper;
 mod doorman_helper;
 mod extended;
 mod fallback_helper;
@@ -12,6 +13,7 @@ mod pgbench_helper;
 mod pgbouncer_helper;
 mod pool_bench_helper;
 mod postgres_helper;
+mod proc_inspect;
 mod service_helper;
 mod shell_helper;
 mod utils;

--- a/tests/bdd/proc_inspect.rs
+++ b/tests/bdd/proc_inspect.rs
@@ -290,10 +290,14 @@ mod linux {
             let Ok(meta) = entry.metadata() else {
                 continue;
             };
-            let owner_uid = meta.uid();
-            if owner_uid != current_uid() {
+            if meta.uid() != current_uid() {
+                // Cannot inspect /proc/<pid>/fd across uid boundary
+                // without ptrace privileges. Skip and keep looking,
+                // but flag so the caller's failure message points at
+                // the right diagnosis when no candidate is found at
+                // all.
                 last_err = Some(format!(
-                    "pid {pid} owns LISTEN port {port} but uid {owner_uid} != ours"
+                    "pid {pid} owns LISTEN port {port} but its /proc/<pid> belongs to a different user"
                 ));
                 continue;
             }

--- a/tests/bdd/proc_inspect.rs
+++ b/tests/bdd/proc_inspect.rs
@@ -100,14 +100,20 @@ impl FdInventory {
             .collect()
     }
 
-    /// Returns `(non_listener_socket_fd_count, offenders)` where each
-    /// offender is a socket fd that does NOT have `FD_CLOEXEC` set.
-    /// The offender list is the diagnostic payload assertions print on
-    /// failure.
+    /// Returns offenders: socket fds that either have `FD_CLOEXEC` not
+    /// set (`Some(false)`) or where `fdinfo` could not be read
+    /// (`None`). The original implementation accepted `None` silently,
+    /// which gives the assertion a soft loophole: if `/proc/<pid>/fdinfo/<fd>`
+    /// disappears between the `readlink` and the `flags:` read, the test
+    /// would call the fd "fine" without ever inspecting it. Treating
+    /// `None` as an offender matches what the step name promises —
+    /// "every non-listener socket fd has FD_CLOEXEC set" — and turns
+    /// a transient read error into a re-inventory candidate rather
+    /// than a pass.
     pub fn non_listener_sockets_without_cloexec(&self) -> Vec<&FdRecord> {
         self.non_listener_socket_fds()
             .into_iter()
-            .filter(|f| matches!(f.cloexec, Some(false)))
+            .filter(|f| !matches!(f.cloexec, Some(true)))
             .collect()
     }
 

--- a/tests/bdd/proc_inspect.rs
+++ b/tests/bdd/proc_inspect.rs
@@ -1,0 +1,375 @@
+//! External `/proc` inspection helpers for the BDD harness.
+//!
+//! Two operations the binary-upgrade-fd-leak tests need:
+//!
+//! 1. Find the PID of the process currently owning the listening TCP
+//!    socket on a known port. Used after `SIGUSR2` upgrades, when the
+//!    new child process is not the one this harness spawned and the
+//!    original `tokio::process::Child` handle no longer tracks it.
+//!
+//! 2. Inventory every open fd of that process: socket inode, fdinfo
+//!    flags, `FD_CLOEXEC` bit. Used to assert "no fd grew across the
+//!    chained upgrades" and "every non-listener socket has CLOEXEC set".
+//!
+//! Both run **from the test process**. The pooler must never read its
+//! own `/proc/self/fd` from a code path that runs under fd pressure —
+//! that's the failure mode we are testing.
+//!
+//! Linux-only. Stubs on other targets so `tests/bdd` still compiles.
+
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use std::collections::BTreeMap;
+
+/// One open fd of an inspected process, as seen from outside.
+#[derive(Debug, Clone)]
+pub struct FdRecord {
+    pub fd: i32,
+    /// Raw `readlink /proc/<pid>/fd/<fd>` value. Examples: `socket:[123]`,
+    /// `pipe:[456]`, `anon_inode:[eventpoll]`, `/dev/null`, `/path/to/log`.
+    pub target: String,
+    /// For socket/pipe/anon_inode targets, the bracketed inode if it
+    /// parsed cleanly. None for regular files.
+    pub inode: Option<u64>,
+    /// FD_CLOEXEC bit from `/proc/<pid>/fdinfo/<fd>` `flags:` line.
+    /// `None` when fdinfo could not be read (race against fd close,
+    /// permission denied, or non-Linux build).
+    pub cloexec: Option<bool>,
+}
+
+impl FdRecord {
+    pub fn is_socket(&self) -> bool {
+        self.target.starts_with("socket:[")
+    }
+
+    pub fn kind(&self) -> &'static str {
+        if self.target.starts_with("socket:[") {
+            "socket"
+        } else if self.target.starts_with("pipe:[") {
+            "pipe"
+        } else if self.target.starts_with("anon_inode:[") {
+            "anon_inode"
+        } else if self.target.starts_with("/dev/") {
+            "device"
+        } else if self.target.starts_with('/') {
+            "file"
+        } else {
+            "other"
+        }
+    }
+}
+
+/// Full external snapshot of a process's fd table plus its kernel-side
+/// listener inode set. Used both for assertions and for diagnostic dumps
+/// on failure.
+#[derive(Debug, Clone)]
+pub struct FdInventory {
+    pub pid: u32,
+    pub fds: Vec<FdRecord>,
+    /// Socket inodes from `/proc/<pid>/net/tcp{,6}` that were in the
+    /// `LISTEN` state at snapshot time. We exclude listener fds from
+    /// the universal CLOEXEC assertion by inode rather than by fd
+    /// number, so the check survives fd-number shuffling across
+    /// generations.
+    pub listener_inodes: std::collections::BTreeSet<u64>,
+}
+
+impl FdInventory {
+    pub fn total_fds(&self) -> usize {
+        self.fds.len()
+    }
+
+    pub fn socket_fd_count(&self) -> usize {
+        self.fds.iter().filter(|f| f.is_socket()).count()
+    }
+
+    /// Non-listener socket fds: socket fds whose inode does not appear
+    /// in the kernel's LISTEN set for this process.
+    pub fn non_listener_socket_fds(&self) -> Vec<&FdRecord> {
+        self.fds
+            .iter()
+            .filter(|f| {
+                if !f.is_socket() {
+                    return false;
+                }
+                match f.inode {
+                    Some(ino) => !self.listener_inodes.contains(&ino),
+                    None => true,
+                }
+            })
+            .collect()
+    }
+
+    /// Returns `(non_listener_socket_fd_count, offenders)` where each
+    /// offender is a socket fd that does NOT have `FD_CLOEXEC` set.
+    /// The offender list is the diagnostic payload assertions print on
+    /// failure.
+    pub fn non_listener_sockets_without_cloexec(&self) -> Vec<&FdRecord> {
+        self.non_listener_socket_fds()
+            .into_iter()
+            .filter(|f| matches!(f.cloexec, Some(false)))
+            .collect()
+    }
+
+    /// Pretty-printed offender table for failure messages. One line per
+    /// fd, with type / inode / fdinfo state / target. Truncated at 40
+    /// rows to keep panic messages bounded.
+    pub fn format_offender_lines(&self, offenders: &[&FdRecord]) -> String {
+        let mut out = String::new();
+        out.push_str("  fd      kind        inode      cloexec  target\n");
+        for f in offenders.iter().take(40) {
+            let ino = f.inode.map(|n| n.to_string()).unwrap_or_default();
+            let cx = match f.cloexec {
+                Some(true) => "yes",
+                Some(false) => "no",
+                None => "?",
+            };
+            out.push_str(&format!(
+                "  {:<7} {:<11} {:<10} {:<8} {}\n",
+                f.fd,
+                f.kind(),
+                ino,
+                cx,
+                f.target
+            ));
+        }
+        if offenders.len() > 40 {
+            out.push_str(&format!("  ... ({} more)\n", offenders.len() - 40));
+        }
+        out
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::FdRecord;
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    /// Parses the inode out of strings like `socket:[12345]`,
+    /// `pipe:[6789]`, `anon_inode:[eventpoll]`. Returns `None` when the
+    /// bracketed value is not numeric (e.g. `anon_inode:[eventpoll]`
+    /// itself).
+    pub(super) fn parse_inode_in_brackets(s: &str) -> Option<u64> {
+        let lb = s.find('[')?;
+        let rb = s.find(']')?;
+        if rb <= lb + 1 {
+            return None;
+        }
+        s[lb + 1..rb].parse::<u64>().ok()
+    }
+
+    /// Reads `O_CLOEXEC` from `/proc/<pid>/fdinfo/<fd>`. The `flags:`
+    /// line is an octal mask; `O_CLOEXEC` is bit `0o2000000`.
+    pub(super) fn read_cloexec(pid: u32, fd: i32) -> Option<bool> {
+        let body = fs::read_to_string(format!("/proc/{pid}/fdinfo/{fd}")).ok()?;
+        for line in body.lines() {
+            if let Some(rest) = line.strip_prefix("flags:") {
+                let flags_str = rest.trim();
+                let flags = u64::from_str_radix(flags_str, 8).ok()?;
+                return Some(flags & 0o2_000_000 != 0);
+            }
+        }
+        None
+    }
+
+    /// Hex column `XXXXXXXX:HHHH` from `/proc/net/tcp` is little-endian
+    /// for IPv4 in the address half and big-endian-as-hex for the port.
+    /// We only need the port for the listener filter; helper kept small.
+    pub(super) fn parse_local_port_hex(local: &str) -> Option<u16> {
+        let mut parts = local.split(':');
+        let _ip = parts.next()?;
+        let port_hex = parts.next()?;
+        u16::from_str_radix(port_hex, 16).ok()
+    }
+
+    /// Returns the inode set of LISTEN sockets on `port` for this
+    /// process. The `pid` argument scopes the read to the right netns
+    /// (via `/proc/<pid>/net/tcp` rather than the global view), so we
+    /// observe the same TCP listing the inspected process does.
+    pub(super) fn listening_inodes_for_port(pid: u32, port: u16) -> BTreeSet<u64> {
+        let mut out = BTreeSet::new();
+        for file in [
+            format!("/proc/{pid}/net/tcp"),
+            format!("/proc/{pid}/net/tcp6"),
+        ] {
+            let Ok(body) = fs::read_to_string(&file) else {
+                continue;
+            };
+            for (i, line) in body.lines().enumerate() {
+                if i == 0 {
+                    continue; // header
+                }
+                let fields: Vec<&str> = line.split_whitespace().collect();
+                if fields.len() < 10 {
+                    continue;
+                }
+                // 0=sl 1=local_address 2=remote_address 3=st 4=tx_queue ... 9=inode
+                let st = fields[3];
+                if st != "0A" {
+                    continue; // not LISTEN
+                }
+                let Some(parsed_port) = parse_local_port_hex(fields[1]) else {
+                    continue;
+                };
+                if parsed_port != port {
+                    continue;
+                }
+                if let Ok(ino) = fields[9].parse::<u64>() {
+                    out.insert(ino);
+                }
+            }
+        }
+        out
+    }
+
+    /// Walks `/proc/<pid>/fd` and returns one FdRecord per slot.
+    /// Skipped entries on EBADF (race against close) are silently
+    /// dropped — the goal is an honest snapshot of what is open right
+    /// now from outside, not a transactional view.
+    pub(super) fn inventory_fds(pid: u32) -> Result<Vec<FdRecord>, String> {
+        let dir = format!("/proc/{pid}/fd");
+        let entries = fs::read_dir(&dir).map_err(|e| format!("read_dir {dir}: {e}"))?;
+        let mut out = Vec::new();
+        for entry in entries.flatten() {
+            let fd_str = entry.file_name();
+            let Some(fd_str) = fd_str.to_str() else {
+                continue;
+            };
+            let Ok(fd) = fd_str.parse::<i32>() else {
+                continue;
+            };
+            let path = entry.path();
+            let target = match fs::read_link(&path) {
+                Ok(p) => p.to_string_lossy().to_string(),
+                Err(_) => continue,
+            };
+            let inode = parse_inode_in_brackets(&target);
+            let cloexec = read_cloexec(pid, fd);
+            out.push(FdRecord {
+                fd,
+                target,
+                inode,
+                cloexec,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Returns the PID of the process that owns the LISTEN socket on
+    /// `port`. Strategy:
+    /// 1. Walk every numeric directory under `/proc`.
+    /// 2. For each PID we can read, ask the kernel via `/proc/<pid>/net/tcp`
+    ///    whether the port appears in the LISTEN state in that netns.
+    /// 3. If yes, walk `/proc/<pid>/fd` looking for a `socket:[inode]`
+    ///    matching one of the listener inodes from step 2.
+    /// 4. First match wins. Tie-breaks aren't expected — only one
+    ///    process can hold a TCP listening fd at a time (SO_REUSEPORT
+    ///    aside, but our scenarios don't enable it on the main listener).
+    pub(super) fn find_pid_owning_listener(port: u16) -> Result<u32, String> {
+        let proc_dir = fs::read_dir("/proc").map_err(|e| format!("read /proc: {e}"))?;
+        let mut last_err: Option<String> = None;
+        for entry in proc_dir.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Ok(pid) = name.parse::<u32>() else {
+                continue;
+            };
+
+            let inodes = listening_inodes_for_port(pid, port);
+            if inodes.is_empty() {
+                continue;
+            }
+
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            let owner_uid = meta.uid();
+            if owner_uid != current_uid() {
+                // Cannot read fd table; skip this PID — but keep
+                // looking, the actual doorman may belong to the same
+                // user even if some random privileged process matched
+                // the port by accident.
+                last_err = Some(format!(
+                    "pid {pid} owns LISTEN port {port} but uid {owner_uid} != ours"
+                ));
+                continue;
+            }
+
+            let fds = match inventory_fds(pid) {
+                Ok(v) => v,
+                Err(e) => {
+                    last_err = Some(format!("inventory_fds({pid}): {e}"));
+                    continue;
+                }
+            };
+            for record in &fds {
+                let Some(ino) = record.inode else { continue };
+                if inodes.contains(&ino) {
+                    return Ok(pid);
+                }
+            }
+        }
+        Err(last_err
+            .unwrap_or_else(|| format!("no process owns a LISTEN socket on port {port} in /proc")))
+    }
+
+    pub(super) fn current_uid() -> u32 {
+        // SAFETY: getuid is async-signal-safe, takes no arguments,
+        // returns the real uid of the calling process.
+        unsafe { libc::getuid() }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn find_pid_owning_listener(port: u16) -> Result<u32, String> {
+    linux::find_pid_owning_listener(port)
+}
+
+#[cfg(target_os = "linux")]
+pub fn inventory(pid: u32, listener_port: u16) -> Result<FdInventory, String> {
+    let fds = linux::inventory_fds(pid)?;
+    let listener_inodes = linux::listening_inodes_for_port(pid, listener_port);
+    Ok(FdInventory {
+        pid,
+        fds,
+        listener_inodes,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn find_pid_owning_listener(_port: u16) -> Result<u32, String> {
+    Err("proc_inspect requires Linux".to_string())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn inventory(_pid: u32, _listener_port: u16) -> Result<FdInventory, String> {
+    Err("proc_inspect requires Linux".to_string())
+}
+
+/// Diagnostic helper for failure messages. Summarises an inventory in
+/// one short line plus a per-kind breakdown.
+pub fn summary(inv: &FdInventory) -> String {
+    let mut by_kind: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for f in &inv.fds {
+        *by_kind.entry(f.kind()).or_insert(0) += 1;
+    }
+    let breakdown = by_kind
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "pid={} total_fds={} listener_inodes={} | {}",
+        inv.pid,
+        inv.total_fds(),
+        inv.listener_inodes.len(),
+        breakdown
+    )
+}
+
+// Note: BDD harness uses harness = false so #[test] items here would not
+// be discovered. Parser correctness for /proc/net/tcp and /proc/PID/fdinfo
+// is exercised end-to-end by the binary-upgrade-fd-cloexec BDD scenario;
+// adding a separate runner would duplicate that signal.

--- a/tests/bdd/proc_inspect.rs
+++ b/tests/bdd/proc_inspect.rs
@@ -260,16 +260,21 @@ mod linux {
     /// Returns the PID of the process that owns the LISTEN socket on
     /// `port`. Strategy:
     /// 1. Walk every numeric directory under `/proc`.
-    /// 2. For each PID we can read, ask the kernel via `/proc/<pid>/net/tcp`
-    ///    whether the port appears in the LISTEN state in that netns.
-    /// 3. If yes, walk `/proc/<pid>/fd` looking for a `socket:[inode]`
-    ///    matching one of the listener inodes from step 2.
-    /// 4. First match wins. Tie-breaks aren't expected — only one
-    ///    process can hold a TCP listening fd at a time (SO_REUSEPORT
-    ///    aside, but our scenarios don't enable it on the main listener).
+    /// 2. Collect every candidate that has the port in `LISTEN` in its
+    ///    `/proc/<pid>/net/tcp{,6}` and an `fd` matching the listener
+    ///    socket inode.
+    /// 3. Prefer the candidate whose `/proc/<pid>/cmdline` contains
+    ///    `--inherit-fd`. That's the child of a SIGUSR2 binary
+    ///    upgrade; without this preference the old parent (still
+    ///    holding the same listener inode during its
+    ///    `shutdown_timeout` window) wins the race.
+    /// 4. Otherwise fall back to the highest PID — newest process
+    ///    spawned, which is the right pick when no upgrade is in
+    ///    flight.
     pub(super) fn find_pid_owning_listener(port: u16) -> Result<u32, String> {
         let proc_dir = fs::read_dir("/proc").map_err(|e| format!("read /proc: {e}"))?;
         let mut last_err: Option<String> = None;
+        let mut candidates: Vec<u32> = Vec::new();
         for entry in proc_dir.flatten() {
             let name = entry.file_name();
             let Some(name) = name.to_str() else { continue };
@@ -287,10 +292,6 @@ mod linux {
             };
             let owner_uid = meta.uid();
             if owner_uid != current_uid() {
-                // Cannot read fd table; skip this PID — but keep
-                // looking, the actual doorman may belong to the same
-                // user even if some random privileged process matched
-                // the port by accident.
                 last_err = Some(format!(
                     "pid {pid} owns LISTEN port {port} but uid {owner_uid} != ours"
                 ));
@@ -304,15 +305,52 @@ mod linux {
                     continue;
                 }
             };
+            let mut matched = false;
             for record in &fds {
                 let Some(ino) = record.inode else { continue };
                 if inodes.contains(&ino) {
-                    return Ok(pid);
+                    matched = true;
+                    break;
                 }
             }
+            if matched {
+                candidates.push(pid);
+            }
         }
-        Err(last_err
-            .unwrap_or_else(|| format!("no process owns a LISTEN socket on port {port} in /proc")))
+
+        if candidates.is_empty() {
+            return Err(last_err.unwrap_or_else(|| {
+                format!("no process owns a LISTEN socket on port {port} in /proc")
+            }));
+        }
+
+        let upgrade_child = candidates
+            .iter()
+            .copied()
+            .find(|pid| cmdline_contains(*pid, "--inherit-fd"));
+        if let Some(pid) = upgrade_child {
+            return Ok(pid);
+        }
+
+        candidates.sort_unstable();
+        Ok(*candidates.last().expect("non-empty after early return"))
+    }
+
+    /// Best-effort `/proc/<pid>/cmdline` substring match. The cmdline
+    /// uses NUL bytes between argv entries; we replace each with a
+    /// space before searching so `--inherit-fd 9` joins into one
+    /// searchable string. Read failures (race against exit, EPERM,
+    /// missing dir) collapse to "no match" — the caller's fallback
+    /// is the right behaviour in either case.
+    pub(super) fn cmdline_contains(pid: u32, needle: &str) -> bool {
+        let Ok(bytes) = fs::read(format!("/proc/{pid}/cmdline")) else {
+            return false;
+        };
+        let joined: String = bytes
+            .iter()
+            .map(|&b| if b == 0 { ' ' } else { b as char })
+            .collect();
+        joined.contains(needle)
     }
 
     pub(super) fn current_uid() -> u32 {

--- a/tests/bdd/proc_inspect.rs
+++ b/tests/bdd/proc_inspect.rs
@@ -1,21 +1,6 @@
-//! External `/proc` inspection helpers for the BDD harness.
-//!
-//! Two operations the binary-upgrade-fd-leak tests need:
-//!
-//! 1. Find the PID of the process currently owning the listening TCP
-//!    socket on a known port. Used after `SIGUSR2` upgrades, when the
-//!    new child process is not the one this harness spawned and the
-//!    original `tokio::process::Child` handle no longer tracks it.
-//!
-//! 2. Inventory every open fd of that process: socket inode, fdinfo
-//!    flags, `FD_CLOEXEC` bit. Used to assert "no fd grew across the
-//!    chained upgrades" and "every non-listener socket has CLOEXEC set".
-//!
-//! Both run **from the test process**. The pooler must never read its
-//! own `/proc/self/fd` from a code path that runs under fd pressure —
-//! that's the failure mode we are testing.
-//!
-//! Linux-only. Stubs on other targets so `tests/bdd` still compiles.
+//! External `/proc` inspection for BDD fd-leak checks.
+//! The pooler must not read `/proc/self/fd` while the test is creating
+//! fd pressure.
 
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
 
@@ -59,18 +44,12 @@ impl FdRecord {
     }
 }
 
-/// Full external snapshot of a process's fd table plus its kernel-side
-/// listener inode set. Used both for assertions and for diagnostic dumps
-/// on failure.
+/// External fd snapshot plus listener inode set.
 #[derive(Debug, Clone)]
 pub struct FdInventory {
     pub pid: u32,
     pub fds: Vec<FdRecord>,
-    /// Socket inodes from `/proc/<pid>/net/tcp{,6}` that were in the
-    /// `LISTEN` state at snapshot time. We exclude listener fds from
-    /// the universal CLOEXEC assertion by inode rather than by fd
-    /// number, so the check survives fd-number shuffling across
-    /// generations.
+    /// Listener socket inodes for the inspected port.
     pub listener_inodes: std::collections::BTreeSet<u64>,
 }
 
@@ -83,8 +62,7 @@ impl FdInventory {
         self.fds.iter().filter(|f| f.is_socket()).count()
     }
 
-    /// Non-listener socket fds: socket fds whose inode does not appear
-    /// in the kernel's LISTEN set for this process.
+    /// Socket fds whose inode is not in the listener set.
     pub fn non_listener_socket_fds(&self) -> Vec<&FdRecord> {
         self.fds
             .iter()
@@ -100,16 +78,8 @@ impl FdInventory {
             .collect()
     }
 
-    /// Returns offenders: socket fds that either have `FD_CLOEXEC` not
-    /// set (`Some(false)`) or where `fdinfo` could not be read
-    /// (`None`). The original implementation accepted `None` silently,
-    /// which gives the assertion a soft loophole: if `/proc/<pid>/fdinfo/<fd>`
-    /// disappears between the `readlink` and the `flags:` read, the test
-    /// would call the fd "fine" without ever inspecting it. Treating
-    /// `None` as an offender matches what the step name promises —
-    /// "every non-listener socket fd has FD_CLOEXEC set" — and turns
-    /// a transient read error into a re-inventory candidate rather
-    /// than a pass.
+    /// Non-listener socket fds without proven FD_CLOEXEC.
+    /// `None` is an offender; the BDD step retries before failing.
     pub fn non_listener_sockets_without_cloexec(&self) -> Vec<&FdRecord> {
         self.non_listener_socket_fds()
             .into_iter()
@@ -117,9 +87,7 @@ impl FdInventory {
             .collect()
     }
 
-    /// Pretty-printed offender table for failure messages. One line per
-    /// fd, with type / inode / fdinfo state / target. Truncated at 40
-    /// rows to keep panic messages bounded.
+    /// Bounded offender table for panic messages.
     pub fn format_offender_lines(&self, offenders: &[&FdRecord]) -> String {
         let mut out = String::new();
         out.push_str("  fd      kind        inode      cloexec  target\n");
@@ -153,10 +121,7 @@ mod linux {
     use std::fs;
     use std::os::unix::fs::MetadataExt;
 
-    /// Parses the inode out of strings like `socket:[12345]`,
-    /// `pipe:[6789]`, `anon_inode:[eventpoll]`. Returns `None` when the
-    /// bracketed value is not numeric (e.g. `anon_inode:[eventpoll]`
-    /// itself).
+    /// Parse bracketed inode from `socket:[12345]`-style targets.
     pub(super) fn parse_inode_in_brackets(s: &str) -> Option<u64> {
         let lb = s.find('[')?;
         let rb = s.find(']')?;
@@ -166,8 +131,7 @@ mod linux {
         s[lb + 1..rb].parse::<u64>().ok()
     }
 
-    /// Reads `O_CLOEXEC` from `/proc/<pid>/fdinfo/<fd>`. The `flags:`
-    /// line is an octal mask; `O_CLOEXEC` is bit `0o2000000`.
+    /// Read `O_CLOEXEC` from `/proc/<pid>/fdinfo/<fd>` flags.
     pub(super) fn read_cloexec(pid: u32, fd: i32) -> Option<bool> {
         let body = fs::read_to_string(format!("/proc/{pid}/fdinfo/{fd}")).ok()?;
         for line in body.lines() {
@@ -180,9 +144,7 @@ mod linux {
         None
     }
 
-    /// Hex column `XXXXXXXX:HHHH` from `/proc/net/tcp` is little-endian
-    /// for IPv4 in the address half and big-endian-as-hex for the port.
-    /// We only need the port for the listener filter; helper kept small.
+    /// Parse `/proc/net/tcp` local address and return only the port.
     pub(super) fn parse_local_port_hex(local: &str) -> Option<u16> {
         let mut parts = local.split(':');
         let _ip = parts.next()?;
@@ -190,10 +152,7 @@ mod linux {
         u16::from_str_radix(port_hex, 16).ok()
     }
 
-    /// Returns the inode set of LISTEN sockets on `port` for this
-    /// process. The `pid` argument scopes the read to the right netns
-    /// (via `/proc/<pid>/net/tcp` rather than the global view), so we
-    /// observe the same TCP listing the inspected process does.
+    /// LISTEN socket inode set for `port` in the target process netns.
     pub(super) fn listening_inodes_for_port(pid: u32, port: u16) -> BTreeSet<u64> {
         let mut out = BTreeSet::new();
         for file in [
@@ -230,10 +189,7 @@ mod linux {
         out
     }
 
-    /// Walks `/proc/<pid>/fd` and returns one FdRecord per slot.
-    /// Skipped entries on EBADF (race against close) are silently
-    /// dropped — the goal is an honest snapshot of what is open right
-    /// now from outside, not a transactional view.
+    /// Snapshot `/proc/<pid>/fd`; skip entries that close mid-walk.
     pub(super) fn inventory_fds(pid: u32) -> Result<Vec<FdRecord>, String> {
         let dir = format!("/proc/{pid}/fd");
         let entries = fs::read_dir(&dir).map_err(|e| format!("read_dir {dir}: {e}"))?;
@@ -263,20 +219,8 @@ mod linux {
         Ok(out)
     }
 
-    /// Returns the PID of the process that owns the LISTEN socket on
-    /// `port`. Strategy:
-    /// 1. Walk every numeric directory under `/proc`.
-    /// 2. Collect every candidate that has the port in `LISTEN` in its
-    ///    `/proc/<pid>/net/tcp{,6}` and an `fd` matching the listener
-    ///    socket inode.
-    /// 3. Prefer the candidate whose `/proc/<pid>/cmdline` contains
-    ///    `--inherit-fd`. That's the child of a SIGUSR2 binary
-    ///    upgrade; without this preference the old parent (still
-    ///    holding the same listener inode during its
-    ///    `shutdown_timeout` window) wins the race.
-    /// 4. Otherwise fall back to the highest PID — newest process
-    ///    spawned, which is the right pick when no upgrade is in
-    ///    flight.
+    /// Find the process that owns the listener on `port`.
+    /// During upgrade overlap, prefer a process started with `--inherit-fd`.
     pub(super) fn find_pid_owning_listener(port: u16) -> Result<u32, String> {
         let proc_dir = fs::read_dir("/proc").map_err(|e| format!("read /proc: {e}"))?;
         let mut last_err: Option<String> = None;
@@ -297,11 +241,8 @@ mod linux {
                 continue;
             };
             if meta.uid() != current_uid() {
-                // Cannot inspect /proc/<pid>/fd across uid boundary
-                // without ptrace privileges. Skip and keep looking,
-                // but flag so the caller's failure message points at
-                // the right diagnosis when no candidate is found at
-                // all.
+                // Same-netns tcp rows are visible across users, but fd
+                // links are not. Keep the diagnostic if no candidate matches.
                 last_err = Some(format!(
                     "pid {pid} owns LISTEN port {port} but its /proc/<pid> belongs to a different user"
                 ));
@@ -346,12 +287,7 @@ mod linux {
         Ok(*candidates.last().expect("non-empty after early return"))
     }
 
-    /// Best-effort `/proc/<pid>/cmdline` substring match. The cmdline
-    /// uses NUL bytes between argv entries; we replace each with a
-    /// space before searching so `--inherit-fd 9` joins into one
-    /// searchable string. Read failures (race against exit, EPERM,
-    /// missing dir) collapse to "no match" — the caller's fallback
-    /// is the right behaviour in either case.
+    /// Best-effort cmdline substring match; read failures mean "no match".
     pub(super) fn cmdline_contains(pid: u32, needle: &str) -> bool {
         let Ok(bytes) = fs::read(format!("/proc/{pid}/cmdline")) else {
             return false;
@@ -396,8 +332,7 @@ pub fn inventory(_pid: u32, _listener_port: u16) -> Result<FdInventory, String> 
     Err("proc_inspect requires Linux".to_string())
 }
 
-/// Diagnostic helper for failure messages. Summarises an inventory in
-/// one short line plus a per-kind breakdown.
+/// One-line inventory summary plus per-kind counts.
 pub fn summary(inv: &FdInventory) -> String {
     let mut by_kind: BTreeMap<&'static str, usize> = BTreeMap::new();
     for f in &inv.fds {
@@ -417,7 +352,5 @@ pub fn summary(inv: &FdInventory) -> String {
     )
 }
 
-// Note: BDD harness uses harness = false so #[test] items here would not
-// be discovered. Parser correctness for /proc/net/tcp and /proc/PID/fdinfo
-// is exercised end-to-end by the binary-upgrade-fd-cloexec BDD scenario;
-// adding a separate runner would duplicate that signal.
+// The BDD binary uses `harness = false`; parser unit tests need a separate
+// test target if this helper grows more parsing logic.

--- a/tests/bdd/world.rs
+++ b/tests/bdd/world.rs
@@ -113,6 +113,13 @@ pub struct DoormanWorld {
     /// Used by `pg_doorman started with NOFILE limit N and config:` to put
     /// the daemon under a tight fd budget for migration-buffer tests.
     pub doorman_nofile_limit: Option<u64>,
+    /// Number of extra inheritable pipe fds to open in `pre_exec` before
+    /// `exec`. Used by the polluted-parent scenario to verify that the
+    /// child of a SIGUSR2 upgrade closes inherited fds outside its
+    /// allowlist (see `c891054`). Each unit opens one pipe(2) pair = 2
+    /// fds, and `FD_CLOEXEC` is cleared on both ends so they survive
+    /// `exec`. None means no extra fds are seeded.
+    pub doorman_extra_inheritable_pipes: Option<usize>,
     pub pg_ssl_ca_cert_file: Option<NamedTempFile>,
     pub pg_ssl_ca_key_file: Option<NamedTempFile>,
     pub pg_ssl_cert_file: Option<NamedTempFile>,


### PR DESCRIPTION
## Summary
- Mark client fds received through SCM_RIGHTS as close-on-exec, using MSG_CMSG_CLOEXEC on Linux plus an fcntl fallback.
- Drop unexpected inherited fds at the very start of binary-upgrade children, preserving only stdio, listener, readiness pipe, and migration socket. This lets an upgrade from an already-buggy process shed stale non-CLOEXEC socket refs before reading config or accepting traffic.
- Restore FD_CLOEXEC on inherited upgrade fds after the child starts, and keep parent-only pipe/socketpair ends non-inheritable.
- Keep the parent listener when the child does not signal readiness, and add EMFILE backoff to the web listener accept loop.
- Configure accepted web TCP sockets with safe options (TCP_NODELAY, optional SO_SNDBUF/SO_RCVBUF caps, keepalive, TCP_USER_TIMEOUT) without applying the pooler SO_LINGER policy.
- Keep EMFILE/ENFILE from backend connect as local pg_doorman resource exhaustion, not backend unreachability, so it does not trigger Patroni-assisted fallback or fallback-candidate cooldown.

## Investigation notes
- 2026-05-21 12:48:01 UTC diagnostics on 3.9.1 showed 15200/15200 fds, 15189 socket fds, but only about 5232 live clients and about 5235 live TCP fds mapped in /proc. Roughly 9954 socket fds were stale/unmapped.
- Latest 3.9.1 -> 3.10.5 log showed unknown=230 before upgrade, then tcp_cw=5502 after upgrade, then unknown=6345 while clients stayed around 4550.
- The web listener produced 100365 unthrottled EMFILE lines after the fd table filled.
- The latest log confirms the fallback bug: at 2026-05-21T15:10:59.610Z, a backend Unix-socket connect failed with `Too many open files`, and the next line routed the pool through fallback.

## Testing
- cargo fmt --check
- cargo check
- cargo test --lib
