### PR TITLE
Route Talos clients to personal or service pools by clientId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.10.8"
+version = "3.11.0"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_doorman"
-version = "3.10.8"
+version = "3.11.0"
 edition = "2021"
 rust-version = "1.87.0"
 license = "MIT"

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -2,13 +2,11 @@
 
 ### 3.11.0
 
-#### Talos clients can route to a dedicated user-specific pool
+#### Talos can route through client-specific pools
 
-When a Talos JWT carries `clientId` (e.g. `billing-api`), pg_doorman now first looks for a pool user named exactly `billing-api`, then a service pool user `srv-billing-api`, before falling back to the maximum role from the token (`owner`, `read_write`, `read_only`). Operators get an info-level log line on every Talos auth that records the resolved username and the source (personal pool, service pool, or max-role fallback).
+For `user=talos`, pg_doorman now selects the pool user in this order: `clientId`, `srv-<clientId>`, then the max token role (`owner`, `read_write`, `read_only`). Each Talos login logs the selected username and route.
 
-The `application_name` on the backend stays the Talos `clientId`, so `SHOW SERVERS` and `pg_stat_activity` keep showing which client opened the connection regardless of which pool serves it.
-
-A Talos JWT continues to bypass `pg_hba` for the resolved backend user across all three routes. Access to personal pools is governed by the JWT issuer and `GRANT`s on the personal user; operators who used `pg_hba` rules for `billing-api`-style usernames must move those rules into JWT issuer policy or revoke `GRANT`s on the pool user.
+Backend `application_name` stays the Talos `clientId`, so `SHOW SERVERS` and `pg_stat_activity` still show the client service. Talos bypasses `pg_hba` for the resolved pool user; enforce per-service access in the token issuer policy or PostgreSQL grants.
 
 ### 3.10.8
 

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 3.11.0
+
+#### Talos clients can route to a dedicated user-specific pool
+
+When a Talos JWT carries `clientId` (e.g. `billing-api`), pg_doorman now first looks for a pool user named exactly `billing-api`, then a service pool user `srv-billing-api`, before falling back to the maximum role from the token (`owner`, `read_write`, `read_only`). Operators get an info-level log line on every Talos auth that records the resolved username and the source (personal pool, service pool, or max-role fallback).
+
+The `application_name` on the backend stays the Talos `clientId`, so `SHOW SERVERS` and `pg_stat_activity` keep showing which client opened the connection regardless of which pool serves it.
+
+A Talos JWT continues to bypass `pg_hba` for the resolved backend user across all three routes. Access to personal pools is governed by the JWT issuer and `GRANT`s on the personal user; operators who used `pg_hba` rules for `billing-api`-style usernames must move those rules into JWT issuer policy or revoke `GRANT`s on the pool user.
+
 ### 3.10.8
 
 #### Cancelled backend startups clear their server stats row

--- a/src/auth/talos.rs
+++ b/src/auth/talos.rs
@@ -47,6 +47,26 @@ pub async fn load_talos_pub_key(key_filename: String) -> Result<(), Error> {
     Ok(())
 }
 
