### PR TITLE
Clear SERVER_STATS rows for cancelled backend startups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.10.7"
+version = "3.10.8"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.10.7"
+version = "3.10.8"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 3.10.8
+
+#### Cancelled backend startups clear their server stats row
+
+Each backend startup attempt publishes a `SERVER_STATS` row before the
+PostgreSQL handshake finishes. If `connect_timeout` cancels pool checkout, or
+startup fails before a `Server` takes ownership, pg_doorman removes that row.
+`SHOW SERVERS`, `SHOW POOLS` (`sv_login`), `/api/servers`, and `/metrics` no
+longer show a long-lived `login` backend for a blackholed PostgreSQL address.
+
+When a local backend attempt fails and Patroni-assisted fallback is enabled,
+pg_doorman clears the local row before probing fallback candidates or waiting
+in retry backoff. Each visible `SHOW SERVERS` row now maps to an active startup
+attempt or an established server connection.
+
 ### 3.10.7
 
 #### pgjdbc LargeObject fastpath calls work in transaction pooling

--- a/src/pool/server_pool.rs
+++ b/src/pool/server_pool.rs
@@ -414,22 +414,14 @@ impl ServerPool {
             self.address.host,
             self.address.port,
         );
-        // Resolve before any `ServerStats` is registered. The budget
-        // preflight can return `ServerStartupParameterRejection`; if we
-        // had already published the stats entry via `stats.register`,
-        // the `?` exit would leak that entry in `sv_login` forever
-        // because the disconnect path runs only after the spawn
-        // attempt produces a result. The resolved map and the TLS
-        // retry share the same Arc, so the plain attempt and the
-        // sslmode=allow retry still see one parameter set.
+        // Parameter-budget rejection happens before a server socket exists.
+        // Leave SERVER_STATS untouched so SHOW SERVERS never lists a backend
+        // startup that did not open a socket. The plain attempt and
+        // sslmode=allow retry share this resolved map.
         let startup_parameters = self.resolved_startup_parameters()?;
 
-        let stats = Arc::new(ServerStats::new(
-            self.address.clone(),
-            crate::utils::clock::now(),
-        ));
-
-        stats.register(stats.clone());
+        let (stats, registration) =
+            ServerStats::new_registered(self.address.clone(), crate::utils::clock::now());
 
         let result = startup_with_timeout(
             self.connect_timeout,
@@ -469,27 +461,23 @@ impl ServerPool {
             ),
             _ => false,
         };
