### PR TITLE
Chore: trim stale comments

### DIFF
--- a/benches/coordinator_benchmarks.rs
+++ b/benches/coordinator_benchmarks.rs
@@ -253,8 +253,7 @@ fn pool_checkout_without_coordinator(c: &mut Criterion) {
 /// Isolated cost of `PoolCoordinator::notify_idle_returned` — a single
 /// `tokio::sync::Notify::notify_one()` call behind an `Arc` deref. This is
 /// the full overhead added to `Pool::return_object` when the pool has a
-/// coordinator and the fix for Phase C reactivity to peer idle returns is
-/// active. Bench target: ~10-20 ns, small enough to be invisible on the
+/// coordinator. Bench target: ~10-20 ns, small enough to be invisible on the
 /// return_object hot path.
 fn notify_idle_returned_standalone(c: &mut Criterion) {
     let rt = runtime();
@@ -273,11 +272,11 @@ fn notify_idle_returned_standalone(c: &mut Criterion) {
     group.finish();
 }
 
-/// Simulates `Pool::return_object` with and without the coordinator notify
-/// the fix introduces. Both variants do the same VecDeque push and semaphore
-/// add_permits; the "with_coordinator_notify" variant additionally calls
-/// `coordinator.notify_idle_returned()` the way `return_object` does now.
-/// The delta between them is the added hot-path cost of the fix.
+/// Simulates `Pool::return_object` with and without the coordinator notify.
+/// Both variants do the same VecDeque push and semaphore add_permits; the
+/// "with_coordinator_notify" variant additionally calls
+/// `coordinator.notify_idle_returned()`. The delta between them is the
+/// added hot-path cost.
 fn return_object_with_coordinator_notify(c: &mut Criterion) {
     use std::collections::VecDeque;
 
@@ -300,8 +299,8 @@ fn return_object_with_coordinator_notify(c: &mut Criterion) {
         });
     });
 
-    // With the fix: after push + add_permits, notify the coordinator so
-    // Phase C waiters can opportunistically retry eviction.
+    // With coordinator notify: after push + add_permits, notify Phase C
+    // waiters so they can opportunistically retry eviction.
     group.bench_function("with_coordinator_notify", |b| {
         let sem = Arc::new(Semaphore::new(10));
         let slots = Arc::new(parking_lot::Mutex::new(VecDeque::from([1u64, 2, 3, 4, 5])));

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,8 @@
 // changes. Without this hint, cargo only watches the regular source
 // tree; a frontend rebuild that produces a new `frontend/dist/...js`
 // would be silently ignored and the resulting binary would still embed
-// the previous bundle. Hits docker pipelines hard — they share `target/`
-// across builds and the COPY layer is too late to invalidate cargo.
+// the previous bundle. Docker builds share `target/`, so the COPY layer
+// alone is too late to invalidate cargo.
 
 use std::fs;
 use std::path::Path;

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -1,7 +1,5 @@
 //! Errors.
 
-// Standard library imports
-
 use crate::auth::hba::CheckResult;
 
 /// Various errors.

--- a/src/app/generate/tests.rs
+++ b/src/app/generate/tests.rs
@@ -139,17 +139,14 @@ fn test_generate_config_with_default_parameters() {
         Ok(databases),
     );
 
-    // Verify the result
     assert!(result.is_ok());
 
     let config_result = result.unwrap();
 
-    // Verify the configuration has the expected values
     assert_eq!(config_result.general.host, "localhost");
     assert_eq!(config_result.general.port, 6432);
     assert_eq!(config_result.general.server_tls_mode, "allow");
 
-    // Verify the pools
     assert_eq!(config_result.pools.len(), 2);
     assert!(config_result.pools.contains_key("postgres"));
     assert!(config_result.pools.contains_key("testdb"));
@@ -207,17 +204,14 @@ fn test_generate_config_with_custom_parameters() {
         Ok(databases),
     );
 
-    // Verify the result
     assert!(result.is_ok());
 
     let config_result = result.unwrap();
 
-    // Verify the configuration has the expected values
     assert_eq!(config_result.general.host, "testhost");
     assert_eq!(config_result.general.port, 6432);
     assert_eq!(config_result.general.server_tls_mode, "allow");
 
-    // Verify the pools
     assert_eq!(config_result.pools.len(), 2);
 
     // Verify the pool mode is Session as specified
@@ -271,12 +265,10 @@ fn test_generate_config_with_ssl_enabled() {
         Ok(databases),
     );
 
-    // Verify the result
     assert!(result.is_ok());
 
     let config_result = result.unwrap();
 
-    // Verify SSL is enabled
     assert_eq!(config_result.general.server_tls_mode, "require");
 }
 
@@ -324,6 +316,5 @@ fn test_generate_config_with_database_error() {
         Ok(databases),
     );
 
-    // Verify the result is an error
     assert!(result.is_err());
 }