+/// Which branch of `resolve_talos_user` produced the resolved username.
+/// Personal: a pool user matching the JWT clientId was found.
+/// ServicePool: a pool user named `srv-<clientId>` was found.
+/// MaxRole: neither matched; the user is the string form of the max role.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TalosUserSource {
+    Personal,
+    ServicePool,
+    MaxRole,
+}
+
+/// Routing decision for a Talos-authenticated client. `username` is the
+/// pool user pg_doorman should connect under; `source` records which
+/// branch picked it (audit + observability).
+#[derive(Debug, Clone)]
+pub struct TalosResolution {
+    pub username: String,
+    pub source: TalosUserSource,
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone)]
 pub enum Role {
     ReadOnly = 1,
@@ -76,6 +96,72 @@ pub fn talos_role_to_string(r: Role) -> String {
         Role::ReadWrite => "read_write".to_string(),
         Role::ReadOnly => "read_only".to_string(),
     }
+}
+
+/// Returns true when `client_id` is safe to use as a pool user lookup key.
+/// Rejects empty strings and any byte below 0x20 or equal to 0x7F so a
+/// misconfigured issuer cannot smuggle control characters into the
+/// `SHOW SERVERS` view or a pool user name.
+fn is_routable_client_id(client_id: &str) -> bool {
+    !client_id.is_empty() && client_id.bytes().all(|b| b >= 0x20 && b != 0x7F)
+}
+
+/// Picks the backend pool user for a Talos-authenticated client.
+///
+/// Order: personal pool (user = `client_id`), service pool (user =
+/// `srv-<client_id>`), then `talos_role_to_string(max_role)`. The
+/// closure signature is `(database, user) -> bool`.
+///
+/// Routing-only sanitization: empty or non-printable `client_id` falls
+/// back to `MaxRole` with a `warn!`. Auth is not rejected; the connection
+/// still proceeds via the max-role pool.
+pub fn resolve_talos_user(
+    pool_name: &str,
+    client_id: &str,
+    max_role: Role,
+    pool_exists: impl Fn(&str, &str) -> bool,
+) -> TalosResolution {
+    if is_routable_client_id(client_id) {
+        if pool_exists(pool_name, client_id) {
+            return TalosResolution {
+                username: client_id.to_string(),
+                source: TalosUserSource::Personal,
+            };
+        }
+        let service_name = format!("srv-{client_id}");
+        if pool_exists(pool_name, &service_name) {
+            return TalosResolution {
+                username: service_name,
+                source: TalosUserSource::ServicePool,
+            };
+        }
+    } else if !client_id.is_empty() {
+        log::warn!(
+            "[talos] client_id {client_id:?} rejected as routing key (contains control characters); falling back to max role"
+        );
+    }
+    TalosResolution {
+        username: talos_role_to_string(max_role),
+        source: TalosUserSource::MaxRole,
+    }
+}
+
+/// Emits one info-level audit line per Talos auth. Key=value format on a
+/// single line for grep. The token, `kid`, and `exp` are NOT logged.
+pub fn log_talos_routing(client_id: &str, pool_name: &str, role: Role, resolved: &TalosResolution) {
+    let reason = match resolved.source {
+        TalosUserSource::Personal => "personal pool found",
+        TalosUserSource::ServicePool => "service pool found",
+        TalosUserSource::MaxRole => "no personal or service pool, fallback to max role",
+    };
+    log::info!(
+        "[talos] auth: client_id={} pool={} role={} → username={} ({})",
+        client_id,
+        pool_name,
+        talos_role_to_string(role),
+        resolved.username,
+        reason,
+    );
 }
 
 fn get_max_role(roles: Vec<String>) -> Result<Role, Error> {
@@ -508,5 +594,109 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
+    }
+
+    // --- resolve_talos_user + log_talos_routing tests ---
+
+    #[test]
+    fn talos_resolution_struct_is_constructible() {
+        let resolved = TalosResolution {
+            username: "owner".to_string(),
+            source: TalosUserSource::MaxRole,
+        };
+        assert_eq!(resolved.source, TalosUserSource::MaxRole);
+        assert_eq!(resolved.username, "owner");
+    }
+
+    #[test]
+    fn resolve_personal_pool_wins() {
+        let resolved = resolve_talos_user("billing_db", "billing-api", Role::Owner, |db, user| {
+            db == "billing_db" && user == "billing-api"
+        });
+        assert_eq!(resolved.source, TalosUserSource::Personal);
+        assert_eq!(resolved.username, "billing-api");
+    }
+
+    #[test]
+    fn resolve_falls_through_to_service_pool() {
+        let resolved =
+            resolve_talos_user("billing_db", "billing-api", Role::ReadOnly, |_, user| {
+                user == "srv-billing-api"
+            });
+        assert_eq!(resolved.source, TalosUserSource::ServicePool);
+        assert_eq!(resolved.username, "srv-billing-api");
+    }
+
+    #[test]
+    fn resolve_falls_through_to_max_role() {
+        let resolved = resolve_talos_user("billing_db", "billing-api", Role::Owner, |_, _| false);
+        assert_eq!(resolved.source, TalosUserSource::MaxRole);
+        assert_eq!(resolved.username, "owner");
+    }
+
+    #[test]
+    fn resolve_max_role_variations() {
+        for (role, expected) in [
+            (Role::Owner, "owner"),
+            (Role::ReadWrite, "read_write"),
+            (Role::ReadOnly, "read_only"),
+        ] {
+            let resolved = resolve_talos_user("db", "billing-api", role, |_, _| false);
+            assert_eq!(resolved.source, TalosUserSource::MaxRole);
+            assert_eq!(resolved.username, expected);
+        }
+    }
+
+    #[test]
+    fn resolve_skips_personal_when_client_id_empty() {
+        use std::cell::Cell;
+        let calls = Cell::new(0u32);
+        let resolved = resolve_talos_user("billing_db", "", Role::Owner, |_, _| {
+            calls.set(calls.get() + 1);
+            true
+        });
+        assert_eq!(resolved.source, TalosUserSource::MaxRole);
+        assert_eq!(
+            calls.get(),
+            0,
+            "pool_exists must not be called for empty client_id"
+        );
+    }
+
+    #[test]
+    fn resolve_skips_personal_when_client_id_has_null() {
+        use std::cell::Cell;
+        let calls = Cell::new(0u32);
+        let resolved = resolve_talos_user("billing_db", "foo\0bar", Role::Owner, |_, _| {
+            calls.set(calls.get() + 1);
+            true
+        });
+        assert_eq!(resolved.source, TalosUserSource::MaxRole);
+        assert_eq!(
+            calls.get(),
+            0,
+            "pool_exists must not be called for control-char client_id"
+        );
+    }
+
+    #[test]
+    fn resolve_skips_personal_when_client_id_has_control_char() {
+        let resolved = resolve_talos_user("billing_db", "foo\u{0001}", Role::Owner, |_, _| true);
+        assert_eq!(resolved.source, TalosUserSource::MaxRole);
+    }
+
+    #[test]
+    fn log_talos_routing_does_not_panic_per_branch() {
+        for source in [
+            TalosUserSource::Personal,
+            TalosUserSource::ServicePool,
+            TalosUserSource::MaxRole,
+        ] {
+            let resolved = TalosResolution {
+                username: "user".to_string(),
+                source,
+            };
+            log_talos_routing("client", "db", Role::Owner, &resolved);
+        }
     }
 }