-        let (result, active_stats) = if should_tls_retry {
+        let (result, active_registration) = if should_tls_retry {
             info!(
                 "plain connection rejected, retrying with tls, user={} pool={} host={} port={} server_tls_mode=allow",
                 self.address.username, self.address.pool_name,
                 self.address.host, self.address.port,
             );
-            // Disconnect the plain-attempt stats before registering the TLS-retry stats.
-            // Without this, both entries would remain in SERVER_STATS: the plain one
-            // as a ghost if the retry succeeds, or the retry one leaking if it fails.
-            stats.disconnect();
+            // The plain attempt ended; keep only the TLS retry row visible.
+            drop(registration);
+            drop(stats);
             let mut retry_address = self.address.clone();
             retry_address.server_tls = std::sync::Arc::new(crate::config::tls::ServerTlsConfig {
                 mode: crate::config::tls::ServerTlsMode::Require,
                 connector: self.address.server_tls.connector.clone(),
                 cert_hash: self.address.server_tls.cert_hash,
             });
-            let retry_stats = Arc::new(ServerStats::new(
-                self.address.clone(),
-                crate::utils::clock::now(),
-            ));
-            retry_stats.register(retry_stats.clone());
+            let (retry_stats, retry_registration) =
+                ServerStats::new_registered(self.address.clone(), crate::utils::clock::now());
             let retry_result = startup_with_timeout(
                 self.connect_timeout,
                 &retry_address.host,
@@ -510,20 +498,22 @@ impl ServerPool {
                 ),
             )
             .await;
-            (retry_result, retry_stats)
+            (retry_result, retry_registration)
         } else {
-            (result, stats)
+            (result, registration)
         };
 
         match result {
             Ok(conn) => {
+                active_registration.release();
                 // Permit is released automatically when _permit goes out of scope
                 conn.stats.idle(0);
                 Ok(conn)
             }
             Err(err) => {
-                active_stats.disconnect();
-                // Local backend unreachable + Patroni-assisted fallback configured: route via fallback.
+                // The local attempt ended before fallback or backoff starts.
+                // Remove its login row before the next attempt publishes one.
+                drop(active_registration);
                 if is_backend_unreachable(&err) {
                     if let Some(ref fallback) = self.fallback_state {
                         fallback.blacklist();
@@ -1055,11 +1045,8 @@ impl ServerPool {
         fallback_address.host = target.host.clone();
         fallback_address.port = target.port;
 
-        let stats = Arc::new(ServerStats::new(
-            fallback_address.clone(),
-            crate::utils::clock::now(),
-        ));
-        stats.register(stats.clone());
+        let (stats, registration) =
+            ServerStats::new_registered(fallback_address.clone(), crate::utils::clock::now());
 
         // Startup parameters are resolved once per fallback round; each
         // candidate reuses the same per-pool cascade.
@@ -1097,7 +1084,7 @@ impl ServerPool {
             ),
             _ => false,
         };
-        let (result, active_stats) = if should_tls_retry {
+        let (result, active_registration) = if should_tls_retry {
             info!(
                 "[{}@{}] fallback: plain connection to {}:{} rejected, retrying with tls",
                 self.address.username,
@@ -1105,18 +1092,17 @@ impl ServerPool {
                 fallback_address.host,
                 fallback_address.port,
             );
-            stats.disconnect();
+            // The plain candidate ended; keep only the TLS retry row visible.
+            drop(registration);
+            drop(stats);
             let mut retry_address = fallback_address.clone();
             retry_address.server_tls = std::sync::Arc::new(crate::config::tls::ServerTlsConfig {
                 mode: crate::config::tls::ServerTlsMode::Require,
                 connector: fallback_address.server_tls.connector.clone(),
                 cert_hash: fallback_address.server_tls.cert_hash,
             });
-            let retry_stats = Arc::new(ServerStats::new(
-                fallback_address.clone(),
-                crate::utils::clock::now(),
-            ));
-            retry_stats.register(retry_stats.clone());
+            let (retry_stats, retry_registration) =
+                ServerStats::new_registered(fallback_address.clone(), crate::utils::clock::now());
             let retry_result = startup_with_timeout(
                 fallback_timeout,
                 &retry_address.host,
@@ -1137,19 +1123,21 @@ impl ServerPool {
                 ),
             )
             .await;
-            (retry_result, retry_stats)
+            (retry_result, retry_registration)
         } else {
-            (result, stats)
+            (result, registration)
         };
 
         match result {
             Ok(mut conn) => {
+                active_registration.release();
                 conn.stats.idle(0);
                 conn.override_lifetime_ms = Some(target.lifetime_ms);
                 Ok(conn)
             }
             Err(err) => {
-                active_stats.disconnect();
+                // No Server owns this fallback candidate, so the startup
+                // registration removes its login row here.
                 Err(err)
             }
         }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -123,8 +123,21 @@ impl Reporter {
         CLIENT_STATS.write().remove(&client_id);
     }
 
-    fn server_register(&self, server_id: i32, stats: Arc<ServerStats>) {
-        SERVER_STATS.write().insert(server_id, stats);
+    /// Inserts one `SERVER_STATS` row unless another row already uses
+    /// `server_id`. The caller retries collisions so a startup guard never
+    /// owns another server's slot.
+    fn server_register(&self, server_id: i32, stats: Arc<ServerStats>) -> bool {
+        use std::collections::hash_map::Entry;
+        match SERVER_STATS.write().entry(server_id) {
+            Entry::Occupied(_) => {
+                warn!("[server_id={server_id}] server stats id collision, retrying with a new id");
+                false
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(stats);
+                true
+            }
+        }
     }
 
     fn server_disconnecting(&self, server_id: i32) {

--- a/src/stats/server.rs
+++ b/src/stats/server.rs
@@ -3,6 +3,7 @@ use super::{get_reporter, Reporter};
 use crate::config::Address;
 use crate::utils::clock;
 use iota::iota;
+use log::debug;
 use parking_lot::Mutex;
 use std::sync::atomic::*;
 use std::sync::Arc;
@@ -98,6 +99,41 @@ pub struct ServerStats {
 /// it from this sentinel.
 const NEVER_ACTIVE: u64 = 0;
 
+/// Tracks a `SERVER_STATS` row created for an in-progress backend startup.
+///
+/// Startup publishes the row before the PostgreSQL handshake finishes so
+/// `SHOW SERVERS` can report `login`. A completed startup calls `release()`
+/// and lets `Server::drop` remove the row later. If startup times out, fails,
+/// or retries through TLS, dropping this guard removes the transient row.
+///
+/// Drop takes the global `SERVER_STATS` write lock. Keep `stats::Collector`
+/// read sections short so mass timeouts do not block on long snapshots.
+#[must_use = "the registration is the only handle that keeps the SERVER_STATS row alive; drop it explicitly only when the row should disappear"]
+pub(crate) struct ServerStatsRegistration {
+    server_id: i32,
+    released: bool,
+}
+
+impl ServerStatsRegistration {
+    /// Marks the row as owned by `Server`; after release, Drop leaves
+    /// `SERVER_STATS` unchanged.
+    pub fn release(mut self) {
+        self.released = true;
+    }
+}
+
+impl Drop for ServerStatsRegistration {
+    fn drop(&mut self) {
+        if !self.released {
+            debug!(
+                "[server_id={}] removing startup SERVER_STATS row without Server ownership",
+                self.server_id
+            );
+            get_reporter().server_disconnecting(self.server_id);
+        }
+    }
+}
+
 /// Default implementation for ServerStats.
 ///
 /// Creates a new ServerStats instance with default values:
@@ -170,17 +206,11 @@ impl ServerStats {
             .store(Self::pack(state, wait), Ordering::Relaxed);
     }
 
-    /// Creates a new ServerStats instance with the specified address and connection time.
-    ///
-    /// This constructor initializes a new server statistics tracker with the provided
-    /// address and connection time. A random server ID is generated, and all counters
-    /// are initialized to zero.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Address configuration for this server connection
-    /// * `connect_time` - Timestamp when the server connection was established
-    pub fn new(address: Address, connect_time: quanta::Instant) -> Self {
+    /// Creates an unregistered `ServerStats`. Production code reaches this
+    /// through `new_registered`, which pairs construction with publication.
+    /// Direct callers are limited to tests and helper code inside the crate
+    /// that must stay outside the global registry.
+    pub(crate) fn new(address: Address, connect_time: quanta::Instant) -> Self {
         Self {
             address,
             connect_time,
@@ -216,25 +246,40 @@ impl ServerStats {
     // Server lifecycle management
     // ------------------------------------------------------------------------------------------
 
-    /// Registers a server connection with the stats system.
+    /// Creates server stats in LOGIN state and publishes the row to
+    /// SERVER_STATS.
     ///
-    /// The stats system uses server_id to track and aggregate statistics from all sources
-    /// that relate to that server. This method should be called when a server connects.
+    /// The returned guard owns the row until startup succeeds. Call
+    /// `release()` after constructing `Server`; otherwise the guard removes
+    /// the row on drop.
     ///
-    /// # Arguments
-    ///
-    /// * `stats` - Arc-wrapped ServerStats instance to register
-    pub fn register(&self, stats: Arc<ServerStats>) {
-        self.reporter.server_register(self.server_id, stats);
-        self.login();
+    /// `server_id` collisions are retried before this function returns, so
+    /// each guard owns exactly one map slot.
+    pub(crate) fn new_registered(
+        address: Address,
+        connect_time: quanta::Instant,
+    ) -> (Arc<Self>, ServerStatsRegistration) {
+        loop {
+            let stats = Arc::new(Self::new(address.clone(), connect_time));
+            if stats
+                .reporter
+                .server_register(stats.server_id, Arc::clone(&stats))
+            {
+                stats.login();
+                let registration = ServerStatsRegistration {
+                    server_id: stats.server_id,
+                    released: false,
+                };
+                return (stats, registration);
+            }
+        }
     }
 
-    /// Reports that a server connection is disconnecting from the pooler.
-    ///
-    /// This method updates metrics on the pool regarding server usage and removes
-    /// the server from the stats tracking system.
+    /// Removes the row from SERVER_STATS. Called by `Server::drop` on
+    /// normal shutdown; the `ServerStatsRegistration` guard handles
+    /// removal on cancelled or failed startups.
     #[inline(always)]
-    pub fn disconnect(&self) {
+    pub(crate) fn disconnect(&self) {
         self.reporter.server_disconnecting(self.server_id);
     }
 
@@ -692,10 +737,8 @@ mod tests {
         assert_eq!(stats.process_id(), 123);
     }
 
-    #[test]
-    fn test_server_lifecycle_methods() {
-        // Create a test address
-        let address = Address {
+    fn make_lifecycle_address() -> Address {
+        Address {
             host: "test_host".to_string(),
             port: 5432,
             database: "test_db".to_string(),
@@ -705,36 +748,46 @@ mod tests {
             stats: Arc::new(AddressStats::default()),
             backend_auth: None,
             ..Address::default()
-        };
+        }
+    }
 
-        // Create a ServerStats with a fixed server_id for testing
-        let now = clock::now();
-        let stats = ServerStats::new(address.clone(), now);
+    #[test]
+    fn new_registered_row_disappears_when_startup_guard_drops() {
+        let (stats, registration) =
+            ServerStats::new_registered(make_lifecycle_address(), clock::now());
+        let server_id = stats.server_id();
 
-        // Set a known server_id for testing
-        let server_id = 54321;
-        let stats = ServerStats { server_id, ..stats };
+        assert!(get_server_stats().contains_key(&server_id));
+        assert_eq!(stats.state(), SERVER_STATE_LOGIN);
+        assert_eq!(*stats.application_name.lock(), "Undefined");
 
-        // Create an Arc-wrapped ServerStats for registration
-        let stats_arc = Arc::new(stats);
-
-        // Check that the server is not in the global registry before registration
+        drop(registration);
         assert!(!get_server_stats().contains_key(&server_id));
+    }
 
-        // Register the server
-        stats_arc.register(Arc::clone(&stats_arc));
+    #[test]
+    fn released_registration_survives_until_server_disconnect() {
+        let (stats, registration) =
+            ServerStats::new_registered(make_lifecycle_address(), clock::now());
+        let server_id = stats.server_id();
 
-        // Check that the server was registered in the global registry
+        registration.release();
         assert!(get_server_stats().contains_key(&server_id));
 
-        // Check that the state was set to LOGIN and application name to "Undefined"
-        assert_eq!(stats_arc.state(), SERVER_STATE_LOGIN);
-        assert_eq!(*stats_arc.application_name.lock(), "Undefined");
+        stats.disconnect();
+        assert!(!get_server_stats().contains_key(&server_id));
+    }
 
-        // Disconnect the server
-        stats_arc.disconnect();
+    #[test]
+    fn disconnect_after_startup_guard_drop_is_idempotent() {
+        let (stats, registration) =
+            ServerStats::new_registered(make_lifecycle_address(), clock::now());
+        let server_id = stats.server_id();
 
-        // Check that the server was removed from the global registry
+        drop(registration);
+        assert!(!get_server_stats().contains_key(&server_id));
+
+        stats.disconnect();
         assert!(!get_server_stats().contains_key(&server_id));
     }
 

--- a/tests/bdd/blackhole_helper.rs
+++ b/tests/bdd/blackhole_helper.rs
@@ -1,0 +1,140 @@
+use crate::pg_connection::PgConnection;
+use crate::world::DoormanWorld;
+use cucumber::{given, then, when};
+use std::time::{Duration, Instant};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// Owns the acceptor tasks started by `start_blackhole_listener` and
+/// aborts them when `DoormanWorld` drops at the end of a scenario, so
+/// scenarios cannot leak background tasks and file descriptors across
+/// the suite.
+#[derive(Default)]
+pub struct BlackholeAbortHandles(pub Vec<JoinHandle<()>>);
+
+impl Drop for BlackholeAbortHandles {
+    fn drop(&mut self) {
+        for handle in self.0.drain(..) {
+            handle.abort();
+        }
+    }
+}
+
+/// Starts a TCP listener that accepts connections and never sends a
+/// PostgreSQL startup response. A backend startup pointed at this listener
+/// stays in login until pg_doorman's `connect_timeout` cancels pool checkout.
+///
+/// The helper stores the selected port in `world.vars` as `<NAME>_PORT` for
+/// `${<NAME>_PORT}` config expansion.
+#[given(regex = r"^TCP blackhole listener registered as '(.+)'$")]
+pub async fn start_blackhole_listener(world: &mut DoormanWorld, name: String) {
+    let port = portpicker::pick_unused_port().expect("no free ports");
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+        .await
+        .expect("failed to bind blackhole listener");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let _hold = stream;
+                        futures::future::pending::<()>().await
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    world.blackhole_aborts.0.push(handle);
+
+    let var_name = format!("{}_PORT", name.to_uppercase());
+    world.vars.insert(var_name, port.to_string());
+}
+
+/// Starts a client session and ignores the expected startup failure. Scenarios
+/// use this step when the assertion belongs to pg_doorman's visible state
+/// (`SHOW SERVERS`, logs), not to the client-side error message.
+///
+/// The connection runs in a task because the protocol helpers may panic after
+/// pg_doorman closes the half-open startup. The join result is ignored with
+/// the startup error; later steps assert on the pooler state.
+#[when(
+    regex = r#"^we attempt session to pg_doorman as "([^"]+)" with password "([^"]*)" and database "([^"]+)" expecting startup failure$"#
+)]
+pub async fn attempt_session_expecting_startup_failure(
+    world: &mut DoormanWorld,
+    user: String,
+    password: String,
+    database: String,
+) {
+    let doorman_port = world.doorman_port.expect("pg_doorman not started");
+    let doorman_addr = format!("127.0.0.1:{}", doorman_port);
+
+    let handle = tokio::spawn(async move {
+        let mut conn = PgConnection::connect(&doorman_addr).await.ok()?;
+        conn.send_startup(&user, &database).await.ok()?;
+        let _ = conn.authenticate(&user, &password).await;
+        Some(())
+    });
+    match handle.await {
+        Ok(_) => {}
+        Err(join_err) if join_err.is_panic() => {
+            // The PgConnection helper panics when pg_doorman replies with a
+            // FATAL ErrorResponse; the scenario expects that path.
+        }
+        Err(join_err) => {
+            panic!("blackhole attempt task aborted unexpectedly: {join_err:?}");
+        }
+    }
+}
+
+/// Polls `SHOW SERVERS` on the named admin session until the row count
+/// matches the expected value or the deadline expires. Used by scenarios
+/// that drop a `ServerStatsRegistration` asynchronously and need a
+/// deterministic wait without padding `sleep` for the slowest CI host.
+#[then(
+    regex = r#"^we poll "SHOW SERVERS" on admin session "([^"]+)" until row count is (\d+) within (\d+)ms$"#
+)]
+pub async fn poll_show_servers_until_row_count(
+    world: &mut DoormanWorld,
+    session_name: String,
+    expected_rows: usize,
+    deadline_ms: u64,
+) {
+    let conn = crate::extended::helpers::get_session(&mut world.named_sessions, &session_name);
+    let deadline = Instant::now() + Duration::from_millis(deadline_ms);
+    let poll_interval = Duration::from_millis(50);
+
+    loop {
+        conn.send_simple_query("SHOW SERVERS")
+            .await
+            .expect("failed to send SHOW SERVERS");
+        let mut rows = 0usize;
+        loop {
+            let (msg_type, data) = conn
+                .read_message()
+                .await
+                .expect("failed to read SHOW SERVERS response");
+            match msg_type {
+                'D' => rows += 1,
+                'Z' => break,
+                'E' => panic!(
+                    "admin session '{}' returned error during SHOW SERVERS poll: {:?}",
+                    session_name,
+                    String::from_utf8_lossy(&data)
+                ),
+                _ => {}
+            }
+        }
+        if rows == expected_rows {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "SHOW SERVERS still reports {rows} rows on admin session '{session_name}' after {deadline_ms}ms; expected {expected_rows}"
+            );
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}

--- a/tests/bdd/features/server-stats-registration-leak.feature
+++ b/tests/bdd/features/server-stats-registration-leak.feature
@@ -1,0 +1,40 @@
+@rust @rust-1 @server-stats-registration-leak
+Feature: Cancelled backend startup attempts remove their SERVER_STATS rows
+
+  Background:
+    Given PostgreSQL started with pg_hba.conf:
+      """
+      local all all trust
+      host all all 127.0.0.1/32 trust
+      """
+    And fixtures from "tests/fixture.sql" applied
+    And TCP blackhole listener registered as 'blackhole'
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all all 127.0.0.1/32 trust"
+      query_wait_timeout = "200ms"
+      connect_timeout = "500ms"
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${BLACKHOLE_PORT}
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 10
+      """
+
+  @cancellation-leak
+  Scenario: Backend startup timeout leaves no SHOW SERVERS row
+    # The blackhole accepts TCP and never sends a PostgreSQL startup response.
+    # connect_timeout cancels pool checkout while pg_doorman has a login row
+    # for the backend attempt. After cancellation, SHOW SERVERS returns no rows.
+    When we attempt session to pg_doorman as "example_user_1" with password "" and database "example_db" expecting startup failure
+    When we create admin session "admin1" to pg_doorman as "admin" with password "admin"
+    Then we poll "SHOW SERVERS" on admin session "admin1" until row count is 0 within 2000ms

--- a/tests/bdd/main.rs
+++ b/tests/bdd/main.rs
@@ -1,5 +1,6 @@
 mod auth_query_helper;
 mod binary_upgrade_fd_helper;
+mod blackhole_helper;
 mod doorman_helper;
 mod extended;
 mod fallback_helper;

--- a/tests/bdd/world.rs
+++ b/tests/bdd/world.rs
@@ -136,6 +136,9 @@ pub struct DoormanWorld {
     pub mock_patroni_names: HashMap<String, u16>,
     /// Mock Patroni server response holders: server name -> shared JSON string
     pub mock_patroni_responses: HashMap<String, Arc<RwLock<String>>>,
+    /// Acceptor tasks for TCP blackhole listeners started by
+    /// `tests/bdd/blackhole_helper.rs`. Aborted when the world drops.
+    pub blackhole_aborts: crate::blackhole_helper::BlackholeAbortHandles,
     /// Path to file capturing pg_doorman stderr (set by `pg_doorman log capture enabled`).
     /// When `Some`, `start_doorman_with_config` redirects the child's stderr there
     /// so scenarios can assert on log content via `pg_doorman log contains`.


### PR DESCRIPTION
Cancelled backend startup attempts no longer leave a `SERVER_STATS` row behind. A startup attempt publishes its row while PostgreSQL login is in progress. If the attempt times out, fails, or is replaced by a TLS retry or fallback candidate before `Server` takes ownership, pg_doorman removes the row.
