### PR TITLE
Clean up Fastpath LargeObject documentation

### DIFF
--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -4,25 +4,20 @@
 
 #### pgjdbc LargeObject fastpath calls work in transaction pooling
 
-pg_doorman now forwards PostgreSQL `FunctionCall` protocol messages and
-passes `FunctionCallResponse` through until `ReadyForQuery` reports the
-transaction state. The pgjdbc LargeObject API uses this fastpath path, and
-transaction-mode clients could previously hang on `getLargeObjectAPI()`
-because the frontend `F` message was not forwarded.
+pg_doorman now forwards PostgreSQL Fastpath `FunctionCall` (`F`) messages and
+passes `FunctionCallResponse` (`V`) back to the client. pgjdbc
+`LargeObjectManager` uses this protocol path for functions such as `lo_open`,
+`lo_read`, and `lo_write`. Transaction-mode clients could previously hang
+because pg_doorman did not forward the frontend `F` message.
 
 Large `FunctionCallResponse` messages now use the same large-message streaming
 path as oversized `DataRow` and `CopyData` messages. This avoids buffering a
 large fastpath `lo_read` response in pg_doorman memory before forwarding it to
 the client.
 
-Regression coverage now includes wire-level fastpath checks in transaction
-and autocommit pooling, plus a pgjdbc LargeObject round trip with a multi-MiB
-payload.
-
-This is an observable behavior change for applications that previously timed
-out or bypassed pg_doorman for large object work. That traffic now succeeds
-through pg_doorman and can hold transaction-pool backends while large object
-reads or writes are in flight. See [Fastpath and Large
+Large object calls now work through pg_doorman and can hold transaction-pool
+backends while reads or writes are in flight. Size pools for concurrent large
+object traffic and keep application-side reads chunked. See [Fastpath and Large
 Objects](operations/fastpath-large-objects.md) for pool sizing, timeout, and
 read-size guidance.
 

--- a/documentation/en/src/operations/fastpath-large-objects.md
+++ b/documentation/en/src/operations/fastpath-large-objects.md
@@ -1,86 +1,69 @@
 # Fastpath and Large Objects
 
-PostgreSQL has a Fastpath FunctionCall message in the frontend/backend
-protocol. A client sends `F`, PostgreSQL returns a `FunctionCallResponse`
-message `V`, and the request is complete only after the following
-`ReadyForQuery` message `Z`.
+Use this page when pgjdbc or Hibernate works with PostgreSQL large objects
+through a pg_doorman transaction pool.
 
-The pgjdbc `LargeObjectManager` uses this protocol path for operations such
-as `lo_creat`, `lo_open`, `lo_write`, `lo_read`, and `lo_close`. Applications
-often reach it indirectly through ORM mappings that store large values in OID
-columns, including Hibernate configurations that unwrap pgjdbc's large object
-API.
+pgjdbc `LargeObjectManager` uses PostgreSQL Fastpath `FunctionCall` (`F`) for
+large object functions such as `lo_creat`, `lo_open`, `lo_read`, `lo_write`,
+and `lo_close`. PostgreSQL replies with `FunctionCallResponse` (`V`) and then
+`ReadyForQuery` (`Z`). The `V` message contains the function result; the
+transaction status is in the following `ReadyForQuery`.
 
-Before 3.10.7, pg_doorman did not forward frontend `FunctionCall` messages in
-transaction pooling. pgjdbc clients could wait forever for the missing
-`FunctionCallResponse`. From 3.10.7, pg_doorman forwards the `F` request,
-passes the `V` response through, and uses the trailing `ReadyForQuery`
-transaction status to decide when a transaction-pool backend can be released.
+Before 3.10.7, pg_doorman did not forward `FunctionCall` in transaction
+pooling. A client could send a large object call and then wait forever for a
+response. Since 3.10.7, pg_doorman forwards the call, passes
+`FunctionCallResponse` back to the client, and releases the backend only after
+`ReadyForQuery` says the session is idle.
 
 ## Transaction Pooling
 
-Large object descriptors live inside a PostgreSQL transaction. If a fastpath
-call finishes with `ReadyForQuery` status `T` or `E`, pg_doorman keeps the same
-backend assigned to the client. The backend is released only when PostgreSQL
-later reports idle status `I`, typically after `COMMIT` or `ROLLBACK`.
+Large object descriptors live inside a PostgreSQL transaction. If
+`ReadyForQuery` reports status `T` or `E` after a fastpath call, pg_doorman
+keeps the same backend assigned to the client. The backend is released only
+after PostgreSQL later reports idle status `I`, normally after `COMMIT` or
+`ROLLBACK`.
 
-Autocommit fastpath calls that finish with `I` release the backend immediately.
+Autocommit fastpath calls release the backend as soon as `ReadyForQuery`
+reports idle.
 
-This matches PgBouncer's transaction-pooling behavior for PostgreSQL
-FunctionCall traffic.
+This matches PgBouncer transaction-pooling behavior for `FunctionCall` traffic.
 
 ## Pool Sizing
 
-Each in-flight large object call holds one backend until PostgreSQL returns
-`ReadyForQuery`. For write-heavy or read-heavy large object workloads, size the
-pool for the number of concurrent large object calls, not only for ordinary SQL
-statement rate.
+Each active large object call holds one backend until PostgreSQL sends
+`ReadyForQuery`. Size the pool for concurrent large object reads and writes,
+not only for ordinary SQL statement rate.
 
-Watch these signals during rollout:
+Watch these signals after enabling this traffic:
 
-- `SHOW POOLS`: `cl_active`, `sv_active`, and waiting clients.
-- Query wait timeout errors.
-- Query latency percentiles for pools used by large object traffic.
+- `SHOW POOLS`: active clients, active servers, and waiting clients.
+- `query_wait_timeout` errors.
+- Latency percentiles for pools used by large object traffic.
 
-If bursts of large object calls push clients close to `query_wait_timeout`,
-increase pool capacity for that user/database or reduce application-side large
-object concurrency.
+If large object bursts push clients close to `query_wait_timeout`, increase
+pool capacity for that user/database or reduce application-side large object
+concurrency.
 
-## Read Size And Memory
+## Large Reads
 
-pg_doorman streams large backend `DataRow` and `CopyData` messages when they
-exceed `general.message_size_to_be_stream`. From 3.10.7 this also applies to
-large `FunctionCallResponse` messages, so a large fastpath `lo_read` result is
-forwarded without keeping the whole response in pg_doorman memory.
+pg_doorman streams large `DataRow`, `CopyData`, and `FunctionCallResponse`
+messages when they exceed `general.message_size_to_be_stream`. A large
+fastpath `lo_read` response is forwarded without buffering the full response in
+pg_doorman memory first.
 
-Keep application-side large object reads chunked anyway. Large single-message
-reads still hold a backend for longer, keep socket buffers busy, and are bounded
-by PostgreSQL protocol message limits. pgjdbc's common
-`LargeObject.read(byte[])` usage already reads in small chunks.
+Streaming limits pg_doorman heap use; it does not make large single reads free.
+A large read still holds a backend and socket buffers while PostgreSQL sends
+the response, and PostgreSQL protocol message limits still apply. Keep
+application-side large object reads chunked.
 
-Changing `general.message_size_to_be_stream` controls when pg_doorman switches
-to byte-stream forwarding for `DataRow`, `CopyData`, and
-`FunctionCallResponse` messages.
+## Timeouts
 
-## Timeouts And Lifetime
-
-`server_lifetime` is applied to idle pooled backends. It does not interrupt a
-backend that is actively serving a large object read or write. The backend can
-be closed after the call finishes and returns to the idle pool.
+`server_lifetime` applies to idle pooled backends. It does not interrupt a
+backend that is serving a large object read or write.
 
 Large object descriptors also depend on PostgreSQL transaction state. If an
 application leaves a large object transaction idle between fastpath calls,
-PostgreSQL's `idle_in_transaction_session_timeout` can terminate the backend.
+PostgreSQL `idle_in_transaction_session_timeout` can terminate the backend.
 pg_doorman then returns a connection error to the client. Keep large object
 transactions short, or tune PostgreSQL timeouts for sessions that perform large
 object work.
-
-## Patroni-Assisted Fallback
-
-During a primary outage, Patroni-assisted fallback may temporarily connect to a
-replica or a candidate that is still read-only. Large object writes sent there
-fail with PostgreSQL read-only errors, for example SQLSTATE `25006`. This is a
-loud PostgreSQL error, not silent data loss.
-
-When large object traffic is critical during failover, monitor read-only errors
-and pool wait time alongside the fallback logs.

--- a/documentation/ru/src/SUMMARY.md
+++ b/documentation/ru/src/SUMMARY.md
@@ -42,6 +42,7 @@
 
 - [Плавное обновление бинаря](tutorials/binary-upgrade.md)
 - [Сигналы и перезагрузка](operations/signals.md)
+- [Fastpath и large objects](operations/fastpath-large-objects.md)
 - [Мониторинг query interner](operations/monitoring-interner.md)
 - [Диагностика](tutorials/troubleshooting.md)
 

--- a/documentation/ru/src/operations/fastpath-large-objects.md
+++ b/documentation/ru/src/operations/fastpath-large-objects.md
@@ -1,0 +1,69 @@
+# Fastpath и large objects
+
+Используйте эту страницу, если pgjdbc или Hibernate работают с PostgreSQL large
+objects через pg_doorman в режиме transaction pool.
+
+pgjdbc `LargeObjectManager` вызывает функции PostgreSQL large object через
+Fastpath `FunctionCall` (`F`): `lo_creat`, `lo_open`, `lo_read`, `lo_write`,
+`lo_close` и другие. PostgreSQL отвечает `FunctionCallResponse` (`V`), а затем
+`ReadyForQuery` (`Z`). В `V` лежит результат функции. Состояние транзакции
+приходит в следующем `ReadyForQuery`.
+
+До 3.10.7 pg_doorman не передавал `FunctionCall` в transaction pooling. Клиент
+мог отправить вызов функции large object и навсегда ждать ответа. Начиная с
+3.10.7 pg_doorman передаёт вызов в PostgreSQL, возвращает клиенту
+`FunctionCallResponse` и освобождает backend только после `ReadyForQuery`, если
+PostgreSQL сообщил idle-состояние.
+
+## Transaction pooling
+
+Дескрипторы large object живут внутри PostgreSQL-транзакции. Если после
+fastpath-вызова `ReadyForQuery` вернул статус `T` или `E`, pg_doorman оставляет
+за клиентом тот же backend. Backend освобождается только после idle-статуса
+`I`, обычно после `COMMIT` или `ROLLBACK`.
+
+Fastpath-вызовы в autocommit освобождают backend сразу после `ReadyForQuery` со
+статусом idle.
+
+Это соответствует поведению PgBouncer в transaction pooling для трафика
+`FunctionCall`.
+
+## Размер пула
+
+Каждый активный вызов функции large object занимает один backend до
+`ReadyForQuery`. Считайте размер пула по числу одновременных чтений и записей
+large objects, а не только по обычному темпу SQL-запросов.
+
+После включения такого трафика следите за:
+
+- `SHOW POOLS`: активные клиенты, активные серверы и ожидающие клиенты.
+- Ошибками `query_wait_timeout`.
+- Перцентилями задержек для пулов с large object трафиком.
+
+Если всплески вызовов large object подводят клиентов к `query_wait_timeout`,
+увеличьте пул для нужной пары user/database или уменьшите параллелизм large
+object операций в приложении.
+
+## Большие чтения
+
+pg_doorman передаёт большие `DataRow`, `CopyData` и `FunctionCallResponse`
+потоково, если они превышают `general.message_size_to_be_stream`. Большой
+fastpath-ответ `lo_read` уходит клиенту без предварительного буферизования
+всего ответа в памяти pg_doorman.
+
+Потоковая передача ограничивает расход heap в pg_doorman, но не делает большие
+одиночные чтения бесплатными. Большой `lo_read` всё равно удерживает backend и
+сокетные буферы, пока PostgreSQL отправляет ответ. Лимиты сообщений протокола
+PostgreSQL тоже остаются. Читайте large objects порциями на стороне приложения.
+
+## Таймауты
+
+`server_lifetime` применяется к idle backend в пуле. Он не прерывает backend,
+который выполняет чтение или запись large object.
+
+Дескрипторы large object зависят от состояния PostgreSQL-транзакции. Если
+приложение оставляет large object транзакцию idle между fastpath-вызовами,
+PostgreSQL `idle_in_transaction_session_timeout` может закрыть backend.
+pg_doorman вернёт клиенту ошибку соединения. Держите large object транзакции
+короткими или настройте PostgreSQL-таймауты для сессий, которые работают с
+large objects.


### PR DESCRIPTION
## Summary
- Rewrite the Fastpath and Large Objects operations page as a concise operator guide.
- Add the matching Russian operations page and RU navigation entry.
- Trim the 3.10.7 changelog entry to remove test/internal wording and keep the behavior, pool sizing, and read-size guidance.
- Remove the non-specific Patroni fallback note from this page; read-only fallback errors apply to writes in general, not specifically to Fastpath/LargeObject traffic.

Follow-up for #267 and #268.

## Verification
- `git diff --check`
- `cd documentation && CARGO_TARGET_DIR=/tmp/pg-doorman-doc-target ./build.sh`

The docs build completed successfully. mdBook printed only existing preprocessor version warnings.