--- a/src/auth/talos.rs
+++ b/src/auth/talos.rs
@@ -47,20 +47,18 @@ pub async fn load_talos_pub_key(key_filename: String) -> Result<(), Error> {
     Ok(())
 }
 
-/// Which branch of `resolve_talos_user` produced the resolved username.
-/// Personal: a pool user matching the JWT clientId was found.
-/// ServicePool: a pool user named `srv-<clientId>` was found.
-/// MaxRole: neither matched; the user is the string form of the max role.
+/// Source used to choose a Talos pool user.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TalosUserSource {
+    /// Pool user equals the JWT `clientId`.
     Personal,
+    /// Pool user is `srv-<clientId>`.
     ServicePool,
+    /// Pool user is the max token role.
     MaxRole,
 }
 
-/// Routing decision for a Talos-authenticated client. `username` is the
-/// pool user pg_doorman should connect under; `source` records which
-/// branch picked it (audit + observability).
+/// Pool user selected for a Talos client.
 #[derive(Debug, Clone)]
 pub struct TalosResolution {
     pub username: String,
@@ -98,23 +96,14 @@ pub fn talos_role_to_string(r: Role) -> String {
     }
 }
 
-/// Returns true when `client_id` is safe to use as a pool user lookup key.
-/// Rejects empty strings and any byte below 0x20 or equal to 0x7F so a
-/// misconfigured issuer cannot smuggle control characters into the
-/// `SHOW SERVERS` view or a pool user name.
+/// Returns true when `client_id` can be used in pool lookup and logs.
 fn is_routable_client_id(client_id: &str) -> bool {
     !client_id.is_empty() && client_id.bytes().all(|b| b >= 0x20 && b != 0x7F)
 }
 
-/// Picks the backend pool user for a Talos-authenticated client.
+/// Selects a Talos pool user: `clientId`, `srv-<clientId>`, then max role.
 ///
-/// Order: personal pool (user = `client_id`), service pool (user =
-/// `srv-<client_id>`), then `talos_role_to_string(max_role)`. The
-/// closure signature is `(database, user) -> bool`.
-///
-/// Routing-only sanitization: empty or non-printable `client_id` falls
-/// back to `MaxRole` with a `warn!`. Auth is not rejected; the connection
-/// still proceeds via the max-role pool.
+/// Invalid `clientId` is ignored for routing, not for authentication.
 pub fn resolve_talos_user(
     pool_name: &str,
     client_id: &str,
@@ -137,7 +126,7 @@ pub fn resolve_talos_user(
         }
     } else if !client_id.is_empty() {
         log::warn!(
-            "[talos] client_id {client_id:?} rejected as routing key (contains control characters); falling back to max role"
+            "[talos] client_id {client_id:?} contains control characters; using max-role pool"
         );
     }
     TalosResolution {
@@ -146,21 +135,20 @@ pub fn resolve_talos_user(
     }
 }
 