--- a/src/app/logger.rs
+++ b/src/app/logger.rs
@@ -220,9 +220,8 @@ mod tests {
 
     #[test]
     fn color_off_when_stderr_is_not_a_tty() {
-        // The fix this guard exists for: under systemd the journal
-        // pipe is not a terminal, so default colour-on used to leak
-        // ANSI escapes into journalctl as `[NNN blob data]`.
+        // systemd journal pipes are not terminals; default colour output
+        // would appear in journalctl as `[NNN blob data]`.
         assert!(!resolve_color(false, false, false));
     }
 }

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -1652,9 +1652,8 @@ fn create_unix_listener(
 /// Prepare a Unix socket path for bind() by clearing any stale file without
 /// clobbering a live peer.
 ///
-/// The previous implementation called `remove_file` unconditionally, which
-/// meant pointing pg_doorman at a shared directory like `/var/run/postgresql`
-/// could silently delete another process's live socket. This helper instead:
+/// Shared directories like `/var/run/postgresql` may contain another process's
+/// live socket. This helper:
 ///
 /// 1. Returns Ok if nothing exists at the path.
 /// 2. Attempts a connect — if it succeeds, a live peer owns the socket and

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -1,10 +1,8 @@
-// Standard library imports
 use std::collections::HashMap;
 use std::fs;
 use std::ops::Add;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-// External crate imports
 use jwt::{Header, PKeyWithDigest, RegisteredClaims, SignWithKey, Token, VerifyWithKey};
 use once_cell::sync::Lazy;
 use openssl::hash::MessageDigest;
@@ -13,7 +11,6 @@ use openssl::rsa::Rsa;
 use serde_derive::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-// Internal crate imports
 use crate::errors::Error;
 
 #[allow(dead_code)]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -8,16 +8,14 @@ pub mod scram;
 pub mod scram_client;
 pub mod talos;
 
-// Standard library imports
 use std::marker::Unpin;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-// External crate imports
 use crate::auth::hba::CheckResult;
 use log::{error, info, warn};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-// Internal crate imports
+
 use crate::auth::jwt::get_user_name_from_jwt;
 use crate::auth::pam::pam_auth;
 use crate::auth::scram::{

--- a/src/auth/pam.rs
+++ b/src/auth/pam.rs
@@ -1,13 +1,9 @@
-// Standard library imports
-
-// External crate imports
 use log::error;
 #[cfg(all(target_os = "linux", feature = "pam"))]
 use pam_client::conv_mock::Conversation;
 #[cfg(all(target_os = "linux", feature = "pam"))]
 use pam_client::{Context, Flag};
 
-// Internal crate imports
 use crate::errors::Error;
 
 /// Helper function to log an error message and return an AuthError

--- a/src/auth/talos.rs
+++ b/src/auth/talos.rs
@@ -158,14 +158,8 @@ struct KidFromJSON {
     #[serde(rename = "kid")]
     kid: String,
 }
-/// Extracts the key identifier (kid) from the JWT token header
-///
-/// A JWT token consists of three parts separated by dots: header.payload.signature
-/// This function parses the header to get the kid (key ID), which is used
-/// to select the correct public key for token verification
+/// Extracts the key identifier from the JWT header.
 fn get_key_from_token(access_token: &str) -> Result<String, Error> {
-    // JWT token has the format: header.payload.signature
-    // We only need the header (first part before the dot)
     let header_part = access_token.split('.').next().ok_or_else(|| {
         Error::JWTValidate("JWT token must contain at least one dot separator".to_string())
     })?;
@@ -502,10 +496,6 @@ mod tests {
         let result =
             extract_talos_token("invalid_token".to_string(), vec!["db1".to_string()]).await;
         assert!(result.is_err(), "Expected error with invalid token");
-
-        // For a more complete test, we would need to mock the extract_talos_token_with_key function
-        // since we can't easily create a valid token with the correct structure in a test
-        // This would require refactoring the code to make it more testable
     }
 
     #[tokio::test]

--- a/src/bin/patroni_proxy/cluster_manager.rs
+++ b/src/bin/patroni_proxy/cluster_manager.rs
@@ -157,12 +157,9 @@ pub async fn handle_config_changes(
                 }
             }
             ClusterDiff::HostsChanged(name, _old, new) => {
-                // Update hosts for existing cluster
                 let managers = cluster_managers.read().await;
                 if managers.contains_key(name) {
-                    // Update hosts in the manager
-                    // Note: We need to update the hosts field, but it's not mutable
-                    // For now, we just log a warning that restart is needed
+                    // Host changes require rebuilding the cluster manager.
                     warn!(
                         "Cluster '{}' hosts changed to {:?}. Full restart required for this change to take effect.",
                         name, new

--- a/src/config/address.rs
+++ b/src/config/address.rs
@@ -99,7 +99,7 @@ impl std::fmt::Display for Address {
     }
 }
 
-// We need to implement PartialEq by ourselves so we skip stats in the comparison
+// Address identity excludes runtime stats.
 impl PartialEq for Address {
     fn eq(&self, other: &Self) -> bool {
         self.host == other.host
@@ -111,7 +111,7 @@ impl PartialEq for Address {
 }
 impl Eq for Address {}
 
-// We need to implement Hash by ourselves so we skip stats in the comparison
+// Keep hashing aligned with PartialEq.
 impl Hash for Address {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.host.hash(state);

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -90,9 +90,6 @@ async fn test_serialize_configs() {
     print!("{}", toml::to_string(&get_config()).unwrap());
 }
 
-// Tests for the validate function
-
-// Test valid configuration
 #[tokio::test]
 async fn test_validate_valid_config() {
     let mut config = Config::default();
@@ -115,12 +112,10 @@ async fn test_validate_valid_config() {
     config.general.prepared_statements = true;
     config.general.prepared_statements_cache_size = 1024;
 
-    // Validate should pass
     let result = config.validate().await;
     assert!(result.is_ok());
 }
 
-// Test TLS rate limit less than 100 (but not 0)
 #[tokio::test]
 async fn test_validate_tls_rate_limit_less_than_100() {
     let mut config = Config::default();
@@ -1407,7 +1402,6 @@ fn test_scaling_config_changes_pool_hash() {
     assert_ne!(pool_a.hash_value(), pool_b.hash_value());
 }
 
-/// Test 9: TOML backward compatibility
 #[tokio::test]
 #[serial]
 async fn test_scaling_config_toml_parsing() {

--- a/src/messages/config_socket.rs
+++ b/src/messages/config_socket.rs
@@ -1,12 +1,9 @@
-// Standard library imports
 use std::time::Duration;
 
-// External crate imports
 use log::{debug, error, log_enabled, Level};
 use socket2::{SockRef, TcpKeepalive};
 use tokio::net::{TcpStream, UnixStream};
 
-// Internal crate imports
 use crate::config::{get_config, Config};
 
 /// Configure Unix socket parameters.

--- a/src/messages/error.rs
+++ b/src/messages/error.rs
@@ -1,8 +1,6 @@
-// Standard library imports
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-// Internal crate imports
 use crate::errors::Error;
 
 /// PostgreSQL error message structure.

--- a/src/messages/extended.rs
+++ b/src/messages/extended.rs
@@ -1,4 +1,3 @@
-// Standard library imports
 use std::collections::hash_map::DefaultHasher;
 use std::ffi::CString;
 use std::hash::Hasher;
@@ -6,11 +5,10 @@ use std::mem;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-// External crate imports
 use bytes::{Buf, BufMut, BytesMut};
 use xxhash_rust::xxh3::Xxh3;
 use zerocopy::IntoBytes;
-// Internal crate imports
+
 use crate::client::PREPARED_STATEMENT_COUNTER;
 use crate::errors::Error;
 use crate::messages::types::BytesMutReader;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,13 +1,10 @@
 // Helper functions to send one-off protocol messages and handle TcpStream (TCP socket).
 
-// Standard library imports
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
-// External crate imports
 use once_cell::sync::Lazy;
 
-// Declare submodules
 pub mod config_socket;
 pub mod constants;
 pub mod error;
@@ -16,7 +13,6 @@ pub mod protocol;
 pub mod socket;
 pub mod types;
 
-// Re-export public items
 pub use config_socket::{configure_tcp_socket, configure_unix_socket, configure_web_tcp_socket};
 pub use error::PgErrorMsg;
 pub use extended::{close_complete, Bind, Close, Describe, ExtendedProtocolData, Parse};
@@ -38,16 +34,12 @@ pub use socket::{
 };
 pub use types::{vec_to_string, BytesMutReader, DataType};
 
-// Re-export protocol constants
 pub use constants::*;
 
-// Constants
 pub const MAX_MESSAGE_SIZE: i32 = 256 * 1024 * 1024;
 
-// Global state
 pub static CURRENT_MEMORY: Lazy<Arc<AtomicI64>> = Lazy::new(|| Arc::new(AtomicI64::new(0)));
 
-// Tests
 #[cfg(test)]
 mod protocol_tests;
 #[cfg(test)]

--- a/src/messages/protocol.rs
+++ b/src/messages/protocol.rs
@@ -1,11 +1,10 @@
-// Standard library imports
 use std::collections::HashMap;
-// External crate imports
+
 use crate::messages::constants::SCRAM_SHA_256;
 use bytes::{Buf, BufMut, BytesMut};
 use md5::{Digest, Md5};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-// Internal crate imports
+
 use crate::config::startup_parameters::full_packet_bytes;
 use crate::errors::Error;
 use crate::messages::socket::{write_all, write_all_flush};

--- a/src/messages/socket.rs
+++ b/src/messages/socket.rs
@@ -1,12 +1,9 @@
-// Standard library imports
 use std::sync::atomic::Ordering;
 
-// External crate imports
 use bytes::{BufMut, BytesMut};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 
-// Internal crate imports
 use crate::errors::Error;
 use crate::errors::Error::ProxyTimeout;
 use crate::messages::{CURRENT_MEMORY, MAX_MESSAGE_SIZE};

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1,17 +1,11 @@
-// Tests for the messages module
-// This file contains tests for the various message handling functions
-
-// Standard library imports
 use std::io::{Error as IoError, ErrorKind};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Wake};
 
-// External crate imports
 use bytes::{BufMut, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-// Internal crate imports
 use crate::errors::Error;
 use crate::messages::protocol::row_description;
 use crate::messages::{
@@ -19,7 +13,6 @@ use crate::messages::{
     PgErrorMsg,
 };
 
-// Mock implementation for AsyncReadExt
 #[allow(dead_code)]
 struct MockReader {
     data: Vec<Vec<u8>>,
@@ -45,7 +38,6 @@ impl AsyncRead for MockReader {
     }
 }
 
-// Mock implementation for AsyncWriteExt
 #[allow(dead_code)]
 struct MockWriter {
     written: Arc<Mutex<Vec<Vec<u8>>>>,
@@ -70,34 +62,26 @@ impl AsyncWrite for MockWriter {
     }
 }
 
-// Helper function to run async tests
 #[allow(dead_code)]
 struct MockWaker;
 impl Wake for MockWaker {
     fn wake(self: Arc<Self>) {}
 }
 
-// Tests for parse_startup function
 #[test]
 fn test_parse_startup_success() {
-    // Create a test BytesMut with parameters including "user"
     let mut bytes = BytesMut::new();
 
-    // Add required "user" parameter
     bytes.put_slice(b"user\0testuser\0");
-    // Add optional parameters
     bytes.put_slice(b"database\0testdb\0");
     bytes.put_slice(b"application_name\0testapp\0");
     bytes.put_u8(0); // Final null terminator
 
-    // Call the function being tested
     let result = parse_startup(bytes);
 
-    // Verify the result
     assert!(result.is_ok());
     let params = result.as_ref().unwrap();
 
-    // Verify parameters
     assert_eq!(params.len(), 3);
     assert_eq!(params.get("user"), Some(&"testuser".to_string()));
     assert_eq!(params.get("database"), Some(&"testdb".to_string()));
@@ -106,38 +90,29 @@ fn test_parse_startup_success() {
 
 #[test]
 fn test_parse_startup_missing_user() {
-    // Create a test BytesMut without the required "user" parameter
     let mut bytes = BytesMut::new();
 
-    // Add some parameters but not "user"
     bytes.put_slice(b"database\0testdb\0");
     bytes.put_slice(b"application_name\0testapp\0");
     bytes.put_u8(0); // Final null terminator
 
-    // Call the function being tested
     let result = parse_startup(bytes);
 
-    // Verify the result is an error
     assert!(result.is_err());
     match result {
-        Err(Error::ClientBadStartup) => {} // Expected error
+        Err(Error::ClientBadStartup) => {}
         _ => panic!("Expected ClientBadStartup error"),
     }
 }
 
-// Tests for error_message function
 #[test]
 fn test_error_message_detailed() {
-    // Call the function being tested
     let result = error_message("Test error message", "28000");
 
-    // Verify the result
     assert!(!result.is_empty());
 
-    // Check message type is 'E' (Error)
     assert_eq!(result[0], b'E');
 
-    // Check message contains our error message and code
     let message_bytes = &result[5..];
     let message_str = String::from_utf8_lossy(message_bytes);
 
@@ -146,74 +121,54 @@ fn test_error_message_detailed() {
     assert!(message_str.contains("FATAL"));
 }
 
-// Tests for row_description function with columns
 #[test]
 fn test_row_description_with_columns() {
-    // Create test columns
     let columns = vec![
         ("id", DataType::Int4),
         ("name", DataType::Text),
         ("active", DataType::Bool),
     ];
 
-    // Call the function being tested
     let result = row_description(&columns);
 
-    // Verify the result
     assert!(!result.is_empty());
 
-    // Check message type is 'T' (Row Description)
     assert_eq!(result[0], b'T');
 
-    // Check the number of columns (should be 3)
     let column_count_bytes = &result[5..7];
     let column_count = i16::from_be_bytes([column_count_bytes[0], column_count_bytes[1]]);
     assert_eq!(column_count, 3);
 }
 
-// Tests for data_row function
 #[test]
 fn test_data_row_with_values() {
-    // Create test row data
     let row = vec!["1".to_string(), "Test Name".to_string(), "true".to_string()];
 
-    // Call the function being tested
     let result = data_row(&row);
 
-    // Verify the result
     assert!(!result.is_empty());
 
-    // Check message type is 'D' (Data Row)
     assert_eq!(result[0], b'D');
 
-    // Check the number of columns (should be 3)
     let column_count_bytes = &result[5..7];
     let column_count = i16::from_be_bytes([column_count_bytes[0], column_count_bytes[1]]);
     assert_eq!(column_count, 3);
 }
 
-// Tests for data_row_nullable function
 #[test]
 fn test_data_row_nullable_with_nulls() {
-    // Create test row data with some null values
     let row = vec![Some("1".to_string()), None, Some("true".to_string())];
 
-    // Call the function being tested
     let result = data_row_nullable(&row);
 
-    // Verify the result
     assert!(!result.is_empty());
 
-    // Check message type is 'D' (Data Row)
     assert_eq!(result[0], b'D');
 
-    // Check the number of columns (should be 3)
     let column_count_bytes = &result[5..7];
     let column_count = i16::from_be_bytes([column_count_bytes[0], column_count_bytes[1]]);
     assert_eq!(column_count, 3);
 
-    // The second value should be null (-1 length)
-    // First find the position after the first value
     let mut pos = 7; // Start after column count
     let first_len_bytes = &result[pos..pos + 4];
     let first_len = i32::from_be_bytes([
@@ -224,7 +179,6 @@ fn test_data_row_nullable_with_nulls() {
     ]);
     pos += 4 + first_len as usize;
 
-    // Now check the second value's length (should be -1 for NULL)
     let second_len_bytes = &result[pos..pos + 4];
     let second_len = i32::from_be_bytes([
         second_len_bytes[0],
@@ -235,40 +189,29 @@ fn test_data_row_nullable_with_nulls() {
     assert_eq!(second_len, -1);
 }
 
-// Tests for ready_for_query function
 #[test]
 fn test_ready_for_query_states() {
-    // Test with in_transaction = false
     let result_idle = ready_for_query(false);
 
-    // Verify the result
     assert_eq!(result_idle.len(), 6);
 
-    // Check message type is 'Z' (Ready For Query)
     assert_eq!(result_idle[0], b'Z');
 
-    // Check transaction status is 'I' (Idle)
     assert_eq!(result_idle[5], b'I');
 
-    // Test with in_transaction = true
     let result_transaction = ready_for_query(true);
 
-    // Verify the result
     assert_eq!(result_transaction.len(), 6);
 
-    // Check message type is 'Z' (Ready For Query)
     assert_eq!(result_transaction[0], b'Z');
 
-    // Check transaction status is 'T' (In Transaction)
     assert_eq!(result_transaction[5], b'T');
 }
 
-// Helper function for PgErrorMsg tests
 fn field(kind: char, content: &str) -> Vec<u8> {
     format!("{kind}{content}\0").as_bytes().to_vec()
 }
 
-// Tests for PgErrorMsg parsing
 #[test]
 fn test_pg_error_msg_parsing() {
     let mut complete_msg = vec![];

--- a/src/messages/types.rs
+++ b/src/messages/types.rs
@@ -1,10 +1,7 @@
-// Standard library imports
 use std::io::{BufRead, Cursor};
 
-// External crate imports
 use bytes::BytesMut;
 
-// Internal crate imports
 use crate::errors::Error;
 
 /// Postgres data type mappings

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1040,7 +1040,6 @@ impl ConnectionPool {
         parse: &Parse,
         client_given_name: Option<&str>,
     ) -> Option<Arc<Parse>> {
-        // We should only be calling this function if the cache is enabled
         self.prepared_statement_cache
             .as_ref()
             .map(|cache| cache.get_or_insert(parse, hash, client_given_name))
@@ -1049,7 +1048,6 @@ impl ConnectionPool {
     /// Promote a prepared statement hash in the LRU
     #[inline(always)]
     pub fn promote_prepared_statement_hash(&self, hash: &u64) {
-        // We should only be calling this function if the cache is enabled
         if let Some(ref prepared_statement_cache) = self.prepared_statement_cache {
             prepared_statement_cache.promote(hash);
         }

--- a/src/server/prepared_statements.rs
+++ b/src/server/prepared_statements.rs
@@ -70,7 +70,6 @@ mod tests {
         Arc::new(ServerStats::default())
     }
 
-    /// After fix: has() now uses get() which DOES promote entries.
     /// Checking a statement moves it to MRU, protecting it from eviction.
     #[test]
     fn test_has_promotes_in_lru() {
@@ -81,7 +80,7 @@ mod tests {
         assert!(add_to_cache(&mut cache, &stats, "DOORMAN_1").is_none());
         assert!(add_to_cache(&mut cache, &stats, "DOORMAN_2").is_none());
 
-        // has(A) now promotes A → LRU order: [B, A]
+        // has(A) promotes A → LRU order: [B, A]
         assert!(has(&mut cache, &stats, "DOORMAN_1"));
 
         // Add C → evicts B (LRU), NOT A
@@ -113,7 +112,7 @@ mod tests {
         );
     }
 
-    /// After fix: the batch scenario works because has() promotes A.
+    /// Batch lookup keeps A hot until C evicts the older B entry.
     /// Parse(A) → has(A) promotes → Bind(A) → has(A) promotes →
     /// Parse(C) → add_to_cache(C) → evicts B (not A).
     #[test]

--- a/src/server/protocol_io.rs
+++ b/src/server/protocol_io.rs
@@ -70,12 +70,7 @@ const COMMAND_COMPLETE_BY_DISCARD_ALL: &[u8; 12] = b"DISCARD ALL\0";
 /// When the buffer reaches this size, it will be flushed to avoid excessive memory usage.
 const BUFFER_FLUSH_THRESHOLD: usize = 8192;
 
-// ============================================================================
-// Public API functions
-// ============================================================================
-
-/// Sends messages to the server and flushes the write buffer with a timeout.
-/// Returns an error if the operation doesn't complete within the specified duration.
+/// Flushes messages within `duration`; timeout marks the server bad.
 pub(crate) async fn send_and_flush_timeout(
     server: &mut Server,
     messages: &BytesMut,
@@ -96,9 +91,7 @@ pub(crate) async fn send_and_flush_timeout(
     }
 }
 
-/// Sends messages to the server and flushes the write buffer immediately.
-/// Updates statistics and last activity timestamp on success.
-/// Marks the connection as bad and logs an error on failure.
+/// Flushes messages and records write stats/activity.
 pub(crate) async fn send_and_flush(server: &mut Server, messages: &BytesMut) -> Result<(), Error> {
     server.stats.data_sent(messages.len());
     server.stats.wait_writing();

--- a/src/server/server_backend.rs
+++ b/src/server/server_backend.rs
@@ -1,19 +1,16 @@
 // Implementation of the PostgreSQL server (database) protocol.
 
-// Standard library imports
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::string::ToString;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
-// External crate imports
 use bytes::{Buf, BufMut, BytesMut};
 use log::{error, info, warn};
 use lru::LruCache;
 use tokio::io::{AsyncReadExt, BufStream};
 
-// Internal crate imports
 use crate::auth::scram_client::ScramSha256;
 use crate::config::{get_config, tls, Address, BackendAuthMethod, User};
 use crate::errors::{Error, ServerIdentifier};
@@ -365,8 +362,6 @@ impl Server {
         self.async_mode
     }
 
-    /// Sends messages to the server and flushes the write buffer with a timeout.
-    /// Returns an error if the operation doesn't complete within the specified duration.
     pub async fn send_and_flush_timeout(
         &mut self,
         messages: &BytesMut,
@@ -375,8 +370,6 @@ impl Server {
         protocol_io::send_and_flush_timeout(self, messages, duration).await
     }
 
-    /// Sends messages to the server and flushes the write buffer immediately.
-    /// This ensures all data is transmitted to the server without delay.
     pub async fn send_and_flush(&mut self, messages: &BytesMut) -> Result<(), Error> {
         protocol_io::send_and_flush(self, messages).await
     }

--- a/src/stats/address.rs
+++ b/src/stats/address.rs
@@ -145,10 +145,7 @@ impl Default for AddressStats {
     }
 }
 
-/// Implementation of IntoIterator for AddressStats to convert statistics into name-value pairs.
-///
-/// This allows the statistics to be easily formatted for reporting or display purposes.
-/// The values are converted to f64 for consistent representation.
+/// Converts address statistics into name-value pairs for reporting.
 impl IntoIterator for &AddressStats {
     type Item = (String, f64);
     type IntoIter = std::vec::IntoIter<Self::Item>;
@@ -490,18 +487,15 @@ impl AddressStats {
         self.update_wait_and_error_averages(stat_period_per_second);
     }
 
-    /// Helper method to update transaction-related averages
     fn update_transaction_averages(&self, stat_period_per_second: u64) {
         let current_xact_count = self.current.xact_count.load(Ordering::Relaxed);
         let current_xact_time = self.current.xact_time_microseconds.load(Ordering::Relaxed);
 
-        // Calculate transactions per second
         self.averages.xact_count.store(
             current_xact_count / stat_period_per_second,
             Ordering::Relaxed,
         );
 
-        // Calculate average time per transaction (or 0 if no transactions)
         if current_xact_count == 0 {
             self.averages
                 .xact_time_microseconds
@@ -513,18 +507,15 @@ impl AddressStats {
         }
     }
 
-    /// Helper method to update query-related averages
     fn update_query_averages(&self, stat_period_per_second: u64) {
         let current_query_count = self.current.query_count.load(Ordering::Relaxed);
         let current_query_time = self.current.query_time_microseconds.load(Ordering::Relaxed);
 
-        // Calculate queries per second
         self.averages.query_count.store(
             current_query_count / stat_period_per_second,
             Ordering::Relaxed,
         );
 
-        // Calculate average time per query (or 0 if no queries)
         if current_query_count == 0 {
             self.averages
                 .query_time_microseconds
@@ -536,16 +527,13 @@ impl AddressStats {
         }
     }
 
-    /// Helper method to update throughput averages
     fn update_throughput_averages(&self, stat_period_per_second: u64) {
-        // Calculate bytes received per second
         let current_bytes_received = self.current.bytes_received.load(Ordering::Relaxed);
         self.averages.bytes_received.store(
             current_bytes_received / stat_period_per_second,
             Ordering::Relaxed,
         );
 
-        // Calculate bytes sent per second
         let current_bytes_sent = self.current.bytes_sent.load(Ordering::Relaxed);
         self.averages.bytes_sent.store(
             current_bytes_sent / stat_period_per_second,
@@ -553,16 +541,13 @@ impl AddressStats {
         );
     }
 
-    /// Helper method to update wait time and error averages
     fn update_wait_and_error_averages(&self, stat_period_per_second: u64) {
-        // Calculate average wait time per second
         let current_wait_time = self.current.wait_time.load(Ordering::Relaxed);
         self.averages.wait_time.store(
             current_wait_time / stat_period_per_second,
             Ordering::Relaxed,
         );
 
-        // Calculate errors per second
         let current_errors = self.current.errors.load(Ordering::Relaxed);
         self.averages
             .errors

--- a/src/stats/address.rs
+++ b/src/stats/address.rs
@@ -587,7 +587,6 @@ impl AddressStats {
     ///
     /// * `row` - A mutable reference to a vector of strings that will be populated with statistics
     pub fn populate_row(&self, row: &mut Vec<String>) {
-        // Convert all statistics to strings and add them to the row
         for (_key, value) in self {
             row.push(value.to_string());
         }
@@ -604,7 +603,6 @@ mod tests {
 
     #[test]
     fn test_address_stat_fields_default() {
-        // Test that AddressStatFields initializes with all zeros
         let fields = AddressStatFields::default();
 
         assert_eq!(fields.xact_count.load(Ordering::Relaxed), 0);
@@ -619,24 +617,18 @@ mod tests {
 
     #[test]
     fn test_address_stats_default() {
-        // Test that AddressStats initializes with all zeros
         let stats = AddressStats::default();
 
-        // Check total fields
         assert_eq!(stats.total.xact_count.load(Ordering::Relaxed), 0);
         assert_eq!(stats.total.query_count.load(Ordering::Relaxed), 0);
 
-        // Check current fields
         assert_eq!(stats.current.xact_count.load(Ordering::Relaxed), 0);
         assert_eq!(stats.current.query_count.load(Ordering::Relaxed), 0);
 
-        // Check averages fields
         assert_eq!(stats.averages.xact_count.load(Ordering::Relaxed), 0);
         assert_eq!(stats.averages.query_count.load(Ordering::Relaxed), 0);
 
-        // Check other fields
         assert!(!stats.averages_updated.load(Ordering::Relaxed));
-        // Check histograms are empty (len() == 0)
         assert_eq!(stats.xact_histogram.lock().len(), 0);
         assert_eq!(stats.query_histogram.lock().len(), 0);
     }
@@ -645,32 +637,26 @@ mod tests {
     fn test_counter_methods() {
         let stats = AddressStats::default();
 
-        // Test xact_count_add
         stats.xact_count_add();
         assert_eq!(stats.total.xact_count.load(Ordering::Relaxed), 1);
         assert_eq!(stats.current.xact_count.load(Ordering::Relaxed), 1);
 
-        // Test query_count_add
         stats.query_count_add();
         assert_eq!(stats.total.query_count.load(Ordering::Relaxed), 1);
         assert_eq!(stats.current.query_count.load(Ordering::Relaxed), 1);
 
-        // Test bytes_received_add
         stats.bytes_received_add(100);
         assert_eq!(stats.total.bytes_received.load(Ordering::Relaxed), 100);
         assert_eq!(stats.current.bytes_received.load(Ordering::Relaxed), 100);
 
-        // Test bytes_sent_add
         stats.bytes_sent_add(200);
         assert_eq!(stats.total.bytes_sent.load(Ordering::Relaxed), 200);
         assert_eq!(stats.current.bytes_sent.load(Ordering::Relaxed), 200);
 
-        // Test wait_time_add
         stats.wait_time_add(300);
         assert_eq!(stats.total.wait_time.load(Ordering::Relaxed), 300);
         assert_eq!(stats.current.wait_time.load(Ordering::Relaxed), 300);
 
-        // Test error
         stats.error();
         assert_eq!(stats.total.errors.load(Ordering::Relaxed), 1);
         assert_eq!(stats.current.errors.load(Ordering::Relaxed), 1);
@@ -745,7 +731,6 @@ mod tests {
     fn test_time_recording_methods() {
         let stats = AddressStats::default();
 
-        // Test xact_time_add with non-zero value
         stats.xact_time_add(150);
         assert_eq!(
             stats.total.xact_time_microseconds.load(Ordering::Relaxed),
@@ -756,13 +741,11 @@ mod tests {
             150
         );
 
-        // Verify the time was recorded in the histogram
         {
             let histogram = stats.xact_histogram.lock();
             assert_eq!(histogram.len(), 1);
         }
 
-        // Test xact_time_add with zero value (should be ignored)
         stats.xact_time_add(0);
         assert_eq!(
             stats.total.xact_time_microseconds.load(Ordering::Relaxed),
@@ -773,7 +756,6 @@ mod tests {
             150
         ); // Unchanged
 
-        // Test query_time_add_microseconds
         stats.query_time_add_microseconds(250);
         assert_eq!(
             stats.total.query_time_microseconds.load(Ordering::Relaxed),
@@ -787,7 +769,6 @@ mod tests {
             250
         );
 
-        // Verify the time was recorded in the histogram
         {
             let histogram = stats.query_histogram.lock();
             assert_eq!(histogram.len(), 1);
@@ -798,16 +779,12 @@ mod tests {
     fn test_histogram_percentiles() {
         let stats = AddressStats::default();
 
-        // Add values to create a known distribution
-        // Add 100 values: 1, 2, 3, ..., 100 microseconds
         for i in 1..=100 {
             stats.xact_time_add(i as u64);
             stats.query_time_add_microseconds(i as u64);
         }
 
-        // Verify percentiles for transactions
         let (p50, p90, p95, p99) = stats.get_xact_percentiles();
-        // p50 should be around 50, p90 around 90, p95 around 95, p99 around 99
         assert!(
             (45..=55).contains(&p50),
             "p50 xact should be ~50, got {}",
@@ -829,7 +806,6 @@ mod tests {
             p99
         );
 
-        // Verify percentiles for queries
         let (p50, p90, p95, p99) = stats.get_query_percentiles();
         assert!(
             (45..=55).contains(&p50),
@@ -857,29 +833,21 @@ mod tests {
     fn test_histogram_reset() {
         let stats = AddressStats::default();
 
-        // Add some values
         for i in 1..=10 {
             stats.xact_time_add(i as u64);
         }
 
-        // Verify histogram has data
         assert_eq!(stats.xact_histogram.lock().len(), 10);
 
-        // Reset histograms
         stats.reset_histograms();
 
-        // Verify histogram is empty
         assert_eq!(stats.xact_histogram.lock().len(), 0);
     }
 
     #[test]
     fn test_update_averages_and_reset() {
-        // We need to mock the STAT_PERIOD for testing
-        // Since we can't modify the constant directly, we'll test with known values
-
         let stats = AddressStats::default();
 
-        // Add some data
         stats.xact_count_add();
         stats.xact_count_add();
         stats.xact_time_add(1000); // 1000 microseconds for first transaction
@@ -898,12 +866,9 @@ mod tests {
         stats.error();
         stats.error();
 
-        // Update averages (assuming STAT_PERIOD is 15000 milliseconds = 15 seconds)
         stats.update_averages();
 
-        // Check averages (transactions per second = 2/15 = 0)
         assert_eq!(stats.averages.xact_count.load(Ordering::Relaxed), 0);
-        // Average transaction time = (1000 + 2000) / 2 = 1500 microseconds
         assert_eq!(
             stats
                 .averages
@@ -912,9 +877,7 @@ mod tests {
             1500
         );
 
-        // Check averages (queries per second = 3/15 = 0)
         assert_eq!(stats.averages.query_count.load(Ordering::Relaxed), 0);
-        // Average query time = (300 + 400 + 500) / 3 = 400 microseconds
         assert_eq!(
             stats
                 .averages
@@ -923,7 +886,6 @@ mod tests {
             400
         );
 
-        // Check throughput averages (bytes per second)
         assert_eq!(
             stats.averages.bytes_received.load(Ordering::Relaxed),
             15000 / 15
@@ -933,14 +895,11 @@ mod tests {
             25000 / 15
         );
 
-        // Check wait time and error averages
         assert_eq!(stats.averages.wait_time.load(Ordering::Relaxed), 500 / 15);
         assert_eq!(stats.averages.errors.load(Ordering::Relaxed), 2 / 15);
 
-        // Now reset current counts
         stats.reset_current_counts();
 
-        // Verify current counts are reset to zero
         assert_eq!(stats.current.xact_count.load(Ordering::Relaxed), 0);
         assert_eq!(
             stats.current.xact_time_microseconds.load(Ordering::Relaxed),
@@ -959,7 +918,6 @@ mod tests {
         assert_eq!(stats.current.wait_time.load(Ordering::Relaxed), 0);
         assert_eq!(stats.current.errors.load(Ordering::Relaxed), 0);
 
-        // But total counts should remain unchanged
         assert_eq!(stats.total.xact_count.load(Ordering::Relaxed), 2);
         assert_eq!(
             stats.total.xact_time_microseconds.load(Ordering::Relaxed),
@@ -976,7 +934,6 @@ mod tests {
     fn test_into_iterator() {
         let stats = AddressStats::default();
 
-        // Add some data
         stats.total.xact_count.store(10, Ordering::Relaxed);
         stats.total.query_count.store(20, Ordering::Relaxed);
         stats.total.bytes_received.store(1000, Ordering::Relaxed);
@@ -1007,10 +964,8 @@ mod tests {
         stats.averages.wait_time.store(30, Ordering::Relaxed);
         stats.averages.errors.store(1, Ordering::Relaxed);
 
-        // Convert to iterator and collect into a HashMap for easy lookup
         let stats_map: HashMap<String, f64> = (&stats).into_iter().collect();
 
-        // Check total values
         assert_eq!(stats_map.get("total_xact_count"), Some(&10.0));
         assert_eq!(stats_map.get("total_query_count"), Some(&20.0));
         assert_eq!(stats_map.get("total_received"), Some(&1000.0));
@@ -1020,7 +975,6 @@ mod tests {
         assert_eq!(stats_map.get("total_wait_time"), Some(&300.0));
         assert_eq!(stats_map.get("total_errors"), Some(&5.0));
 
-        // Check average values
         assert_eq!(stats_map.get("avg_xact_count"), Some(&2.0));
         assert_eq!(stats_map.get("avg_query_count"), Some(&4.0));
         assert_eq!(stats_map.get("avg_recv"), Some(&200.0));
@@ -1035,23 +989,17 @@ mod tests {
     fn test_populate_row() {
         let stats = AddressStats::default();
 
-        // Add some data
         stats.total.xact_count.store(10, Ordering::Relaxed);
         stats.total.query_count.store(20, Ordering::Relaxed);
 
-        // Create a row vector
         let mut row = Vec::new();
 
-        // Populate the row
         stats.populate_row(&mut row);
 
-        // Check that the row has the expected number of elements
         assert_eq!(row.len(), 16); // 8 total stats + 8 average stats
 
-        // Check that the first element is "10" (total_xact_count)
         assert_eq!(row[0], "10");
 
-        // Check that the second element is "20" (total_query_count)
         assert_eq!(row[1], "20");
     }
 
@@ -1060,7 +1008,6 @@ mod tests {
         let stats = Arc::new(AddressStats::default());
         let mut handles = vec![];
 
-        // Spawn 10 threads, each incrementing counters
         for _ in 0..10 {
             let stats_clone = Arc::clone(&stats);
             let handle = thread::spawn(move || {
@@ -1081,12 +1028,10 @@ mod tests {
             handles.push(handle);
         }
 
-        // Wait for all threads to complete
         for handle in handles {
             handle.join().unwrap();
         }
 
-        // Check that all operations were counted correctly
         assert_eq!(stats.total.xact_count.load(Ordering::Relaxed), 1000); // 10 threads * 100 increments
         assert_eq!(stats.total.query_count.load(Ordering::Relaxed), 1000);
         assert_eq!(stats.total.bytes_received.load(Ordering::Relaxed), 10000); // 10 threads * 100 * 10 bytes
@@ -1102,7 +1047,6 @@ mod tests {
         assert_eq!(stats.total.wait_time.load(Ordering::Relaxed), 2000); // 10 threads * 100 * 2 microseconds
         assert_eq!(stats.total.errors.load(Ordering::Relaxed), 1000); // 10 threads * 100 errors
 
-        // Same checks for current counters
         assert_eq!(stats.current.xact_count.load(Ordering::Relaxed), 1000);
         assert_eq!(stats.current.query_count.load(Ordering::Relaxed), 1000);
         assert_eq!(stats.current.bytes_received.load(Ordering::Relaxed), 10000);

--- a/src/stats/client.rs
+++ b/src/stats/client.rs
@@ -316,59 +316,43 @@ impl ClientStats {
     // Client state management
     // ------------------------------------------------------------------------------------------
 
-    /// Sets the client state to IDLE and wait status to READ.
-    ///
-    /// This indicates the client is done querying the server, is no longer assigned
-    /// a server connection, and we're reading from the client.
+    /// Client is done querying, has no assigned server, and is reading from the client socket.
     #[inline(always)]
     pub fn idle_read(&self) {
         self.set_state_wait(CLIENT_STATE_IDLE, CLIENT_WAIT_READ);
     }
 
-    /// Sets the client state to IDLE and wait status to WRITE.
-    ///
-    /// This indicates the client is done querying the server, is no longer assigned
-    /// a server connection, and we're writing to the client.
+    /// Client is done querying, has no assigned server, and is writing to the client socket.
     #[inline(always)]
     pub fn idle_write(&self) {
         self.set_state_wait(CLIENT_STATE_IDLE, CLIENT_WAIT_WRITE);
     }
 
-    /// Sets the client state to WAITING and wait status to IDLE.
-    ///
-    /// This indicates the client is waiting for a server connection from the pool.
+    /// Client is waiting for a server connection from the pool.
     #[inline(always)]
     pub fn waiting(&self) {
         self.set_state_wait(CLIENT_STATE_WAITING, CLIENT_WAIT_IDLE);
     }
 
-    /// Sets the client state to ACTIVE and wait status to READ.
-    ///
-    /// This indicates the client has obtained a server connection and we're reading from it.
+    /// Client has a server connection and is reading from it.
     #[inline(always)]
     pub fn active_read(&self) {
         self.set_state_wait(CLIENT_STATE_ACTIVE, CLIENT_WAIT_READ);
     }
 
-    /// Sets the client state to ACTIVE and wait status to WRITE.
-    ///
-    /// This indicates the client has obtained a server connection and we're writing to it.
+    /// Client has a server connection and is writing to it.
     #[inline(always)]
     pub fn active_write(&self) {
         self.set_state_wait(CLIENT_STATE_ACTIVE, CLIENT_WAIT_WRITE);
     }
 
-    /// Sets the client state to ACTIVE and wait status to IDLE.
-    ///
-    /// This indicates the client has obtained a server connection and is waiting for a response.
+    /// Client has a server connection and is waiting for a response.
     #[inline(always)]
     pub fn active_idle(&self) {
         self.set_state_wait(CLIENT_STATE_ACTIVE, CLIENT_WAIT_IDLE);
     }
 
-    /// Sets the client state to IDLE and wait status to IDLE.
-    ///
-    /// This indicates the client has failed to obtain a connection from the pool.
+    /// Client failed to obtain a connection from the pool.
     #[inline(always)]
     pub fn checkout_error(&self) {
         self.set_state_wait(CLIENT_STATE_IDLE, CLIENT_WAIT_IDLE);

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -106,21 +106,7 @@ static STAT_PERIOD: u64 = 15000;
 pub struct Reporter {}
 
 impl Reporter {
-    /// Registers a client with the statistics system.
-    ///
-    /// This method adds a client's statistics object to the global registry, making it
-    /// available for tracking and reporting. The client_id is used as a unique identifier
-    /// to track and aggregate statistics from all sources related to that client.
-    ///
-    /// # Arguments
-    ///
-    /// * `client_id` - Unique identifier for the client
-    /// * `stats` - Arc-wrapped ClientStats instance to register
-    ///
-    /// # Note
-    ///
-    /// If a client with the same ID is already registered, a warning is logged and
-    /// the registration is ignored to prevent overwriting existing statistics.
+    /// Registers client stats; duplicate ids are logged and ignored.
     fn client_register(&self, client_id: u64, stats: Arc<ClientStats>) {
         use std::collections::hash_map::Entry;
         match CLIENT_STATS.write().entry(client_id) {
@@ -133,40 +119,14 @@ impl Reporter {
         }
     }
 
-    /// Unregisters a client from the statistics system.
-    ///
-    /// This method removes a client's statistics object from the global registry
-    /// when the client disconnects from the pooler.
-    ///
-    /// # Arguments
-    ///
-    /// * `client_id` - Unique identifier for the client to unregister
     fn client_disconnecting(&self, client_id: u64) {
         CLIENT_STATS.write().remove(&client_id);
     }
 
-    /// Registers a server connection with the statistics system.
-    ///
-    /// This method adds a server's statistics object to the global registry, making it
-    /// available for tracking and reporting. The server_id is used as a unique identifier
-    /// to track and aggregate statistics from all sources related to that server.
-    ///
-    /// # Arguments
-    ///
-    /// * `server_id` - Unique identifier for the server
-    /// * `stats` - Arc-wrapped ServerStats instance to register
     fn server_register(&self, server_id: i32, stats: Arc<ServerStats>) {
         SERVER_STATS.write().insert(server_id, stats);
     }
 
-    /// Unregisters a server connection from the statistics system.
-    ///
-    /// This method removes a server's statistics object from the global registry
-    /// when the server disconnects from the pooler.
-    ///
-    /// # Arguments
-    ///
-    /// * `server_id` - Unique identifier for the server to unregister
     fn server_disconnecting(&self, server_id: i32) {
         SERVER_STATS.write().remove(&server_id);
     }

--- a/src/stats/server.rs
+++ b/src/stats/server.rs
@@ -242,22 +242,13 @@ impl ServerStats {
     // Server state management
     // ------------------------------------------------------------------------------------------
 
-    /// Sets the server state to LOGIN and application name to "Undefined".
-    ///
-    /// This indicates the server is attempting to establish a connection to PostgreSQL.
+    /// Server is attempting to establish a connection to PostgreSQL.
     pub fn login(&self) {
         self.set_state(SERVER_STATE_LOGIN);
         self.set_undefined_application();
     }
 
-    /// Sets the server state to ACTIVE and updates the application name.
-    ///
-    /// This indicates the server has been assigned to a client and is actively
-    /// processing queries or transactions.
-    ///
-    /// # Arguments
-    ///
-    /// * `application_name` - Name of the application using this server connection
+    /// Server is assigned to a client and actively processing work.
     pub fn active(&self, application_name: String) {
         // Refresh the activation timestamp before flipping state to ACTIVE.
         // The two atomics use Relaxed and provide no happens-before, so a
@@ -297,14 +288,7 @@ impl ServerStats {
             .as_nanos() as u64
     }
 
-    /// Sets the server state to IDLE and records transaction time.
-    ///
-    /// This indicates the server is no longer assigned to a client and is
-    /// available for the next client to pick it up.
-    ///
-    /// # Arguments
-    ///
-    /// * `microseconds` - Transaction time in microseconds to record
+    /// Server is idle and available for the next client.
     #[inline(always)]
     pub fn idle(&self, microseconds: u64) {
         self.address.stats.xact_time_add(microseconds);
@@ -317,13 +301,6 @@ impl ServerStats {
     }
 
     /// Records transaction time and sets the server state to IDLE.
-    ///
-    /// This is a variant of the idle() method that emphasizes recording
-    /// transaction time.
-    ///
-    /// # Arguments
-    ///
-    /// * `microseconds` - Transaction time in microseconds to record
     #[inline(always)]
     pub fn add_xact_time_and_idle(&self, microseconds: u64) {
         self.set_state(SERVER_STATE_IDLE);
@@ -339,25 +316,19 @@ impl ServerStats {
     // Wait state management
     // ------------------------------------------------------------------------------------------
 
-    /// Sets the server wait status to READ.
-    ///
-    /// This indicates the server is waiting for data to be read from the connection.
+    /// Server is waiting for a read.
     #[inline]
     pub fn wait_reading(&self) {
         self.set_wait(SERVER_WAIT_READ);
     }
 
-    /// Sets the server wait status to WRITE.
-    ///
-    /// This indicates the server is waiting for data to be written to the connection.
+    /// Server is waiting for a write.
     #[inline]
     pub fn wait_writing(&self) {
         self.set_wait(SERVER_WAIT_WRITE);
     }
 
-    /// Sets the server wait status to IDLE.
-    ///
-    /// This indicates the server is not waiting for any I/O operation.
+    /// Server is not waiting for I/O.
     #[inline]
     pub fn wait_idle(&self) {
         self.set_wait(SERVER_WAIT_IDLE);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,10 +1,7 @@
 //! Transport descriptor used by the client authentication pipeline.
 //!
-//! Replaces the `(SocketAddr, ssl: bool, is_unix: bool)` triplet that used
-//! to be threaded through the HBA matcher and `Client::startup`. Having a
-//! single enum removes the "two booleans in a row" footgun and gives us a
-//! natural place to hang transport-specific helpers like a display string
-//! for logs.
+//! A single enum carries transport-specific data through HBA matching,
+//! client startup, and log formatting.
 
 use std::net::SocketAddr;
 

--- a/src/utils/core_affinity.rs
+++ b/src/utils/core_affinity.rs
@@ -11,15 +11,12 @@ extern crate libc;
 #[cfg_attr(all(not(test), not(target_os = "macos")), allow(unused_extern_crates))]
 extern crate num_cpus;
 
-/// This function tries to retrieve information
-/// on all the "cores" on which the current thread
-/// is allowed to run.
+/// Returns the CPU cores available to the current thread.
 pub fn get_core_ids() -> Option<Vec<CoreId>> {
     get_core_ids_helper()
 }
 
-/// This function tries to pin the current
-/// thread to the specified core.
+/// Pins the current thread to `core_id`.
 ///
 /// # Arguments
 ///

--- a/src/web/metrics/metrics.rs
+++ b/src/web/metrics/metrics.rs
@@ -228,12 +228,10 @@ fn update_socket_metrics() {
 }
 
 fn update_pool_metrics() {
-    // Reuse the shared 250 ms snapshot — codex Arch P2#6 / Perf P2#6.
-    // /metrics scrapes typically arrive every 15-30 s, but during an
-    // incident the SPA can be polling /api/* on the same listener at
-    // 1.5 s. Without the cache both paths each cloned CLIENT_STATS and
-    // SERVER_STATS under their own read lock; with the cache they
-    // share one snapshot whenever they fall inside the TTL.
+    // /metrics scrapes usually arrive every 15-30 s, but during an
+    // incident the SPA can poll /api/* on the same listener every 1.5 s.
+    // The shared 250 ms snapshot keeps both paths from cloning CLIENT_STATS
+    // and SERVER_STATS under separate read locks inside the TTL.
     let snap = crate::web::routes::collect::snapshot();
     reset_pool_metrics();
 
@@ -1249,12 +1247,11 @@ mod tests {
 
     #[test]
     fn counter_delta_tracker_emits_post_reset_delta_only_once() {
-        // Reproduces the codex review scenario for the same generation:
-        // a pool whose `AddressStats` was replaced by `Pool::from_config`
-        // reports a smaller cumulative value than what the Prometheus
-        // counter holds. The tracker must increment by `current` once
-        // and a follow-up scrape with the same `current` must not
-        // fabricate another delta.
+        // A pool whose `AddressStats` was replaced by `Pool::from_config`
+        // reports a smaller cumulative value than the Prometheus counter
+        // holds. The tracker must increment by `current` once and a
+        // follow-up scrape with the same `current` must not fabricate
+        // another delta.
         let tracker: super::CounterDeltaTracker<&'static str> = super::CounterDeltaTracker::new();
         let counter =
             prometheus::IntCounter::new("pg_doorman_test_reset_counter", "test counter").unwrap();
@@ -1287,10 +1284,9 @@ mod tests {
             "subsequent growth advances by the actual delta",
         );
 
-        // codex review BLOCKER 1: new generation already grew past the
-        // previous cumulative between two scrapes. `current >= last`
-        // is misleading — the source identity changed, this is a
-        // recreate, not a continuation.
+        // A new generation may already exceed the previous cumulative value
+        // between two scrapes. `current >= last` is misleading here; the
+        // source identity changed, so this is a recreate, not a continuation.
         tracker.observe(&counter, "key", gen_b, 1_500);
         assert_eq!(
             counter.get(),

--- a/src/web/metrics/tests.rs
+++ b/src/web/metrics/tests.rs
@@ -11,9 +11,6 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
-// Test for the HTTP server functionality
-// This test is focused on the public interface of the prometheus module
-//
 // `#[serial]` because `start_web_server` writes the process-wide
 // `WebServerOptions` slot used by every other web::tests test.
 #[tokio::test]
@@ -223,8 +220,6 @@ fn test_pool_state_gauges_register_and_export() {
     SHOW_POOLS_MAXWAIT_MICROSECONDS.reset();
 }
 
-// Integration test for the full server
-// This is more complex and would start the actual server
 #[tokio::test]
 #[ignore] // Ignore by default as it requires network access and might conflict with other tests
 async fn test_prometheus_server_integration() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,8 +1,5 @@
-//! Web subsystem: Prometheus metrics endpoint, future REST API for the UI,
-//! authentication, log tap, and SPA static assets.
-//!
-//! Phase 1 wires only the metrics submodule (the former `crate::web::metrics`).
-//! Auth, routes, log_tap, and static_assets are added in subsequent phases.
+//! Web subsystem: Prometheus metrics, REST API routes, authentication,
+//! log tap, and SPA static assets.
 
 pub mod access_log;
 pub mod auth;

--- a/src/web/routes/admin.rs
+++ b/src/web/routes/admin.rs
@@ -93,10 +93,8 @@ fn parse_scope(
 /// Same outcome envelope shape across the two transports: 404 with a
 /// typed JSON error when the scope filter excluded every pool, 200 with
 /// the list of touched pool ids otherwise. Uses serde_json::json! so
-/// every value goes through the SerDe escaper — codex Arch P2#4
-/// flagged the previous hand-formatted JSON because `db.replace('"', '\\"')`
-/// missed control characters that PostgreSQL identifier rules technically
-/// allow.
+/// every value goes through the SerDe escaper, including PostgreSQL
+/// identifiers with control characters.
 fn render_effect(action: &str, effect: AdminEffect) -> Response {
     match effect {
         AdminEffect::NoMatchingDb { db } => Response::ok_json(&json!({
@@ -120,8 +118,7 @@ fn render_effect(action: &str, effect: AdminEffect) -> Response {
 
 fn json_ok(action: &str, affected: &[crate::pool::PoolIdentifier]) -> Response {
     // `affected_pools` keeps the bare count for backward compat; the
-    // typed `affected` array is what codex DBA P2#3 wanted so a DBA
-    // can see exactly which user@db rows the action ran against.
+    // typed `affected` array lists each user@db row the action touched.
     let ids: Vec<String> = affected
         .iter()
         .map(|id| format!("{}@{}", id.user, id.db))
@@ -134,10 +131,9 @@ fn json_ok(action: &str, affected: &[crate::pool::PoolIdentifier]) -> Response {
     }))
 }
 
-/// `reload` is global, so `affected_pools` is meaningless (codex DBA
-/// P2#5: the route used to hardcode `affected_pools: 1`). Surface
-/// `changed: true|false` instead — DBAs need that signal to tell a
-/// "config actually rotated" reload from a no-op SIGHUP.
+/// `reload` is global, so `affected_pools` is meaningless. Surface
+/// `changed: true|false` so operators can distinguish a config rotation
+/// from a no-op SIGHUP.
 fn json_reload(changed: bool) -> Response {
     Response::ok_json(&json!({
         "ts": now_unix_ms(),

--- a/src/web/routes/collect/config.rs
+++ b/src/web/routes/collect/config.rs
@@ -266,11 +266,8 @@ mod tests {
         assert!(!super::is_immutable_key("port"));
     }
 
-    /// Coverage check: the previous implementation only exposed
-    /// host/port/connect_timeout/idle_timeout/shutdown_timeout plus
-    /// pool users/mode. The flattened serde view now surfaces every
-    /// field in `Config` — verify a representative sample so a future
-    /// refactor that quietly trims keys gets caught.
+    /// Coverage check for the flattened serde view: representative
+    /// operational fields must stay visible after refactors.
     #[test]
     fn collect_config_exposes_operationally_relevant_fields() {
         let dto = super::collect_config(true);

--- a/src/web/routes/mod.rs
+++ b/src/web/routes/mod.rs
@@ -1,7 +1,4 @@
 //! REST API routes mounted under `/api/`.
-//!
-//! Phase 3a wires only `/api/version`, `/api/overview`, `/api/pools`.
-//! Subsequent phases add `/api/clients`, `/api/servers`, top-N, etc.
 
 pub mod collect;
 pub mod dto;

--- a/src/web/server/mod.rs
+++ b/src/web/server/mod.rs
@@ -5,13 +5,11 @@
 //! - `GET /api/version`  → version info, public.
 //! - `GET /api/overview` → cluster overview, public.
 //! - `GET /api/pools`    → pool list, public.
-//! - `GET /api/*`        → other endpoints return 501 until wired in later phases.
-//! - `GET /` | `GET /assets/*` → SPA placeholder, returns 404 (filled in phase 7).
+//! - `GET /api/*`        → route table in [`router`].
+//! - `GET /` | `GET /assets/*` → SPA static assets.
 //! - everything else → 404.
 //!
-//! Submodule layout (codex Arch P2#5 split — the original single-file
-//! `server.rs` mixed listener lifecycle, HTTP parsing, auth policy, routing,
-//! and response serialization in ~1300 lines):
+//! Submodule layout:
 //! - [`state`]    — reload-aware [`WebServerOptions`] backed by `ArcSwap`.
 //! - [`wire`]     — request parser, response builder, gzip cache, header helpers.
 //! - [`http`]     — keep-alive driven HTTP/1.1 connection handler.

--- a/src/web/server/wire.rs
+++ b/src/web/server/wire.rs
@@ -96,8 +96,7 @@ impl<'a> ParsedRequest<'a> {
             }
             // Headers are case-insensitive per RFC 7230. Match by case-
             // insensitive prefix without allocating a lowercase copy of
-            // the header value — `to_lowercase()` per request line was
-            // codex perf P3#9.
+            // the header value.
             if let Some(value) = strip_header_prefix(line, "Authorization") {
                 authorization = Some(value);
             } else if let Some(value) = strip_header_prefix(line, "Cookie") {
@@ -242,8 +241,7 @@ impl Response {
 
     /// Override the status line on a Response built via [`Response::ok_json`].
     /// Useful when the body shape is the same JSON envelope but the
-    /// outcome should travel back as 4xx/5xx — codex Arch P2#4 admin
-    /// route refactor.
+    /// outcome should travel back as 4xx/5xx.
     pub(crate) fn with_status(mut self, status: u16, reason: &'static str) -> Self {
         self.status = status;
         self.reason = reason;
@@ -326,8 +324,7 @@ fn strip_header_prefix<'a>(line: &'a str, header: &str) -> Option<&'a str> {
     Some(&line[need..])
 }
 
-/// Case-insensitive `contains` over ASCII bytes. Avoids the
-/// `value.to_lowercase()` allocation that codex P3#9 flagged.
+/// Case-insensitive `contains` over ASCII bytes without allocation.
 fn contains_ascii_ci(haystack: &str, needle: &str) -> bool {
     let h = haystack.as_bytes();
     let n = needle.as_bytes();

--- a/src/web/tests.rs
+++ b/src/web/tests.rs
@@ -73,11 +73,9 @@ fn mint_jwt(name: &str, exp_offset: i64) -> String {
 }
 
 /// Bind on `127.0.0.1:0`, ask the kernel for an actual port, hand the
-/// pre-bound listener to the accept loop. Replaces the previous
-/// `portpicker::pick_unused_port + sleep(150ms)` pattern that codex
-/// flagged: pick_unused_port races between picking and binding (the
-/// port can be claimed in that window), and the fixed sleep was a
-/// readiness fudge instead of a synchronisation point.
+/// pre-bound listener to the accept loop. Picking a port before binding
+/// races with other processes; the bound listener is the synchronisation
+/// point.
 async fn spawn_server(opts: WebServerOptions) -> u16 {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -576,9 +574,7 @@ async fn api_events_returns_envelope() {
 async fn http_keep_alive_serves_two_requests_on_one_connection() {
     // Two sequential GETs without `Connection: close` should both come
     // back over the same TCP connection. The server then closes when
-    // we drop our half (no more requests). Until codex perf P1#2 the
-    // listener closed after one request, forcing the SPA to reconnect
-    // multiple times per poll interval.
+    // we drop our half.
     let port = spawn_server(opts(true, true)).await;
     let mut stream = tokio::time::timeout(
         Duration::from_secs(2),
@@ -698,12 +694,9 @@ async fn anonymous_personal_data_path_returns_401() {
 #[tokio::test]
 #[serial]
 async fn anonymous_public_passes_with_poison_basic_header() {
-    // Regression: the SPA's `api.ts` sends `Authorization: Basic ` on
-    // every fetch when there are no credentials, to override the
-    // browser's basic-auth cache. The backend used to demote that to
-    // Anonymous; the three-role refactor briefly let it fall through
-    // as Rejected and 401'd every public endpoint. This test pins the
-    // fix.
+    // The SPA sends `Authorization: Basic ` with no credentials to override
+    // the browser's basic-auth cache. Public endpoints must treat it as
+    // Anonymous, not Rejected.
     let port = spawn_server(opts(true, true)).await;
     let raw = send(
         port,


### PR DESCRIPTION
## Summary
- remove stale phase/process-history comments from web, messages, stats, and tests
- rewrite history-bound notes as present-tense behavior notes
- leave Phase C coordinator regression comments for a separate concurrency-focused pass

## Tests
- cargo fmt --check
- git diff --check
- RUSTFLAGS='-D warnings' CARGO_TARGET_DIR=target-host make test