### PR TITLE
Refactor BDD protocol helpers

### DIFF
--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -1979,8 +1979,25 @@ mod umask_guard_tests {
 mod inherited_fd_cleanup_tests {
     use super::close_unexpected_fds;
 
-    fn fd_is_open(fd: libc::c_int) -> bool {
-        unsafe { libc::fcntl(fd, libc::F_GETFD) >= 0 }
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct FdIdentity {
+        dev: libc::dev_t,
+        ino: libc::ino_t,
+    }
+
+    fn fd_identity(fd: libc::c_int) -> Option<FdIdentity> {
+        // SAFETY: fstat reads metadata for the supplied descriptor only.
+        unsafe {
+            let mut stat = std::mem::zeroed::<libc::stat>();
+            if libc::fstat(fd, &mut stat) == 0 {
+                Some(FdIdentity {
+                    dev: stat.st_dev,
+                    ino: stat.st_ino,
+                })
+            } else {
+                None
+            }
+        }
     }
 
     struct Pipe {
@@ -1998,14 +2015,19 @@ mod inherited_fd_cleanup_tests {
                 write: fds[1],
             }
         }
+
+        fn mark_closed(&mut self) {
+            self.read = -1;
+            self.write = -1;
+        }
     }
 
     impl Drop for Pipe {
         fn drop(&mut self) {
-            if fd_is_open(self.read) {
+            if self.read >= 0 {
                 unsafe { libc::close(self.read) };
             }
-            if fd_is_open(self.write) {
+            if self.write >= 0 {
                 unsafe { libc::close(self.write) };
             }
         }
@@ -2014,18 +2036,29 @@ mod inherited_fd_cleanup_tests {
     #[test]
     fn close_unexpected_fds_preserves_allowlist() {
         let keep = Pipe::new();
-        let leaked = Pipe::new();
+        let mut leaked = Pipe::new();
+        let keep_read_identity = fd_identity(keep.read).expect("keep read fd must be open");
+        let keep_write_identity = fd_identity(keep.write).expect("keep write fd must be open");
+        let leaked_read = leaked.read;
+        let leaked_write = leaked.write;
 
         let mut allow = vec![0, 1, 2, keep.read, keep.write];
         allow.sort_unstable();
         let closed =
-            close_unexpected_fds([keep.read, keep.write, leaked.read, leaked.write], &allow);
+            close_unexpected_fds([keep.read, keep.write, leaked_read, leaked_write], &allow);
+        leaked.mark_closed();
 
-        assert!(closed >= 2, "expected to close the leaked pipe fds");
-        assert!(fd_is_open(keep.read), "allowlisted read fd must survive");
-        assert!(fd_is_open(keep.write), "allowlisted write fd must survive");
-        assert!(!fd_is_open(leaked.read), "unexpected read fd must close");
-        assert!(!fd_is_open(leaked.write), "unexpected write fd must close");
+        assert_eq!(closed, 2, "expected to close exactly the leaked pipe fds");
+        assert_eq!(
+            fd_identity(keep.read),
+            Some(keep_read_identity),
+            "allowlisted read fd must survive"
+        );
+        assert_eq!(
+            fd_identity(keep.write),
+            Some(keep_write_identity),
+            "allowlisted write fd must survive"
+        );
     }
 }
 

--- a/tests/bdd/doorman_helper.rs
+++ b/tests/bdd/doorman_helper.rs
@@ -231,7 +231,6 @@ pub async fn generate_pg_ssl_certificates(world: &mut DoormanWorld) {
     world.pg_ssl_wrong_ca_cert_file = Some(wrong_ca_cert_file);
 }
 
-/// Set pg_doorman hba file with inline content
 #[given("pg_doorman hba file contains:")]
 pub async fn set_doorman_hba_file(world: &mut DoormanWorld, step: &Step) {
     let hba_content = step
@@ -243,10 +242,8 @@ pub async fn set_doorman_hba_file(world: &mut DoormanWorld, step: &Step) {
     world.doorman_hba_file = Some(create_temp_file(&hba_content));
 }
 
-/// Start pg_doorman with config content
 #[given("pg_doorman started with config:")]
 pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
-    // Stop any previously running pg_doorman before starting a new one
     if let Some(ref mut child) = world.doorman_process {
         stop_doorman(child);
     }
@@ -261,14 +258,12 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
     let doorman_port = pick_unused_port().expect("No free ports for pg_doorman");
     world.doorman_port = Some(doorman_port);
 
-    // Use centralized placeholder replacement
     let config_content = world.replace_placeholders(&config_content);
 
     let config_file = create_config_file(&config_content);
     let config_path = config_file.path().to_path_buf();
     world.doorman_config_file = Some(config_file);
 
-    // Use CARGO_BIN_EXE_pg_doorman which is automatically set by cargo test
     let doorman_binary = env!("CARGO_BIN_EXE_pg_doorman");
     // For @bench scenarios, always use "info" level to avoid debug overhead
     let log_level = if world.is_bench {
@@ -350,7 +345,6 @@ pub async fn start_doorman_with_config(world: &mut DoormanWorld, step: &Step) {
 
     world.doorman_process = Some(child);
 
-    // Wait for pg_doorman to be ready (custom implementation with log capture)
     let log_path = world.doorman_log_path.clone();
     wait_for_doorman_ready(
         doorman_port,
@@ -830,10 +824,8 @@ pub async fn send_sigint_to_foreground(world: &mut DoormanWorld) {
 pub async fn wait_for_foreground_binary_upgrade(world: &mut DoormanWorld) {
     let port = world.doorman_port.expect("doorman_port not set");
 
-    // Wait a bit for the new process to start and signal readiness
     sleep(Duration::from_millis(2000)).await;
 
-    // Verify the port is still accessible (new process is listening)
     for _ in 0..20 {
         if std::net::TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok() {
             return;
@@ -847,7 +839,7 @@ pub async fn wait_for_foreground_binary_upgrade(world: &mut DoormanWorld) {
     );
 }
 
-/// Verify that foreground pg_doorman PID has changed after binary upgrade
+/// Foreground upgrade keeps the service reachable after SIGUSR2.
 #[then(regex = r#"foreground pg_doorman PID should be different from stored "([^"]+)""#)]
 pub async fn verify_foreground_pid_changed(world: &mut DoormanWorld, name: String) {
     let port = world.doorman_port.expect("doorman_port not set");
@@ -857,27 +849,16 @@ pub async fn verify_foreground_pid_changed(world: &mut DoormanWorld, name: Strin
         .get(&(name.clone(), "foreground_pid".to_string()))
         .expect("Stored foreground PID not found");
 
-    // The old process should have exited or be in graceful shutdown
-    // We need to find the new process listening on the port
-    // Since we can't easily get the new PID, we verify the old process is no longer the main listener
-
-    // Wait a bit and check if old process is still running
+    // Foreground mode does not expose the replacement child PID to the harness.
+    // The contract here is availability across the handoff; the separate
+    // `stored foreground PID ... should not exist` step verifies old PID exit.
     sleep(Duration::from_millis(500)).await;
 
-    // Check if port is still accessible
     assert!(
         std::net::TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok(),
         "New pg_doorman should be listening on port {}",
         port
     );
-
-    // The old process should eventually exit after graceful shutdown
-    // For now, we just verify the service is still available
-    // In a real scenario, the old process exits after all clients disconnect
-
-    // Note: We can't easily verify PID change in foreground mode without additional tracking
-    // because the child process is not tracked by our test harness
-    // The key verification is that the service remains available after SIGINT
 
     println!(
         "Binary upgrade completed: old PID was {}, service still available on port {}",

--- a/tests/bdd/extended/dual_connection.rs
+++ b/tests/bdd/extended/dual_connection.rs
@@ -4,6 +4,25 @@ use cucumber::{then, when};
 
 use super::helpers;
 
+fn get_dual_connections(world: &mut DoormanWorld) -> (&mut PgConnection, &mut PgConnection) {
+    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
+    let doorman_conn = world
+        .doorman_conn
+        .as_mut()
+        .expect("Not connected to pg_doorman");
+
+    (pg_conn, doorman_conn)
+}
+
+fn append_dual_messages(
+    world: &mut DoormanWorld,
+    pg_messages: helpers::ProtocolMessages,
+    doorman_messages: helpers::ProtocolMessages,
+) {
+    world.pg_accumulated_messages.extend(pg_messages);
+    world.doorman_accumulated_messages.extend(doorman_messages);
+}
+
 #[when(
     regex = r#"^we login to postgres and pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)"$"#
 )]
@@ -19,7 +38,6 @@ pub async fn login_to_both(
     let pg_addr = format!("127.0.0.1:{}", pg_port);
     let doorman_addr = format!("127.0.0.1:{}", doorman_port);
 
-    // Connect to PostgreSQL
     let mut pg_conn = PgConnection::connect(&pg_addr)
         .await
         .expect("Failed to connect to PostgreSQL");
@@ -32,7 +50,6 @@ pub async fn login_to_both(
         .await
         .expect("Failed to authenticate to PostgreSQL");
 
-    // Connect to pg_doorman
     let mut doorman_conn = PgConnection::connect(&doorman_addr)
         .await
         .expect("Failed to connect to pg_doorman");
@@ -48,7 +65,6 @@ pub async fn login_to_both(
     world.pg_conn = Some(pg_conn);
     world.doorman_conn = Some(doorman_conn);
 
-    // Save credentials for reconnection
     world.last_user = Some(user);
     world.last_password = Some(password);
     world.last_database = Some(database);
@@ -56,12 +72,9 @@ pub async fn login_to_both(
 
 #[when(regex = r#"^we disconnect from both$"#)]
 pub async fn disconnect_from_both(world: &mut DoormanWorld) {
-    // Drop connections by setting them to None
-    // This will close the TCP connections gracefully
     world.pg_conn = None;
     world.doorman_conn = None;
 
-    // Clear accumulated messages for fresh start after reconnect
     world.pg_accumulated_messages.clear();
     world.doorman_accumulated_messages.clear();
 }
@@ -87,7 +100,6 @@ pub async fn reconnect_to_both(world: &mut DoormanWorld) {
     let pg_addr = format!("127.0.0.1:{}", pg_port);
     let doorman_addr = format!("127.0.0.1:{}", doorman_port);
 
-    // Connect to PostgreSQL
     let mut pg_conn = PgConnection::connect(&pg_addr)
         .await
         .expect("Failed to reconnect to PostgreSQL");
@@ -100,7 +112,6 @@ pub async fn reconnect_to_both(world: &mut DoormanWorld) {
         .await
         .expect("Failed to authenticate to PostgreSQL");
 
-    // Connect to pg_doorman
     let mut doorman_conn = PgConnection::connect(&doorman_addr)
         .await
         .expect("Failed to reconnect to pg_doorman");
@@ -116,40 +127,26 @@ pub async fn reconnect_to_both(world: &mut DoormanWorld) {
     world.pg_conn = Some(pg_conn);
     world.doorman_conn = Some(doorman_conn);
 
-    // Clear accumulated messages for fresh start
     world.pg_accumulated_messages.clear();
     world.doorman_accumulated_messages.clear();
 }
 
 #[when(regex = r#"^we send SimpleQuery "([^"]+)" to both$"#)]
 pub async fn send_simple_query_to_both(world: &mut DoormanWorld, query: String) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
+    let (pg_messages, doorman_messages) = {
+        let (pg_conn, doorman_conn) = get_dual_connections(world);
+        pg_conn
+            .send_simple_query(&query)
+            .await
+            .expect("Failed to send query to PostgreSQL");
+        doorman_conn
+            .send_simple_query(&query)
+            .await
+            .expect("Failed to send query to pg_doorman");
+        helpers::read_both_until_ready(pg_conn, doorman_conn).await
+    };
 
-    pg_conn
-        .send_simple_query(&query)
-        .await
-        .expect("Failed to send query to PostgreSQL");
-    doorman_conn
-        .send_simple_query(&query)
-        .await
-        .expect("Failed to send query to pg_doorman");
-
-    // Read messages from both
-    let pg_messages = pg_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from PostgreSQL");
-    let doorman_messages = doorman_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from pg_doorman");
-
-    world.pg_accumulated_messages.extend(pg_messages);
-    world.doorman_accumulated_messages.extend(doorman_messages);
+    append_dual_messages(world, pg_messages, doorman_messages);
 }
 
 #[when(regex = r#"^we send CopyFromStdin "([^"]+)" with data "([^"]*)" to both$"#)]
@@ -160,36 +157,29 @@ pub async fn send_copy_from_stdin_to_both(world: &mut DoormanWorld, query: Strin
         .as_mut()
         .expect("Not connected to pg_doorman");
 
-    // Unescape the data string (handle \t and \n)
     let unescaped_data = data.replace("\\t", "\t").replace("\\n", "\n");
 
-    // Send the COPY command via simple query to PostgreSQL
     pg_conn
         .send_simple_query(&query)
         .await
         .expect("Failed to send COPY query to PostgreSQL");
 
-    // Send the COPY command via simple query to pg_doorman
     doorman_conn
         .send_simple_query(&query)
         .await
         .expect("Failed to send COPY query to pg_doorman");
 
-    // Read initial response from PostgreSQL (should be CopyInResponse 'G' or ErrorResponse 'E')
     let (pg_msg_type, pg_msg_data) = pg_conn
         .read_message()
         .await
         .expect("Failed to read COPY response from PostgreSQL");
 
-    // Read initial response from pg_doorman
     let (doorman_msg_type, doorman_msg_data) = doorman_conn
         .read_message()
         .await
         .expect("Failed to read COPY response from pg_doorman");
 
-    // If we got CopyInResponse ('G'), send the data and CopyDone
     if pg_msg_type == 'G' {
-        // Send copy data to PostgreSQL
         if !unescaped_data.is_empty() {
             pg_conn
                 .send_copy_data(unescaped_data.as_bytes())
@@ -201,14 +191,12 @@ pub async fn send_copy_from_stdin_to_both(world: &mut DoormanWorld, query: Strin
             .await
             .expect("Failed to send CopyDone to PostgreSQL");
     } else {
-        // Error response - store it
         world
             .pg_accumulated_messages
             .push((pg_msg_type, pg_msg_data.clone()));
     }
 
     if doorman_msg_type == 'G' {
-        // Send copy data to pg_doorman
         if !unescaped_data.is_empty() {
             doorman_conn
                 .send_copy_data(unescaped_data.as_bytes())
@@ -220,13 +208,11 @@ pub async fn send_copy_from_stdin_to_both(world: &mut DoormanWorld, query: Strin
             .await
             .expect("Failed to send CopyDone to pg_doorman");
     } else {
-        // Error response - store it
         world
             .doorman_accumulated_messages
             .push((doorman_msg_type, doorman_msg_data.clone()));
     }
 
-    // Read remaining messages until ReadyForQuery from both
     let pg_messages = pg_conn
         .read_all_messages_until_ready()
         .await
@@ -242,20 +228,8 @@ pub async fn send_copy_from_stdin_to_both(world: &mut DoormanWorld, query: Strin
 
 #[when(regex = r#"^we send Parse "([^"]*)" with query "([^"]+)" to both$"#)]
 pub async fn send_parse_to_both(world: &mut DoormanWorld, name: String, query: String) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
-    pg_conn
-        .send_parse(&name, &query)
-        .await
-        .expect("Failed to send Parse to PostgreSQL");
-    doorman_conn
-        .send_parse(&name, &query)
-        .await
-        .expect("Failed to send Parse to pg_doorman");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_parse_to_both(pg_conn, doorman_conn, &name, &query).await;
 }
 
 #[when(regex = r#"^we send Bind "([^"]*)" to "([^"]*)" with params "([^"]*)" to both$"#)]
@@ -265,64 +239,24 @@ pub async fn send_bind_to_both(
     statement: String,
     params_str: String,
 ) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
     let params = super::helpers::parse_bind_params(&params_str);
-
-    pg_conn
-        .send_bind(&portal, &statement, params.clone())
-        .await
-        .expect("Failed to send Bind to PostgreSQL");
-    doorman_conn
-        .send_bind(&portal, &statement, params)
-        .await
-        .expect("Failed to send Bind to pg_doorman");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_bind_to_both(pg_conn, doorman_conn, &portal, &statement, params).await;
 }
 
 #[when(regex = r#"^we send Describe "([^"])" "([^"]*)" to both$"#)]
 pub async fn send_describe_to_both(world: &mut DoormanWorld, target_type: String, name: String) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
-    let target_char = target_type.chars().next().expect("Empty target type");
-
-    pg_conn
-        .send_describe(target_char, &name)
-        .await
-        .expect("Failed to send Describe to PostgreSQL");
-    doorman_conn
-        .send_describe(target_char, &name)
-        .await
-        .expect("Failed to send Describe to pg_doorman");
+    let target_char = helpers::single_char(&target_type, "target type");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_describe_to_both(pg_conn, doorman_conn, target_char, &name).await;
 }
 
 #[when(regex = r#"^we send Execute "([^"]*)" to both$"#)]
 pub async fn send_execute_to_both(world: &mut DoormanWorld, portal: String) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
-    pg_conn
-        .send_execute(&portal, 0)
-        .await
-        .expect("Failed to send Execute to PostgreSQL");
-    doorman_conn
-        .send_execute(&portal, 0)
-        .await
-        .expect("Failed to send Execute to pg_doorman");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_execute_to_both(pg_conn, doorman_conn, &portal, 0).await;
 }
 
-/// Helper step to repeat a sequence of Parse, Bind, Describe, Execute messages multiple times
-/// Format: we repeat <N> times: Parse "<name>" with query "<query>", Bind "<portal>" to "<statement>" with params "<params>", Describe "<type>" "<name>", Execute "<portal>" to both
 #[allow(clippy::too_many_arguments)]
 #[when(
     regex = r#"^we repeat (\d+) times: Parse "([^"]*)" with query "([^"]+)", Bind "([^"]*)" to "([^"]*)" with params "([^"]+)", Describe "([^"])" "([^"]*)", Execute "([^"]*)" to both$"#
@@ -347,122 +281,43 @@ pub async fn repeat_extended_protocol_to_both(
 
     let params = super::helpers::parse_bind_params(&params_str);
 
-    let describe_char = describe_type.chars().next().expect("Empty describe type");
+    let describe_char = helpers::single_char(&describe_type, "describe type");
 
-    // Send all messages N times
     for _ in 0..times {
-        // Parse
-        pg_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to PostgreSQL");
-        doorman_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to pg_doorman");
-
-        // Bind
-        pg_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to PostgreSQL");
-        doorman_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to pg_doorman");
-
-        // Describe
-        pg_conn
-            .send_describe(describe_char, &describe_name)
-            .await
-            .expect("Failed to send Describe to PostgreSQL");
-        doorman_conn
-            .send_describe(describe_char, &describe_name)
-            .await
-            .expect("Failed to send Describe to pg_doorman");
-
-        // Execute
-        pg_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to PostgreSQL");
-        doorman_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to pg_doorman");
+        helpers::send_parse_to_both(pg_conn, doorman_conn, &parse_name, &query).await;
+        helpers::send_bind_to_both(
+            pg_conn,
+            doorman_conn,
+            &bind_portal,
+            &bind_statement,
+            params.clone(),
+        )
+        .await;
+        helpers::send_describe_to_both(pg_conn, doorman_conn, describe_char, &describe_name).await;
+        helpers::send_execute_to_both(pg_conn, doorman_conn, &execute_portal, 0).await;
     }
 
-    // Send Sync to both
-    pg_conn
-        .send_sync()
-        .await
-        .expect("Failed to send Sync to PostgreSQL");
-    doorman_conn
-        .send_sync()
-        .await
-        .expect("Failed to send Sync to pg_doorman");
-
-    // Read messages from both
-    let pg_messages = pg_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from PostgreSQL");
-    let doorman_messages = doorman_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from pg_doorman");
-
-    world.pg_accumulated_messages.extend(pg_messages);
-    world.doorman_accumulated_messages.extend(doorman_messages);
+    helpers::send_sync_to_both(pg_conn, doorman_conn).await;
+    let (pg_messages, doorman_messages) =
+        helpers::read_both_until_ready(pg_conn, doorman_conn).await;
+    append_dual_messages(world, pg_messages, doorman_messages);
 }
 
 #[when(regex = r#"^we send Sync to both$"#)]
 pub async fn send_sync_to_both(world: &mut DoormanWorld) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
+    let (pg_messages, doorman_messages) = {
+        let (pg_conn, doorman_conn) = get_dual_connections(world);
+        helpers::send_sync_to_both(pg_conn, doorman_conn).await;
+        helpers::read_both_until_ready(pg_conn, doorman_conn).await
+    };
 
-    pg_conn
-        .send_sync()
-        .await
-        .expect("Failed to send Sync to PostgreSQL");
-    doorman_conn
-        .send_sync()
-        .await
-        .expect("Failed to send Sync to pg_doorman");
-
-    // Read messages from both
-    let pg_messages = pg_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from PostgreSQL");
-    let doorman_messages = doorman_conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages from pg_doorman");
-
-    world.pg_accumulated_messages.extend(pg_messages);
-    world.doorman_accumulated_messages.extend(doorman_messages);
+    append_dual_messages(world, pg_messages, doorman_messages);
 }
 
 #[when(regex = r#"^we send Flush to both$"#)]
 pub async fn send_flush_to_both(world: &mut DoormanWorld) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
-    pg_conn
-        .send_flush()
-        .await
-        .expect("Failed to send Flush to PostgreSQL");
-    doorman_conn
-        .send_flush()
-        .await
-        .expect("Failed to send Flush to pg_doorman");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_flush_to_both(pg_conn, doorman_conn).await;
 }
 
 #[when(regex = r#"^we send Execute "([^"]*)" with max_rows "(\d+)" to both$"#)]
@@ -471,67 +326,28 @@ pub async fn send_execute_with_max_rows_to_both(
     portal: String,
     max_rows: String,
 ) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
     let max_rows_int: i32 = max_rows.parse().expect("Invalid max_rows value");
-
-    pg_conn
-        .send_execute(&portal, max_rows_int)
-        .await
-        .expect("Failed to send Execute to PostgreSQL");
-    doorman_conn
-        .send_execute(&portal, max_rows_int)
-        .await
-        .expect("Failed to send Execute to pg_doorman");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_execute_to_both(pg_conn, doorman_conn, &portal, max_rows_int).await;
 }
 
 #[when(regex = r#"^we send Close "([^"])" "([^"]*)" to both$"#)]
 pub async fn send_close_to_both(world: &mut DoormanWorld, target_type: String, name: String) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
-
-    let target_char = target_type.chars().next().expect("Empty target type");
-
-    pg_conn
-        .send_close(target_char, &name)
-        .await
-        .expect("Failed to send Close to PostgreSQL");
-    doorman_conn
-        .send_close(target_char, &name)
-        .await
-        .expect("Failed to send Close to pg_doorman");
+    let target_char = helpers::single_char(&target_type, "target type");
+    let (pg_conn, doorman_conn) = get_dual_connections(world);
+    helpers::send_close_to_both(pg_conn, doorman_conn, target_char, &name).await;
 }
 
 #[when(regex = r#"^we verify partial response received from both$"#)]
 pub async fn verify_partial_response(world: &mut DoormanWorld) {
-    let pg_conn = world.pg_conn.as_mut().expect("Not connected to PostgreSQL");
-    let doorman_conn = world
-        .doorman_conn
-        .as_mut()
-        .expect("Not connected to pg_doorman");
+    let (pg_messages, doorman_messages) = {
+        let (pg_conn, doorman_conn) = get_dual_connections(world);
+        helpers::read_partial_from_both(pg_conn, doorman_conn).await
+    };
 
-    // Read partial messages (without waiting for ReadyForQuery)
-    let pg_messages = pg_conn
-        .read_partial_messages()
-        .await
-        .expect("Failed to read partial messages from PostgreSQL");
-    let doorman_messages = doorman_conn
-        .read_partial_messages()
-        .await
-        .expect("Failed to read partial messages from pg_doorman");
-
-    world.pg_accumulated_messages.extend(pg_messages);
-    world.doorman_accumulated_messages.extend(doorman_messages);
+    append_dual_messages(world, pg_messages, doorman_messages);
 }
 
-/// Helper step to repeat a simple sequence of Parse, Bind, Execute messages multiple times
 #[when(
     regex = r#"^we repeat (\d+) times: Parse "([^"]*)" with query "([^"]+)", Bind "([^"]*)" to "([^"]*)" with params "([^"]+)", Execute "([^"]*)" to both$"#
 )]
@@ -554,41 +370,20 @@ pub async fn repeat_simple_extended_protocol(
 
     let params = super::helpers::parse_bind_params(&params_str);
 
-    // Send all messages N times
     for _ in 0..times {
-        // Parse
-        pg_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to PostgreSQL");
-        doorman_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to pg_doorman");
-
-        // Bind
-        pg_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to PostgreSQL");
-        doorman_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to pg_doorman");
-
-        // Execute
-        pg_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to PostgreSQL");
-        doorman_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to pg_doorman");
+        helpers::send_parse_to_both(pg_conn, doorman_conn, &parse_name, &query).await;
+        helpers::send_bind_to_both(
+            pg_conn,
+            doorman_conn,
+            &bind_portal,
+            &bind_statement,
+            params.clone(),
+        )
+        .await;
+        helpers::send_execute_to_both(pg_conn, doorman_conn, &execute_portal, 0).await;
     }
 }
 
-/// Helper step to repeat a sequence with Close command
 #[allow(clippy::too_many_arguments)]
 #[when(
     regex = r#"^we repeat (\d+) times: Parse "([^"]*)" with query "([^"]+)", Bind "([^"]*)" to "([^"]*)" with params "([^"]+)", Describe "([^"])" "([^"]*)", Execute "([^"]*)", Close "([^"])" "([^"]*)" to both$"#
@@ -615,60 +410,22 @@ pub async fn repeat_extended_protocol_with_close(
 
     let params = super::helpers::parse_bind_params(&params_str);
 
-    let describe_char = describe_type.chars().next().expect("Empty describe type");
-    let close_char = close_type.chars().next().expect("Empty close type");
+    let describe_char = helpers::single_char(&describe_type, "describe type");
+    let close_char = helpers::single_char(&close_type, "close type");
 
-    // Send all messages N times
     for _ in 0..times {
-        // Parse
-        pg_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to PostgreSQL");
-        doorman_conn
-            .send_parse(&parse_name, &query)
-            .await
-            .expect("Failed to send Parse to pg_doorman");
-
-        // Bind
-        pg_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to PostgreSQL");
-        doorman_conn
-            .send_bind(&bind_portal, &bind_statement, params.clone())
-            .await
-            .expect("Failed to send Bind to pg_doorman");
-
-        // Describe
-        pg_conn
-            .send_describe(describe_char, &describe_name)
-            .await
-            .expect("Failed to send Describe to PostgreSQL");
-        doorman_conn
-            .send_describe(describe_char, &describe_name)
-            .await
-            .expect("Failed to send Describe to pg_doorman");
-
-        // Execute
-        pg_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to PostgreSQL");
-        doorman_conn
-            .send_execute(&execute_portal, 0)
-            .await
-            .expect("Failed to send Execute to pg_doorman");
-
-        // Close
-        pg_conn
-            .send_close(close_char, &close_name)
-            .await
-            .expect("Failed to send Close to PostgreSQL");
-        doorman_conn
-            .send_close(close_char, &close_name)
-            .await
-            .expect("Failed to send Close to pg_doorman");
+        helpers::send_parse_to_both(pg_conn, doorman_conn, &parse_name, &query).await;
+        helpers::send_bind_to_both(
+            pg_conn,
+            doorman_conn,
+            &bind_portal,
+            &bind_statement,
+            params.clone(),
+        )
+        .await;
+        helpers::send_describe_to_both(pg_conn, doorman_conn, describe_char, &describe_name).await;
+        helpers::send_execute_to_both(pg_conn, doorman_conn, &execute_portal, 0).await;
+        helpers::send_close_to_both(pg_conn, doorman_conn, close_char, &close_name).await;
     }
 }
 
@@ -677,7 +434,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
     let pg_messages = &world.pg_accumulated_messages;
     let doorman_messages = &world.doorman_accumulated_messages;
 
-    // Check message count and provide detailed error if mismatch
     if pg_messages.len() != doorman_messages.len() {
         let mut error_msg = format!(
             "\n=== MESSAGE COUNT MISMATCH ===\nPostgreSQL: {} messages\npg_doorman: {} messages\n",
@@ -715,7 +471,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
         let (pg_type, pg_data) = pg_msg;
         let (doorman_type, doorman_data) = doorman_msg;
 
-        // Check message type
         if pg_type != doorman_type {
             eprintln!("\n=== MESSAGE TYPE MISMATCH at position {} ===", i);
             eprintln!(
@@ -732,7 +487,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
             );
         }
 
-        // Check message length
         if pg_data.len() != doorman_data.len() {
             eprintln!("\n=== MESSAGE LENGTH MISMATCH at position {} ===", i);
             eprintln!(
@@ -744,7 +498,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
                 helpers::format_message_details(*doorman_type, doorman_data)
             );
 
-            // Show hex diff for first 64 bytes
             let max_len = pg_data.len().max(doorman_data.len()).min(64);
             eprintln!("\n--- Hex comparison (first {} bytes) ---", max_len);
             eprintln!(
@@ -774,7 +527,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
             );
         }
 
-        // Check message data
         // For RowDescription ('T'), normalize table OIDs before comparison
         // because temp tables have different OIDs on different connections
         let (pg_data_normalized, doorman_data_normalized) = if *pg_type == 'T' {
@@ -797,7 +549,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
                 helpers::format_message_details(*doorman_type, doorman_data)
             );
 
-            // Find first difference
             for (pos, (pg_byte, doorman_byte)) in pg_data_normalized
                 .iter()
                 .zip(doorman_data_normalized.iter())
@@ -809,7 +560,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
                         pos, pg_byte, doorman_byte
                     );
 
-                    // Show context around the difference
                     let start = pos.saturating_sub(8);
                     let end = (pos + 8).min(pg_data.len());
                     eprintln!("Context (bytes {}-{}):", start, end);
@@ -843,7 +593,6 @@ pub async fn verify_identical_messages(world: &mut DoormanWorld) {
         );
     }
 
-    // Clear accumulated messages for next scenario
     world.pg_accumulated_messages.clear();
     world.doorman_accumulated_messages.clear();
 }

--- a/tests/bdd/extended/helpers.rs
+++ b/tests/bdd/extended/helpers.rs
@@ -1,7 +1,8 @@
 use crate::pg_connection::PgConnection;
 use std::collections::HashMap;
 
-/// Get a mutable reference to a named session, panicking with a clear message if not found.
+pub(crate) type ProtocolMessages = Vec<(char, Vec<u8>)>;
+
 pub(crate) fn get_session<'a>(
     named_sessions: &'a mut HashMap<String, PgConnection>,
     session_name: &str,
@@ -9,6 +10,184 @@ pub(crate) fn get_session<'a>(
     named_sessions
         .get_mut(session_name)
         .unwrap_or_else(|| panic!("Session '{}' not found", session_name))
+}
+
+pub(crate) fn single_char(value: &str, label: &str) -> char {
+    value
+        .chars()
+        .next()
+        .unwrap_or_else(|| panic!("{label} must not be empty"))
+}
+
+pub(crate) async fn send_parse_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+    name: &str,
+    query: &str,
+) {
+    pg_conn
+        .send_parse(name, query)
+        .await
+        .expect("Failed to send Parse to PostgreSQL");
+    doorman_conn
+        .send_parse(name, query)
+        .await
+        .expect("Failed to send Parse to pg_doorman");
+}
+
+pub(crate) async fn send_bind_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+    portal: &str,
+    statement: &str,
+    params: Vec<Option<Vec<u8>>>,
+) {
+    pg_conn
+        .send_bind(portal, statement, params.clone())
+        .await
+        .expect("Failed to send Bind to PostgreSQL");
+    doorman_conn
+        .send_bind(portal, statement, params)
+        .await
+        .expect("Failed to send Bind to pg_doorman");
+}
+
+pub(crate) async fn send_describe_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+    target_type: char,
+    name: &str,
+) {
+    pg_conn
+        .send_describe(target_type, name)
+        .await
+        .expect("Failed to send Describe to PostgreSQL");
+    doorman_conn
+        .send_describe(target_type, name)
+        .await
+        .expect("Failed to send Describe to pg_doorman");
+}
+
+pub(crate) async fn send_execute_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+    portal: &str,
+    max_rows: i32,
+) {
+    pg_conn
+        .send_execute(portal, max_rows)
+        .await
+        .expect("Failed to send Execute to PostgreSQL");
+    doorman_conn
+        .send_execute(portal, max_rows)
+        .await
+        .expect("Failed to send Execute to pg_doorman");
+}
+
+pub(crate) async fn send_close_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+    target_type: char,
+    name: &str,
+) {
+    pg_conn
+        .send_close(target_type, name)
+        .await
+        .expect("Failed to send Close to PostgreSQL");
+    doorman_conn
+        .send_close(target_type, name)
+        .await
+        .expect("Failed to send Close to pg_doorman");
+}
+
+pub(crate) async fn send_sync_to_both(pg_conn: &mut PgConnection, doorman_conn: &mut PgConnection) {
+    pg_conn
+        .send_sync()
+        .await
+        .expect("Failed to send Sync to PostgreSQL");
+    doorman_conn
+        .send_sync()
+        .await
+        .expect("Failed to send Sync to pg_doorman");
+}
+
+pub(crate) async fn send_flush_to_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+) {
+    pg_conn
+        .send_flush()
+        .await
+        .expect("Failed to send Flush to PostgreSQL");
+    doorman_conn
+        .send_flush()
+        .await
+        .expect("Failed to send Flush to pg_doorman");
+}
+
+pub(crate) async fn read_both_until_ready(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+) -> (ProtocolMessages, ProtocolMessages) {
+    let pg_messages = pg_conn
+        .read_all_messages_until_ready()
+        .await
+        .expect("Failed to read messages from PostgreSQL");
+    let doorman_messages = doorman_conn
+        .read_all_messages_until_ready()
+        .await
+        .expect("Failed to read messages from pg_doorman");
+
+    (pg_messages, doorman_messages)
+}
+
+pub(crate) async fn read_partial_from_both(
+    pg_conn: &mut PgConnection,
+    doorman_conn: &mut PgConnection,
+) -> (ProtocolMessages, ProtocolMessages) {
+    let pg_messages = pg_conn
+        .read_partial_messages()
+        .await
+        .expect("Failed to read partial messages from PostgreSQL");
+    let doorman_messages = doorman_conn
+        .read_partial_messages()
+        .await
+        .expect("Failed to read partial messages from pg_doorman");
+
+    (pg_messages, doorman_messages)
+}
+
+pub(crate) async fn send_simple_query_and_read_until_ready(
+    conn: &mut PgConnection,
+    query: &str,
+) -> ProtocolMessages {
+    conn.send_simple_query(query)
+        .await
+        .expect("Failed to send query");
+
+    conn.read_all_messages_until_ready()
+        .await
+        .expect("Failed to read messages")
+}
+
+pub(crate) async fn read_first_datarow_int_until_ready(conn: &mut PgConnection) -> Option<i32> {
+    let mut value = None;
+    loop {
+        let (msg_type, data) = conn.read_message().await.expect("Failed to read message");
+
+        match msg_type {
+            'D' => value = parse_first_datarow_int(&data),
+            'Z' => break,
+            'E' => {
+                eprintln!(
+                    "ErrorResponse while reading query result: {:?}",
+                    String::from_utf8_lossy(&data)
+                );
+            }
+            _ => {}
+        }
+    }
+    value
 }
 
 /// Parse the first field of a DataRow message as an integer.

--- a/tests/bdd/extended/session_management.rs
+++ b/tests/bdd/extended/session_management.rs
@@ -453,7 +453,6 @@ pub async fn create_named_session_to_postgres(
     let pg_port = world.pg_port.expect("PostgreSQL not started");
     let pg_addr = format!("127.0.0.1:{}", pg_port);
 
-    // Connect to PostgreSQL directly
     let mut conn = PgConnection::connect(&pg_addr)
         .await
         .expect("Failed to connect to PostgreSQL");
@@ -475,15 +474,7 @@ pub async fn send_simple_query_to_session(
 ) {
     let conn = super::helpers::get_session(&mut world.named_sessions, &session_name);
 
-    conn.send_simple_query(&query)
-        .await
-        .expect("Failed to send query");
-
-    // Read all messages until ReadyForQuery
-    let _messages = conn
-        .read_all_messages_until_ready()
-        .await
-        .expect("Failed to read messages");
+    let _messages = super::helpers::send_simple_query_and_read_until_ready(conn, &query).await;
 }
 
 #[when(regex = r#"^we send SimpleQuery "([^"]+)" to session "([^"]+)" and store backend_pid$"#)]
@@ -498,28 +489,7 @@ pub async fn send_simple_query_and_store_backend_pid(
         .await
         .expect("Failed to send query");
 
-    // Read messages and parse backend_pid
-    let mut backend_pid: Option<i32> = None;
-    loop {
-        let (msg_type, data) = conn.read_message().await.expect("Failed to read message");
-
-        match msg_type {
-            'T' => {
-                // RowDescription - skip
-            }
-            'D' => {
-                backend_pid = super::helpers::parse_first_datarow_int(&data);
-            }
-            'Z' => break,
-            'E' => {
-                eprintln!(
-                    "Error received (expected for bad sql): {:?}",
-                    String::from_utf8_lossy(&data)
-                );
-            }
-            _ => {}
-        }
-    }
+    let backend_pid = super::helpers::read_first_datarow_int_until_ready(conn).await;
 
     if let Some(pid) = backend_pid {
         world.session_backend_pids.insert(session_name, pid);
@@ -541,28 +511,7 @@ pub async fn send_simple_query_and_store_named_backend_pid(
         .await
         .expect("Failed to send query");
 
-    // Read messages and parse backend_pid
-    let mut backend_pid: Option<i32> = None;
-    loop {
-        let (msg_type, data) = conn.read_message().await.expect("Failed to read message");
-
-        match msg_type {
-            'T' => {
-                // RowDescription - skip
-            }
-            'D' => {
-                backend_pid = super::helpers::parse_first_datarow_int(&data);
-            }
-            'Z' => break,
-            'E' => {
-                eprintln!(
-                    "Error received (expected for bad sql): {:?}",
-                    String::from_utf8_lossy(&data)
-                );
-            }
-            _ => {}
-        }
-    }
+    let backend_pid = super::helpers::read_first_datarow_int_until_ready(conn).await;
 
     if let Some(pid) = backend_pid {
         world
@@ -572,13 +521,8 @@ pub async fn send_simple_query_and_store_named_backend_pid(
 }
 
 #[when(regex = r#"^we sleep (\d+)ms$"#)]
-pub async fn sleep_ms(_world: &mut DoormanWorld, ms: String) {
-    let duration = ms.parse::<u64>().expect("Invalid sleep duration");
-    tokio::time::sleep(tokio::time::Duration::from_millis(duration)).await;
-}
-
 #[when(regex = r#"^we sleep for (\d+) milliseconds$"#)]
-pub async fn sleep_for_milliseconds(_world: &mut DoormanWorld, ms: String) {
+pub async fn sleep_ms(_world: &mut DoormanWorld, ms: String) {
     let duration = ms.parse::<u64>().expect("Invalid sleep duration");
     tokio::time::sleep(tokio::time::Duration::from_millis(duration)).await;
 }
@@ -594,7 +538,6 @@ pub async fn send_simple_query_to_session_without_waiting(
     conn.send_simple_query(&query)
         .await
         .expect("Failed to send query");
-    // Don't wait for response - just send the query
 }
 
 #[when(
@@ -667,7 +610,6 @@ pub async fn send_simple_query_to_session_expecting_error(
         .await
         .expect("Failed to send query");
 
-    // Read all messages until ReadyForQuery or error and store them
     let messages = conn
         .read_all_messages_until_ready()
         .await
@@ -692,7 +634,6 @@ pub async fn send_simple_query_to_session_expecting_error_after_ready(
         .await
         .expect("Failed to send query");
 
-    // Read all messages until ReadyForQuery AND any additional messages after (like ErrorResponse)
     let messages = conn
         .read_all_messages_until_ready_and_more()
         .await
@@ -713,19 +654,14 @@ pub async fn send_simple_query_to_session_expecting_connection_close(
 ) {
     let conn = super::helpers::get_session(&mut world.named_sessions, &session_name);
 
-    // Try to send query - may fail if connection already closed
     if conn.send_simple_query(&query).await.is_err() {
-        // Connection already closed - this is expected
         return;
     }
 
-    // Try to read response - should fail with connection reset or return error
     match conn.read_all_messages_until_ready().await {
         Ok(messages) => {
-            // Check if we got an error response (pooler shutdown message)
             let has_error = messages.iter().any(|(msg_type, _)| *msg_type == 'E');
             if has_error {
-                // Store messages for potential further inspection
                 world
                     .session_messages
                     .insert(session_name.clone(), messages);
@@ -736,9 +672,7 @@ pub async fn send_simple_query_to_session_expecting_connection_close(
                 session_name
             );
         }
-        Err(_) => {
-            // Connection closed - this is expected
-        }
+        Err(_) => {}
     }
 }
 
@@ -808,7 +742,6 @@ pub async fn send_sync_to_session(world: &mut DoormanWorld, session_name: String
 
     conn.send_sync().await.expect("Failed to send Sync");
 
-    // Read all messages until ReadyForQuery and store them
     let messages = conn
         .read_all_messages_until_ready()
         .await
@@ -845,7 +778,6 @@ pub async fn abort_session_tcp_connection(world: &mut DoormanWorld, session_name
         .remove(&session_name)
         .unwrap_or_else(|| panic!("Session '{}' not found", session_name));
 
-    // Abruptly close the TCP connection
     conn.abort_connection().await;
 }
 
@@ -865,7 +797,6 @@ pub async fn session_should_receive_datarow(
     session_name: String,
     expected_value: String,
 ) {
-    // Get messages from the stored session messages
     let messages = world
         .session_messages
         .get(&session_name)
@@ -998,11 +929,9 @@ pub async fn session_should_receive_error_containing(
         .get(&session_name)
         .unwrap_or_else(|| panic!("No messages stored for session '{}'", session_name));
 
-    // Find ErrorResponse in the messages
     let mut found_error: Option<String> = None;
     for (msg_type, data) in messages {
         if *msg_type == 'E' {
-            // ErrorResponse - parse the error message
             let error_str = String::from_utf8_lossy(data).to_string();
             found_error = Some(error_str);
             break;
@@ -1036,17 +965,14 @@ pub async fn session_should_receive_error_containing_with_code(
     expected_text: String,
     expected_code: String,
 ) {
-    // Get messages from the stored session messages
     let messages = world
         .session_messages
         .get(&session_name)
         .unwrap_or_else(|| panic!("No messages stored for session '{}'", session_name));
 
-    // Find ErrorResponse in the messages
     let mut found_error: Option<(String, String)> = None;
     for (msg_type, data) in messages {
         if *msg_type == 'E' {
-            // ErrorResponse - parse the error message and code
             // Format: S<severity>\0 V<severity>\0 C<code>\0 M<message>\0 ... \0
             let mut code = String::new();
             let mut message = String::new();
@@ -1109,15 +1035,12 @@ pub async fn send_copy_from_stdin_to_session_expecting_error(
 ) {
     let conn = super::helpers::get_session(&mut world.named_sessions, &session_name);
 
-    // Unescape the data string (handle \t and \n)
     let unescaped_data = data.replace("\\t", "\t").replace("\\n", "\n");
 
-    // Send the COPY command via simple query
     conn.send_simple_query(&query)
         .await
         .expect("Failed to send COPY query");
 
-    // Read initial response (should be CopyInResponse 'G' or ErrorResponse 'E')
     let (msg_type, msg_data) = conn
         .read_message()
         .await
@@ -1125,9 +1048,7 @@ pub async fn send_copy_from_stdin_to_session_expecting_error(
 
     let mut messages: Vec<(char, Vec<u8>)> = Vec::new();
 
-    // If we got CopyInResponse ('G'), send the data and CopyDone
     if msg_type == 'G' {
-        // Send copy data
         if !unescaped_data.is_empty() {
             conn.send_copy_data(unescaped_data.as_bytes())
                 .await
@@ -1137,11 +1058,9 @@ pub async fn send_copy_from_stdin_to_session_expecting_error(
             .await
             .expect("Failed to send CopyDone");
     } else {
-        // Error response - store it
         messages.push((msg_type, msg_data));
     }
 
-    // Read remaining messages until ReadyForQuery
     let remaining = conn
         .read_all_messages_until_ready()
         .await

--- a/tests/bdd/main.rs
+++ b/tests/bdd/main.rs
@@ -23,7 +23,6 @@ use cucumber::World;
 use world::DoormanWorld;
 
 fn main() {
-    // Initialize tracing subscriber for debug logging when DEBUG env var is set
     if std::env::var("DEBUG").is_ok() {
         tracing_subscriber::fmt()
             .with_max_level(tracing::Level::DEBUG)
@@ -33,17 +32,13 @@ fn main() {
             .init();
     }
 
-    // Create tokio runtime manually so we can control cleanup
-    // Use 4 worker threads explicitly for consistent benchmark results
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
         .build()
         .unwrap();
 
-    // Run tests with after hook for cleanup
     rt.block_on(async {
-        // Parse CLI options and add todo-skip filter
         use cucumber::gherkin::tagexpr::TagOperation;
         let mut cli = cucumber::cli::Opts::<
             cucumber::parser::basic::Cli,
@@ -52,7 +47,6 @@ fn main() {
             cucumber::cli::Empty,
         >::parsed();
 
-        // Create "not @todo-skip" filter
         let not_todo_skip = TagOperation::Not(Box::new(TagOperation::Tag("todo-skip".to_string())));
 
         // On non-Linux platforms, also skip @linux-only scenarios
@@ -78,7 +72,6 @@ fn main() {
             .with_cli(cli)
             .before(|feature, _rule, scenario, world| {
                 Box::pin(async move {
-                    // Skip timeout for @bench scenarios - they run long benchmarks
                     let is_bench = feature.tags.iter().any(|t| t == "bench")
                         || scenario.tags.iter().any(|t| t == "bench");
                     if is_bench {
@@ -90,8 +83,6 @@ fn main() {
                         return;
                     }
 
-                    // Spawn a periodic warning task for slow scenarios
-                    // Prints every 60 seconds while test is running, aborted when scenario finishes
                     let scenario_name = scenario.name.clone();
                     let feature_name = feature.name.clone();
                     let slow_warning_task = tokio::spawn(async move {
@@ -111,12 +102,9 @@ fn main() {
                 })
             })
             .after(|_feature, _rule, _scenario, _finished, world| {
-                // This hook is called after EVERY scenario, regardless of success/failure
-                // Cleanup pg_doorman process if it exists
                 // NOTE: We only stop the specific process from this scenario, NOT all pg_doorman processes
                 // because the next scenario's Background steps may have already started a new pg_doorman
                 if let Some(w) = world {
-                    // Cancel the slow warning task since scenario has finished
                     if let Some(abort_handle) = w.slow_warning_abort.take() {
                         abort_handle.abort();
                     }
@@ -126,8 +114,7 @@ fn main() {
                     }
                     w.doorman_process = None;
 
-                    // Stop daemon process if running (for daemon mode tests)
-                    // Read PID from file to handle binary-upgrade where PID changes
+                    // Binary-upgrade daemon tests may replace the original PID.
                     if let Some(ref pid_path) = w.doorman_daemon_pid_file {
                         if let Ok(pid_content) = std::fs::read_to_string(pid_path) {
                             if let Ok(pid) = pid_content.trim().parse::<u32>() {
@@ -152,7 +139,6 @@ fn main() {
             .run("tests/bdd/features")
             .await;
 
-        // Check if execution failed or if there are skipped tests
         use cucumber::writer::Stats;
         let has_failures = writer.execution_has_failed();
         let skipped = writer.skipped_steps();


### PR DESCRIPTION
## Summary
- extract shared protocol helpers for BDD extended-query steps
- keep existing Cucumber step regex wrappers while reducing duplicated send/read logic
- remove low-value narrating comments and rewrite the foreground upgrade check as a present-tense contract

## Tests
- cargo fmt --check
- git diff --check
- cargo test --test bdd --no-run
- make test-bdd TAGS=@async-protocol