-/// Emits one info-level audit line per Talos auth. Key=value format on a
-/// single line for grep. The token, `kid`, and `exp` are NOT logged.
+/// Logs the Talos routing choice without token material.
 pub fn log_talos_routing(client_id: &str, pool_name: &str, role: Role, resolved: &TalosResolution) {
-    let reason = match resolved.source {
-        TalosUserSource::Personal => "personal pool found",
-        TalosUserSource::ServicePool => "service pool found",
-        TalosUserSource::MaxRole => "no personal or service pool, fallback to max role",
+    let route = match resolved.source {
+        TalosUserSource::Personal => "personal_pool",
+        TalosUserSource::ServicePool => "service_pool",
+        TalosUserSource::MaxRole => "max_role",
     };
     log::info!(
-        "[talos] auth: client_id={} pool={} role={} → username={} ({})",
+        "[talos] auth: client_id={} pool={} role={} username={} route={}",
         client_id,
         pool_name,
         talos_role_to_string(role),
         resolved.username,
-        reason,
+        route,
     );
 }
 

--- a/src/client/startup.rs
+++ b/src/client/startup.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpStream;
 
 use crate::auth::authenticate;
 use crate::auth::hba::CheckResult;
-use crate::auth::talos::{extract_talos_token, talos_role_to_string};
+use crate::auth::talos::{extract_talos_token, log_talos_routing, resolve_talos_user};
 use crate::config::{check_hba, get_config};
 use crate::errors::{ClientIdentifier, Error};
 use crate::messages::constants::*;
@@ -309,8 +309,15 @@ where
                         return Err(Error::AuthError(format!("Invalid Talos token: {err:?}")));
                     }
                 };
-                client_identifier.application_name = token.client_id;
-                client_identifier.username = talos_role_to_string(token.role);
+                let resolved = resolve_talos_user(
+                    pool_name.as_str(),
+                    &token.client_id,
+                    token.role,
+                    crate::pool::pool_exists,
+                );
+                log_talos_routing(&token.client_id, pool_name.as_str(), token.role, &resolved);
+                client_identifier.application_name = token.client_id.clone();
+                client_identifier.username = resolved.username;
                 client_identifier.is_talos = true;
             }
         }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1216,6 +1216,15 @@ pub fn get_pool(db: &str, user: &str) -> Option<ConnectionPool> {
         .cloned()
 }
 
+/// Returns true if the pool identified by `(db, user)` is registered.
+///
+/// Cheaper than `get_pool(db, user).is_some()` because it skips the
+/// `ConnectionPool` clone. Use for routing-discovery lookups where the
+/// caller only needs presence, not the pool itself.
+pub fn pool_exists(db: &str, user: &str) -> bool {
+    (*(*POOLS.load())).contains_key(&PoolIdentifier::new(db, user))
+}
+
 /// Get pool-level configuration by database name.
 /// Returns the Pool config if the database exists in configuration.
 /// Used by auth_query to find auth_query config when user is not in static config.
@@ -1240,6 +1249,12 @@ pub fn get_coordinator(db: &str) -> Option<Arc<pool_coordinator::PoolCoordinator
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pool_exists_returns_false_for_missing_entry() {
+        // POOLS is global; assert a clearly-nonexistent pair is absent.
+        assert!(!pool_exists("nonexistent_db", "nonexistent_user"));
+    }
 
     // --- per_user_overlay_hash tests ---
 

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1218,9 +1218,7 @@ pub fn get_pool(db: &str, user: &str) -> Option<ConnectionPool> {
 
 /// Returns true if the pool identified by `(db, user)` is registered.
 ///
-/// Cheaper than `get_pool(db, user).is_some()` because it skips the
-/// `ConnectionPool` clone. Use for routing-discovery lookups where the
-/// caller only needs presence, not the pool itself.
+/// Use this for routing checks that only need presence, not the pool clone.
 pub fn pool_exists(db: &str, user: &str) -> bool {
     (*(*POOLS.load())).contains_key(&PoolIdentifier::new(db, user))
 }
@@ -1252,7 +1250,7 @@ mod tests {
 
     #[test]
     fn pool_exists_returns_false_for_missing_entry() {
-        // POOLS is global; assert a clearly-nonexistent pair is absent.
+        // POOLS is global; use a pair no test should register.
         assert!(!pool_exists("nonexistent_db", "nonexistent_user"));
     }
 

--- a/tests/bdd/features/talos-personal-pool-routing.feature
+++ b/tests/bdd/features/talos-personal-pool-routing.feature
@@ -1,5 +1,5 @@
 @rust @rust-1 @talos-personal-pool-routing
-Feature: Talos clients route to personal or service pool by clientId
+Feature: Talos clientId pool routing
 
   Background:
     Given PostgreSQL started with pg_hba.conf:
@@ -12,7 +12,7 @@ Feature: Talos clients route to personal or service pool by clientId
     And keypair 'talos1' generated for talos with kid 'kid-test'
 
   @personal-pool
-  Scenario: Personal pool user wins over max role
+  Scenario: clientId pool is preferred to role pool
     Given pg_doorman log capture enabled
     And pg_doorman started with config:
       """
@@ -42,10 +42,10 @@ Feature: Talos clients route to personal or service pool by clientId
       pool_size = 5
       """
     When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
-    Then pg_doorman log contains "username=billing-api (personal pool found)"
+    Then pg_doorman log contains "username=billing-api route=personal_pool"
 
   @service-pool
-  Scenario: Service pool fallback when personal pool missing
+  Scenario: srv-clientId pool is used when clientId pool is absent
     Given pg_doorman log capture enabled
     And pg_doorman started with config:
       """
@@ -75,10 +75,10 @@ Feature: Talos clients route to personal or service pool by clientId
       pool_size = 5
       """
     When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
-    Then pg_doorman log contains "username=srv-billing-api (service pool found)"
+    Then pg_doorman log contains "username=srv-billing-api route=service_pool"
 
   @fallback-max-role-owner
-  Scenario: Owner role fallback when no personal or service pool
+  Scenario: owner role is used when no clientId pool exists
     Given pg_doorman log capture enabled
     And pg_doorman started with config:
       """
@@ -103,10 +103,10 @@ Feature: Talos clients route to personal or service pool by clientId
       pool_size = 5
       """
     When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
-    Then pg_doorman log contains "username=owner (no personal or service pool, fallback to max role)"
+    Then pg_doorman log contains "username=owner route=max_role"
 
   @fallback-max-role-read-write
-  Scenario: Read-write role fallback maps to read_write pool user
+  Scenario: read_write role maps to read_write pool user
     Given pg_doorman log capture enabled
     And pg_doorman started with config:
       """
@@ -131,10 +131,10 @@ Feature: Talos clients route to personal or service pool by clientId
       pool_size = 5
       """
     When we open Talos session 'c1' as client_id 'analytics' role 'read_write' database 'example_db' signed with 'talos1'
-    Then pg_doorman log contains "username=read_write (no personal or service pool, fallback to max role)"
+    Then pg_doorman log contains "username=read_write route=max_role"
 
   @application-name-stays-client-id
-  Scenario: SHOW SERVERS records a backend after Talos personal-pool routing
+  Scenario: SHOW SERVERS keeps the Talos clientId
     Given pg_doorman started with config:
       """
       [general]
@@ -163,7 +163,7 @@ Feature: Talos clients route to personal or service pool by clientId
     Then admin session "admin1" response should contain "billing-api"
 
   @mismatch-personal-but-read-only-token
-  Scenario: Personal pool wins even when token carries a lower role
+  Scenario: clientId pool is used for a read_only token
     Given pg_doorman log capture enabled
     And pg_doorman started with config:
       """
@@ -193,5 +193,4 @@ Feature: Talos clients route to personal or service pool by clientId
       pool_size = 5
       """
     When we open Talos session 'c1' as client_id 'billing-api' role 'read_only' database 'example_db' signed with 'talos1'
-    Then pg_doorman log contains "username=billing-api (personal pool found)"
-
+    Then pg_doorman log contains "username=billing-api route=personal_pool"

--- a/tests/bdd/features/talos-personal-pool-routing.feature
+++ b/tests/bdd/features/talos-personal-pool-routing.feature
@@ -1,0 +1,197 @@
+@rust @rust-1 @talos-personal-pool-routing
+Feature: Talos clients route to personal or service pool by clientId
+
+  Background:
+    Given PostgreSQL started with pg_hba.conf:
+      """
+      local all all trust
+      host all all 127.0.0.1/32 trust
+      """
+    And fixtures from "tests/fixture.sql" applied
+    And fixtures from "tests/talos_fixture.sql" applied
+    And keypair 'talos1' generated for talos with kid 'kid-test'
+
+  @personal-pool
+  Scenario: Personal pool user wins over max role
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 5
+
+      [[pools.example_db.users]]
+      username = "billing-api"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
+    Then pg_doorman log contains "username=billing-api (personal pool found)"
+
+  @service-pool
+  Scenario: Service pool fallback when personal pool missing
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = ""
+      pool_size = 5
+
+      [[pools.example_db.users]]
+      username = "srv-billing-api"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
+    Then pg_doorman log contains "username=srv-billing-api (service pool found)"
+
+  @fallback-max-role-owner
+  Scenario: Owner role fallback when no personal or service pool
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "owner"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
+    Then pg_doorman log contains "username=owner (no personal or service pool, fallback to max role)"
+
+  @fallback-max-role-read-write
+  Scenario: Read-write role fallback maps to read_write pool user
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "read_write"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'analytics' role 'read_write' database 'example_db' signed with 'talos1'
+    Then pg_doorman log contains "username=read_write (no personal or service pool, fallback to max role)"
+
+  @application-name-stays-client-id
+  Scenario: SHOW SERVERS records a backend after Talos personal-pool routing
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "billing-api"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'billing-api' role 'owner' database 'example_db' signed with 'talos1'
+    And we create admin session "admin1" to pg_doorman as "admin" with password "admin"
+    And we execute "SHOW SERVERS" on admin session "admin1" and store response
+    Then admin session "admin1" response should contain "billing-api"
+
+  @mismatch-personal-but-read-only-token
+  Scenario: Personal pool wins even when token carries a lower role
+    Given pg_doorman log capture enabled
+    And pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba.content = "host all talos 127.0.0.1/32 md5\nhost all all 127.0.0.1/32 trust"
+
+      [talos]
+      keys = ["${TALOS1_PUBKEY_PATH}"]
+      databases = ["example_db"]
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+
+      [[pools.example_db.users]]
+      username = "billing-api"
+      password = ""
+      pool_size = 5
+
+      [[pools.example_db.users]]
+      username = "read_only"
+      password = ""
+      pool_size = 5
+      """
+    When we open Talos session 'c1' as client_id 'billing-api' role 'read_only' database 'example_db' signed with 'talos1'
+    Then pg_doorman log contains "username=billing-api (personal pool found)"
+

--- a/tests/bdd/main.rs
+++ b/tests/bdd/main.rs
@@ -17,6 +17,7 @@ mod postgres_helper;
 mod proc_inspect;
 mod service_helper;
 mod shell_helper;
+mod talos_helper;
 mod utils;
 mod world;
 

--- a/tests/bdd/talos_helper.rs
+++ b/tests/bdd/talos_helper.rs
@@ -11,10 +11,8 @@ use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::NamedTempFile;
 
-/// Generates a temporary RSA keypair, stores the PEM paths under
-/// `world.vars` as `<NAME>_PUBKEY_PATH` / `<NAME>_PRIVKEY_PATH` and the
-/// `kid` as `<NAME>_KID`. The public key file stem equals the `kid` so
-/// pg_doorman's `load_talos_pub_key` registers it under that name.
+/// Generates an RSA keypair and stores its paths in `world.vars`.
+/// The public key file stem is the Talos `kid`.
 #[given(regex = r"^keypair '(.+)' generated for talos with kid '(.+)'$")]
 pub async fn generate_keypair(world: &mut DoormanWorld, name: String, kid: String) {
     let rsa = Rsa::generate(2048).expect("failed to generate RSA keypair");
@@ -44,10 +42,8 @@ pub async fn generate_keypair(world: &mut DoormanWorld, name: String, kid: Strin
     world.talos_priv_keys.push(priv_file);
 }
 
-/// Opens a Talos session: signs a JWT with the named keypair, sends it as
-/// the password for user `talos`, and stores the session for later steps.
-/// A FATAL ErrorResponse from pg_doorman panics this step (real failure);
-/// successful auth is the expected path for routing-validation scenarios.
+/// Opens a `user=talos` session with a freshly signed JWT.
+/// Any auth error fails the step.
 #[when(
     regex = r#"^we open Talos session '([^']+)' as client_id '([^']+)' role '([^']+)' database '([^']+)' signed with '([^']+)'$"#
 )]

--- a/tests/bdd/talos_helper.rs
+++ b/tests/bdd/talos_helper.rs
@@ -1,0 +1,151 @@
+use crate::pg_connection::PgConnection;
+use crate::world::DoormanWorld;
+use cucumber::{given, when};
+use jwt::{Header, PKeyWithDigest, SignWithKey, Token};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::rsa::Rsa;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::NamedTempFile;
+
+/// Generates a temporary RSA keypair, stores the PEM paths under
+/// `world.vars` as `<NAME>_PUBKEY_PATH` / `<NAME>_PRIVKEY_PATH` and the
+/// `kid` as `<NAME>_KID`. The public key file stem equals the `kid` so
+/// pg_doorman's `load_talos_pub_key` registers it under that name.
+#[given(regex = r"^keypair '(.+)' generated for talos with kid '(.+)'$")]
+pub async fn generate_keypair(world: &mut DoormanWorld, name: String, kid: String) {
+    let rsa = Rsa::generate(2048).expect("failed to generate RSA keypair");
+
+    let mut priv_file = NamedTempFile::new().expect("priv tempfile");
+    priv_file
+        .write_all(&rsa.private_key_to_pem().expect("private pem"))
+        .expect("write priv pem");
+    priv_file.flush().expect("flush priv pem");
+
+    let pub_dir = tempfile::tempdir().expect("pub dir");
+    let pub_path = pub_dir.path().join(format!("{kid}.pem"));
+    std::fs::write(&pub_path, rsa.public_key_to_pem().expect("public pem")).expect("write pub pem");
+
+    let upper = name.to_uppercase();
+    world.vars.insert(
+        format!("{upper}_PUBKEY_PATH"),
+        pub_path.to_str().unwrap().to_string(),
+    );
+    world.vars.insert(
+        format!("{upper}_PRIVKEY_PATH"),
+        priv_file.path().to_str().unwrap().to_string(),
+    );
+    world.vars.insert(format!("{upper}_KID"), kid);
+
+    world.talos_pub_keys.push(pub_dir);
+    world.talos_priv_keys.push(priv_file);
+}
+
+/// Opens a Talos session: signs a JWT with the named keypair, sends it as
+/// the password for user `talos`, and stores the session for later steps.
+/// A FATAL ErrorResponse from pg_doorman panics this step (real failure);
+/// successful auth is the expected path for routing-validation scenarios.
+#[when(
+    regex = r#"^we open Talos session '([^']+)' as client_id '([^']+)' role '([^']+)' database '([^']+)' signed with '([^']+)'$"#
+)]
+pub async fn open_talos_session(
+    world: &mut DoormanWorld,
+    session_name: String,
+    client_id: String,
+    role: String,
+    database: String,
+    keypair_name: String,
+) {
+    let upper = keypair_name.to_uppercase();
+    let priv_path = world
+        .vars
+        .get(&format!("{upper}_PRIVKEY_PATH"))
+        .expect("keypair not generated; missing Given step")
+        .clone();
+    let kid = world
+        .vars
+        .get(&format!("{upper}_KID"))
+        .expect("kid not stored")
+        .clone();
+
+    let token = build_talos_jwt(&client_id, &role, &database, &priv_path, &kid);
+
+    let doorman_port = world.doorman_port.expect("pg_doorman not started");
+    let addr = format!("127.0.0.1:{doorman_port}");
+
+    let mut conn = PgConnection::connect(&addr)
+        .await
+        .expect("failed to connect to pg_doorman");
+    conn.send_startup("talos", &database)
+        .await
+        .expect("failed to send startup");
+    conn.authenticate("talos", &token)
+        .await
+        .expect("Talos authentication failed");
+
+    world.named_sessions.insert(session_name, conn);
+}
+
+#[derive(Serialize)]
+struct BddTalosRoles<'a> {
+    roles: Vec<&'a str>,
+}
+
+#[derive(Serialize)]
+struct BddTalosClaims<'a> {
+    exp: u64,
+    nbf: u64,
+    #[serde(rename = "clientId")]
+    client_id: &'a str,
+    resource_access: HashMap<String, BddTalosRoles<'a>>,
+}
+
+fn build_talos_jwt(
+    client_id: &str,
+    role: &str,
+    database: &str,
+    priv_path: &str,
+    kid: &str,
+) -> String {
+    let priv_pem = std::fs::read_to_string(priv_path).expect("read priv");
+    let rsa = Rsa::private_key_from_pem(priv_pem.as_bytes()).expect("rsa from pem");
+    let pkey = PKey::from_rsa(rsa).expect("pkey from rsa");
+    let signer = PKeyWithDigest {
+        digest: MessageDigest::sha256(),
+        key: pkey,
+    };
+
+    let header = Header {
+        algorithm: jwt::AlgorithmType::Rs256,
+        key_id: Some(kid.to_string()),
+        type_: Some(jwt::header::HeaderType::JsonWebToken),
+        content_type: None,
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_secs();
+
+    let mut resource_access = HashMap::new();
+    resource_access.insert(
+        format!("postgres.local:{database}"),
+        BddTalosRoles { roles: vec![role] },
+    );
+
+    let claims = BddTalosClaims {
+        exp: now + 60,
+        nbf: now.saturating_sub(5),
+        client_id,
+        resource_access,
+    };
+
+    Token::new(header, claims)
+        .sign_with_key(&signer)
+        .expect("sign jwt")
+        .as_str()
+        .to_string()
+}

--- a/tests/bdd/world.rs
+++ b/tests/bdd/world.rs
@@ -139,6 +139,12 @@ pub struct DoormanWorld {
     /// Acceptor tasks for TCP blackhole listeners started by
     /// `tests/bdd/blackhole_helper.rs`. Aborted when the world drops.
     pub blackhole_aborts: crate::blackhole_helper::BlackholeAbortHandles,
+    /// Temp directories holding generated Talos public keys; one per
+    /// `keypair '<name>' generated for talos with kid '<kid>'` step.
+    /// Held so the files survive the scenario.
+    pub talos_pub_keys: Vec<tempfile::TempDir>,
+    /// Private key tempfiles paired with `talos_pub_keys`.
+    pub talos_priv_keys: Vec<tempfile::NamedTempFile>,
     /// Path to file capturing pg_doorman stderr (set by `pg_doorman log capture enabled`).
     /// When `Some`, `start_doorman_with_config` redirects the child's stderr there
     /// so scenarios can assert on log content via `pg_doorman log contains`.

--- a/tests/bdd/world.rs
+++ b/tests/bdd/world.rs
@@ -139,11 +139,9 @@ pub struct DoormanWorld {
     /// Acceptor tasks for TCP blackhole listeners started by
     /// `tests/bdd/blackhole_helper.rs`. Aborted when the world drops.
     pub blackhole_aborts: crate::blackhole_helper::BlackholeAbortHandles,
-    /// Temp directories holding generated Talos public keys; one per
-    /// `keypair '<name>' generated for talos with kid '<kid>'` step.
-    /// Held so the files survive the scenario.
+    /// Temp directories for generated Talos public keys.
     pub talos_pub_keys: Vec<tempfile::TempDir>,
-    /// Private key tempfiles paired with `talos_pub_keys`.
+    /// Private keys paired with `talos_pub_keys`.
     pub talos_priv_keys: Vec<tempfile::NamedTempFile>,
     /// Path to file capturing pg_doorman stderr (set by `pg_doorman log capture enabled`).
     /// When `Some`, `start_doorman_with_config` redirects the child's stderr there

--- a/tests/talos_fixture.sql
+++ b/tests/talos_fixture.sql
@@ -1,0 +1,8 @@
+\c example_db
+
+create user "billing-api" with password 'test' superuser;
+create user "srv-billing-api" with password 'test' superuser;
+create user "analytics" with password 'test' superuser;
+create user "owner" with password 'test' superuser;
+create user "read_write" with password 'test' superuser;
+create user "read_only" with password 'test' superuser;


### PR DESCRIPTION
## Summary
- For `user=talos`, pg_doorman now picks the pool user in this order: `clientId`, `srv-<clientId>`, then the max token role (`owner`, `read_write`, `read_only`).
- Backend `application_name` stays the Talos `clientId`; `SHOW SERVERS` and `pg_stat_activity` still show the client service.
- Talos still bypasses `pg_hba` for the resolved pool user. Keep per-service access in the token issuer policy or PostgreSQL grants.

## Logs
Each Talos login writes one routing line:

```text
[talos] auth: client_id=... pool=... role=... username=... route=personal_pool|service_pool|max_role
```

## Test plan
- [x] `cargo test --lib auth::talos pool::tests`
- [x] `make test-bdd TAGS=@talos-personal-pool-routing`
- [x] `cargo fmt`
- [x] `cargo clippy --deny warnings`