### PR TITLE
feat: add pool-level sync_server_parameters override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_doorman"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,103 +1,102 @@
 [package]
-name = "pg_doorman"
-version = "3.11.0"
 edition = "2021"
-rust-version = "1.87.0"
 license = "MIT"
-
+name = "pg_doorman"
+rust-version = "1.87.0"
+version = "3.11.1"
 
 [profile.release]
 codegen-units = 1
 lto = true
 
 [profile.profiling]
-inherits = "release"
 debug = true
+inherits = "release"
 
 [dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["background_threads_runtime_support"] }
-tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.20", features = ["json", "env-filter", "std"]}
+arc-swap = "1.7.1"
+base64 = "0.22.1"
+bytes = "1.10.1"
+chrono = "0.4"
+clap = {version = "4.5.37", features = ["derive", "env"]}
+exitcode = "1.1.2"
+hmac = "0.12"
+include_dir = "0.7"
+ipnet = {version = "2.11.0", features = ["serde"]}
+jwt = {version = "0.16.0", features = ["openssl"]}
+libc = "0.2.172"
 log = "0.4.27"
-clap = { version = "4.5.37", features = ["derive", "env"] }
-serde = { version = "1", features = ["derive"] }
+lru = "0.16.3"
+md-5 = "0.10"
+native-tls = {version = "0.2.14"}
+nix = {version = "0.30.1", features = ["process", "signal"]}
+num_cpus = "1.16.0"
+once_cell = "1.21.3"
+parking_lot = {version = "0.12.1", features = ["hardware-lock-elision"]}
+pin-project = "1"
+prometheus = "0.14.0"
+quanta = "0.12"
+rand = "0.9.1"
+scopeguard = "1.2"
+serde = {version = "1", features = ["derive"]}
+serde-toml-merge = {version = "0.3.8"}
 serde_derive = "1"
 serde_json = "1.0.140"
 serde_yaml = "0.9"
-ipnet = { version = "2.11.0", features = ["serde"] }
-once_cell = "1.21.3"
-quanta = "0.12"
-arc-swap = "1.7.1"
-toml = "0.8"
-prometheus = "0.14.0"
-tokio = { version = "1.48.4", features = ["rt-multi-thread", "fs", "parking_lot", "sync", "io-util", "net", "macros", "signal", "time"] }
-exitcode = "1.1.2"
-pin-project = "1"
-bytes = "1.10.1"
-md-5 = "0.10"
-socket2 = { version = "0.6.1", features = ["all"] }
-chrono = "0.4"
-rand = "0.9.1"
-base64 = "0.22.1"
-hmac = "0.12"
+sha-1 = "0.10"
 sha2 = "0.10"
+socket2 = {version = "0.6.1", features = ["all"]}
 stringprep = "0.1"
 subtle = "2"
-nix = { version = "0.30.1", features = ["process", "signal"] }
-sha-1 = "0.10"
-lru = "0.16.3"
-scopeguard = "1.2"
-parking_lot = {version = "0.12.1", features = ["hardware-lock-elision"]}
-libc = "0.2.172"
-include_dir = "0.7"
-num_cpus = "1.16.0"
 syslog = "7.0.0"
-native-tls = { version = "0.2.14" }
-tokio-native-tls = { version = "0.3.1" }
-serde-toml-merge = { version = "0.3.8"}
-jwt = { version = "0.16.0", features = ["openssl"] }
+tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}
+tikv-jemallocator = {version = "0.6.0", features = ["background_threads_runtime_support"]}
+tokio = {version = "1.48.4", features = ["rt-multi-thread", "fs", "parking_lot", "sync", "io-util", "net", "macros", "signal", "time"]}
+tokio-native-tls = {version = "0.3.1"}
+toml = "0.8"
+tracing = "0.1.37"
+tracing-subscriber = {version = "0.3.20", features = ["json", "env-filter", "std"]}
 # `jwt` (above) is shared with the web UI SSO flow. Both code paths
 # verify RS256 against an RSA public key loaded through openssl, so
 # adding a second JWT crate would only duplicate functionality and
 # pull extra transitive licenses (ring, ISC) into the vendor set.
-thiserror = "1"
-openssl = { version = "0.10.78" }
-openssl-sys = { version = "0.9.114" }
-iota = { version = "0.2.3" }
+iota = {version = "0.2.3"}
+openssl = {version = "0.10.78"}
+openssl-sys = {version = "0.9.114"}
+pam-client = {version = "0.5.0", optional = true}
 pin-project-lite = "0.2.16"
-pam-client = { version =  "0.5.0", optional = true }
 postgres = "0.19.10"
+thiserror = "1"
 # `with-serde_json-1` lets `Row::try_get` decode `json`/`jsonb`
 # columns directly into `serde_json::Value`, which allows auth_query
 # startup_parameters to come from a native JSON column.
-tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
-postgres-native-tls = "0.5.1"
-flate2 = "1.0.28"
-sd-notify = "0.4"
-zerocopy = "0.8.24"
-xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 ahash = "0.8"
-smallvec = "1.13"
 dashmap = "6.1"
-reqwest = { version = "0.11", features = ["json"] }
+flate2 = "1.0.28"
 futures = "0.3"
 hdrhistogram = "7.5"
+postgres-native-tls = "0.5.1"
+reqwest = {version = "0.11", features = ["json"]}
+sd-notify = "0.4"
+smallvec = "1.13"
+tokio-postgres = {version = "0.7", features = ["with-serde_json-1"]}
+xxhash-rust = {version = "0.8.15", features = ["xxh3"]}
+zerocopy = "0.8.24"
 
 [patch.crates-io]
-native-tls = { path = "patches/rust-native-tls" }
-tokio-native-tls = { path = "patches/tokio-native-tls" }
-openssl-src = { path = "patches/openssl-src" }
+native-tls = {path = "patches/rust-native-tls"}
+openssl-src = {path = "patches/openssl-src"}
+tokio-native-tls = {path = "patches/tokio-native-tls"}
 
 [dev-dependencies]
-cucumber = "0.21"
-tempfile = "3"
-portpicker = "0.1"
-tokio-postgres = "0.7"
 criterion = "0.5"
-pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
-serial_test = "3"
+cucumber = "0.21"
+portpicker = "0.1"
+pprof = {version = "0.14", features = ["flamegraph", "criterion"]}
 regex = "1"
+serial_test = "3"
+tempfile = "3"
+tokio-postgres = "0.7"
 
 [[bin]]
 name = "pg_doorman"
@@ -112,38 +111,38 @@ name = "metrics_stress"
 path = "src/bin/metrics_stress.rs"
 
 [[test]]
-name = "bdd"
 harness = false
+name = "bdd"
 path = "tests/bdd/main.rs"
 
 [[test]]
-name = "patroni_proxy_bdd"
 harness = false
+name = "patroni_proxy_bdd"
 path = "src/bin/patroni_proxy/tests/bdd/main.rs"
 
 [[bench]]
+harness = false
 name = "hash_benchmarks"
-harness = false
 
 [[bench]]
+harness = false
 name = "cache_benchmarks"
-harness = false
 
 [[bench]]
+harness = false
 name = "coordinator_benchmarks"
-harness = false
 
 [[bench]]
+harness = false
 name = "log_benchmarks"
-harness = false
 
 [[bench]]
+harness = false
 name = "memory_benchmarks"
-harness = false
 
 [[bench]]
-name = "pool_anticipation_benchmarks"
 harness = false
+name = "pool_anticipation_benchmarks"
 
 [features]
 default = []

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### 3.11.1
+
+#### Pool-level `sync_server_parameters` override
+
+`sync_server_parameters` can now be set per pool in addition to the global
+`[general]` section. When a pool defines `sync_server_parameters = true`,
+client-sent session parameters (e.g. `search_path`, `work_mem`,
+`statement_timeout`) are applied via `SET` queries on checkout for that pool only. When omitted at pool level, the global setting is used.
+
+```toml
+[general]
+sync_server_parameters = false  # global default
+
+[pools.synced_db]
+sync_server_parameters = true   # override for this pool
+```
+
 ### 3.11.0
 
 #### Talos can route through client-specific pools

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -18,6 +18,13 @@ Changing `sync_server_parameters` via RELOAD takes effect immediately for new ch
 Pool connections are recreated with the updated setting. In-flight transactions are not affected - they continue with the server they were
 assigned at checkout time.
 
+Prepared statements compiled before a RELOAD retain their original schema
+resolution. When `sync_server_parameters` is enabled, a `PREPARE` resolves
+table references against the client's `search_path` at prepare time. If the
+configuration is subsequently reloaded and `sync_server_parameters` is
+disabled, the prepared statement still targets the original schema — the
+query tree is fixed at compile time by PostgreSQL.
+
 ```toml
 [general]
 sync_server_parameters = false  # global default

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -9,6 +9,15 @@
 client-sent session parameters (e.g. `search_path`, `work_mem`,
 `statement_timeout`) are applied via `SET` queries on checkout for that pool only. When omitted at pool level, the global setting is used.
 
+Enabling `sync_server_parameters` adds a round-trip to PostgreSQL on every
+checkout where client parameters differ from the backend defaults. This
+increases total query count and can affect TPS under high concurrency.
+Enable it only for pools that really need per-client session parameters.
+
+Changing `sync_server_parameters` via RELOAD takes effect immediately for new checkouts. 
+Pool connections are recreated with the updated setting. In-flight transactions are not affected - they continue with the server they were
+assigned at checkout time.
+
 ```toml
 [general]
 sync_server_parameters = false  # global default

--- a/documentation/en/src/changelog.md
+++ b/documentation/en/src/changelog.md
@@ -13,17 +13,19 @@ Enabling `sync_server_parameters` adds a round-trip to PostgreSQL on every
 checkout where client parameters differ from the backend defaults. This
 increases total query count and can affect TPS under high concurrency.
 Enable it only for pools that really need per-client session parameters.
+Note that parameters sent via libpq `options=-c ...` (`lock_timeout`, `statement_timeout`,
+`idle_in_transaction_session_timeout`, etc.) are not applied on the
+backend when `sync_server_parameters` is disabled.
 
 Changing `sync_server_parameters` via RELOAD takes effect immediately for new checkouts. 
-Pool connections are recreated with the updated setting. In-flight transactions are not affected - they continue with the server they were
-assigned at checkout time.
+Pool connections are recreated with the updated setting. In-flight transactions are not affected -
+they continue with the server they were assigned at checkout time.
 
-Prepared statements compiled before a RELOAD retain their original schema
-resolution. When `sync_server_parameters` is enabled, a `PREPARE` resolves
-table references against the client's `search_path` at prepare time. If the
-configuration is subsequently reloaded and `sync_server_parameters` is
-disabled, the prepared statement still targets the original schema — the
-query tree is fixed at compile time by PostgreSQL.
+In-flight backend connections retain the `search_path` that was SET at
+checkout, so a prepared statement compiled before RELOAD continues to
+target the same schema. New connections that checkout after RELOAD may
+have a different `search_path`, which causes PostgreSQL to re-plan the
+prepared statement against the new schema resolution.
 
 ```toml
 [general]

--- a/pg_doorman.toml
+++ b/pg_doorman.toml
@@ -564,6 +564,10 @@ pool_mode = "transaction"
 # Default: true
 cleanup_server_connections = true
 
+# Override global sync_server_parameters for this pool.
+# Default: None (uses global setting)
+# sync_server_parameters = false
+
 # Override global prepared_statements_cache_size for this pool.
 # prepared_statements_cache_size = 8192
 

--- a/pg_doorman.yaml
+++ b/pg_doorman.yaml
@@ -611,6 +611,10 @@ pools:
     # Default: true
     cleanup_server_connections: true
 
+    # Override global sync_server_parameters for this pool.
+    # Default: None (uses global setting)
+    # sync_server_parameters: false
+
     # Override global prepared_statements_cache_size for this pool.
     # prepared_statements_cache_size: 8192
 

--- a/src/app/generate/annotated.rs
+++ b/src/app/generate/annotated.rs
@@ -175,6 +175,7 @@ pub fn generate_reference_config(format: ConfigFormat, russian: bool) -> String 
         server_tls_certificate: None,
         server_tls_private_key: None,
         auth_query: None,
+        sync_server_parameters: None,
         startup_parameters: std::collections::BTreeMap::new(),
         users: vec![User {
             username: "app_user".to_string(),

--- a/src/app/generate/annotated.rs
+++ b/src/app/generate/annotated.rs
@@ -1386,6 +1386,14 @@ fn write_single_pool(w: &mut ConfigWriter, pool_name: &str, pool: &Pool) {
     );
     w.blank();
 
+    write_field_comment(w, fi, "pool", "sync_server_parameters");
+    if let Some(val) = pool.sync_server_parameters {
+        w.kv(fi, "sync_server_parameters", &w.bool_val(val));
+    } else {
+        w.commented_kv(fi, "sync_server_parameters", "false");
+    }
+    w.blank();
+
     write_field_desc(w, fi, "pool", "prepared_statements_cache_size");
     if let Some(val) = pool.prepared_statements_cache_size {
         w.kv(fi, "prepared_statements_cache_size", &w.num_val(val));

--- a/src/app/generate/docs.rs
+++ b/src/app/generate/docs.rs
@@ -293,6 +293,7 @@ fn write_pool_fields(out: &mut String, f: &FieldsData) {
         "reserve_pool_size",
         "reserve_pool_timeout",
         "min_guaranteed_pool_size",
+        "sync_server_parameters",
         "startup_parameters",
     ];
 

--- a/src/app/generate/fields.yaml
+++ b/src/app/generate/fields.yaml
@@ -1370,6 +1370,13 @@ fields:
       doc: "Close server connections in this pool that have been opened for longer than this value, in milliseconds. Only applied to idle connections. If not specified, the global server_lifetime setting is used."
       default: "None (uses global setting)"
 
+    sync_server_parameters:
+      config:
+        en: "Override global sync_server_parameters for this pool."
+        ru: "Переопределить глобальный sync_server_parameters для этого пула."
+      doc: "Override global sync_server_parameters for this pool. When enabled, client-sent session parameters (e.g. search_path, work_mem) are applied via SET queries on checkout. If not specified, the global setting is used."
+      default: "None (uses global setting)"
+
     cleanup_server_connections:
       config:
         en: |

--- a/src/app/generate/mod.rs
+++ b/src/app/generate/mod.rs
@@ -168,6 +168,7 @@ pub fn generate_config_with_client(
                     server_tls_certificate: None,
                     server_tls_private_key: None,
                     auth_query: None,
+                    sync_server_parameters: None,
                     startup_parameters: std::collections::BTreeMap::new(),
                     users: users.clone(),
                 },

--- a/src/app/generate/tests.rs
+++ b/src/app/generate/tests.rs
@@ -86,6 +86,7 @@ pub fn generate_config_with_client<
                         server_tls_certificate: None,
                         server_tls_private_key: None,
                         auth_query: None,
+                        sync_server_parameters: None,
                         patroni_api_urls: None,
                         fallback_cooldown: None,
                         patroni_api_timeout: None,

--- a/src/config/pool.rs
+++ b/src/config/pool.rs
@@ -176,6 +176,9 @@ pub struct Pool {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_query: Option<AuthQueryConfig>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_server_parameters: Option<bool>,
+
     /// Pool-level PostgreSQL configuration parameters added to backend
     /// `StartupMessage`s. These values override general settings per key;
     /// passthrough `auth_query` rows can override them per user. Config
@@ -471,6 +474,7 @@ impl Default for Pool {
             server_tls_certificate: None,
             server_tls_private_key: None,
             auth_query: None,
+            sync_server_parameters: None,
             startup_parameters: std::collections::BTreeMap::new(),
         }
     }

--- a/src/config/pool.rs
+++ b/src/config/pool.rs
@@ -174,10 +174,10 @@ pub struct Pool {
     pub server_tls_private_key: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auth_query: Option<AuthQueryConfig>,
+    pub sync_server_parameters: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sync_server_parameters: Option<bool>,
+    pub auth_query: Option<AuthQueryConfig>,
 
     /// Pool-level PostgreSQL configuration parameters added to backend
     /// `StartupMessage`s. These values override general settings per key;
@@ -203,6 +203,13 @@ impl Pool {
         let mut s = DefaultHasher::new();
         self.hash(&mut s);
         s.finish()
+    }
+
+    /// Return the effective `sync_server_parameters` flag by falling back
+    /// to the global default when the pool-level override is `None`.
+    pub fn effective_sync_server_parameters(&self, general: &super::General) -> bool {
+        self.sync_server_parameters
+            .unwrap_or(general.sync_server_parameters)
     }
 
     pub fn default_pool_mode() -> PoolMode {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 use serial_test::serial;
-use std::io::Write;
+use std::{assert_eq, io::Write};
 use tempfile::NamedTempFile;
 
 // Helper function to create a temporary config file for testing
@@ -2101,4 +2101,104 @@ async fn reject_merged_general_pool_startup_parameters_overflow() {
         ),
         other => panic!("expected BadConfig, got {other:?}"),
     }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_server_parameters_pool_override_true() {
+    let config_content = r#"
+[general]
+host = "127.0.0.1"
+port = 6432
+admin_username = "admin"
+admin_password = "admin_password"
+sync_server_parameters = false
+
+[pools.mydb]
+server_host = "localhost"
+server_port = 5432
+sync_server_parameters = true
+
+[[pools.mydb.users]]
+username = "user1"
+password = "pass1"
+pool_size = 10
+"#;
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(config_content.as_bytes()).unwrap();
+    temp_file.flush().unwrap();
+
+    let file_path = temp_file.path().to_str().unwrap();
+    parse(file_path).await.unwrap();
+
+    let config = get_config();
+    assert!(!config.general.sync_server_parameters);
+    let pool = &config.pools["mydb"];
+    assert_eq!(pool.sync_server_parameters, Some(true));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_server_parameters_pool_declared_only_for_pool() {
+    let config_content = r#"
+[general]
+host = "127.0.0.1"
+port = 6432
+admin_username = "admin"
+admin_password = "admin_password"
+
+[pools.mydb]
+server_host = "localhost"
+server_port = 5432
+sync_server_parameters = true
+
+[[pools.mydb.users]]
+username = "user1"
+password = "pass1"
+pool_size = 10
+"#;
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(config_content.as_bytes()).unwrap();
+    temp_file.flush().unwrap();
+
+    let file_path = temp_file.path().to_str().unwrap();
+    parse(file_path).await.unwrap();
+
+    let config = get_config();
+    assert!(!config.general.sync_server_parameters);
+    let pool = &config.pools["mydb"];
+    assert_eq!(pool.sync_server_parameters, Some(true));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_server_parameters_pool_declared_only_for_general() {
+    let config_content = r#"
+[general]
+host = "127.0.0.1"
+port = 6432
+admin_username = "admin"
+admin_password = "admin_password"
+sync_server_parameters = true
+
+[pools.mydb]
+server_host = "localhost"
+server_port = 5432
+
+[[pools.mydb.users]]
+username = "user1"
+password = "pass1"
+pool_size = 10
+"#;
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(config_content.as_bytes()).unwrap();
+    temp_file.flush().unwrap();
+
+    let file_path = temp_file.path().to_str().unwrap();
+    parse(file_path).await.unwrap();
+
+    let config = get_config();
+    assert!(config.general.sync_server_parameters);
+    let pool = &config.pools["mydb"];
+    assert_eq!(pool.sync_server_parameters, None);
 }

--- a/src/pool/dynamic.rs
+++ b/src/pool/dynamic.rs
@@ -255,9 +255,7 @@ pub fn create_dynamic_pool(
             life_time_ms: pool_config
                 .server_lifetime
                 .unwrap_or(config.general.server_lifetime.as_millis()),
-            sync_server_parameters: pool_config
-                .sync_server_parameters
-                .unwrap_or(config.general.sync_server_parameters),
+            sync_server_parameters: pool_config.effective_sync_server_parameters(&config.general),
             min_guaranteed_pool_size: pool_config.min_guaranteed_pool_size.unwrap_or(0),
         },
         prepared_statement_cache: match config.general.prepared_statements {

--- a/src/pool/dynamic.rs
+++ b/src/pool/dynamic.rs
@@ -255,7 +255,9 @@ pub fn create_dynamic_pool(
             life_time_ms: pool_config
                 .server_lifetime
                 .unwrap_or(config.general.server_lifetime.as_millis()),
-            sync_server_parameters: config.general.sync_server_parameters,
+            sync_server_parameters: pool_config
+                .sync_server_parameters
+                .unwrap_or(config.general.sync_server_parameters),
             min_guaranteed_pool_size: pool_config.min_guaranteed_pool_size.unwrap_or(0),
         },
         prepared_statement_cache: match config.general.prepared_statements {

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -627,7 +627,7 @@ impl ConnectionPool {
                         life_time_ms: pool_config
                             .server_lifetime
                             .unwrap_or(config.general.server_lifetime.as_millis()),
-                        sync_server_parameters: config.general.sync_server_parameters,
+                        sync_server_parameters: pool_config.sync_server_parameters.unwrap_or(config.general.sync_server_parameters),
                         min_guaranteed_pool_size: pool_config.min_guaranteed_pool_size.unwrap_or(0),
                     },
                     prepared_statement_cache: match config.general.prepared_statements {
@@ -850,7 +850,7 @@ impl ConnectionPool {
                                 life_time_ms: pool_config
                                     .server_lifetime
                                     .unwrap_or(config.general.server_lifetime.as_millis()),
-                                sync_server_parameters: config.general.sync_server_parameters,
+                                sync_server_parameters: pool_config.sync_server_parameters.unwrap_or(config.general.sync_server_parameters),
                                 min_guaranteed_pool_size: pool_config
                                     .min_guaranteed_pool_size
                                     .unwrap_or(0),

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -406,10 +406,11 @@ impl ConnectionPool {
         }
 
         // Hashing each pool's effective config against (Pool, general
-        // startup_parameters baseline) folds general-level GUC changes into
-        // the same reuse decision pg_doorman already uses for pool-level
-        // changes. Without this, a SIGHUP that only edits
-        // `general.startup_parameters` would leave every idle backend
+        // startup_parameters baseline + sync_server_parameters) folds
+        // general-level GUC changes into the same reuse decision pg_doorman
+        // already uses for pool-level changes. Without this, a SIGHUP that
+        // only edits `general.startup_parameters` or
+        // `general.sync_server_parameters` would leave every idle backend
         // pinned to the previous `reset_val` until the connection rotates
         // through `lifetime_ms`, so clients would see mixed defaults from
         // the same pool depending on which backend they got.
@@ -417,6 +418,7 @@ impl ConnectionPool {
             use std::hash::{Hash, Hasher};
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             config.general.startup_parameters.hash(&mut hasher);
+            config.general.sync_server_parameters.hash(&mut hasher);
             hasher.finish()
         };
         // Load only; the hash is not advanced until the new pool map has
@@ -627,7 +629,7 @@ impl ConnectionPool {
                         life_time_ms: pool_config
                             .server_lifetime
                             .unwrap_or(config.general.server_lifetime.as_millis()),
-                        sync_server_parameters: pool_config.sync_server_parameters.unwrap_or(config.general.sync_server_parameters),
+                        sync_server_parameters: pool_config.effective_sync_server_parameters(&config.general),
                         min_guaranteed_pool_size: pool_config.min_guaranteed_pool_size.unwrap_or(0),
                     },
                     prepared_statement_cache: match config.general.prepared_statements {
@@ -827,7 +829,13 @@ impl ConnectionPool {
                             })
                             .build();
 
-                        let new_pool_hash_value = pool_config.hash_value();
+                        let new_pool_hash_value = {
+                            use std::hash::Hasher;
+                            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                            hasher.write_u64(pool_config.hash_value());
+                            hasher.write_u64(general_startup_hash);
+                            hasher.finish()
+                        };
                         let conn_pool = ConnectionPool {
                             database: pool,
                             address,
@@ -850,7 +858,7 @@ impl ConnectionPool {
                                 life_time_ms: pool_config
                                     .server_lifetime
                                     .unwrap_or(config.general.server_lifetime.as_millis()),
-                                sync_server_parameters: pool_config.sync_server_parameters.unwrap_or(config.general.sync_server_parameters),
+                                sync_server_parameters: pool_config.effective_sync_server_parameters(&config.general),
                                 min_guaranteed_pool_size: pool_config
                                     .min_guaranteed_pool_size
                                     .unwrap_or(0),
@@ -1247,6 +1255,7 @@ pub fn get_coordinator(db: &str) -> Option<Arc<pool_coordinator::PoolCoordinator
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Pool as ConfigPool;
 
     #[test]
     fn pool_exists_returns_false_for_missing_entry() {
@@ -1459,5 +1468,179 @@ mod tests {
     fn anon_cache_explicit_zero_disables_lru_regardless_of_pool() {
         let g = General::test_with_cache_sizes(8192, Some(0));
         assert_eq!(resolve_client_anon_cache_size_inner(&g, Some(1024)), 0);
+    }
+
+    // --- sync_server_parameters reload tests ---
+
+    #[test]
+    fn effective_sync_server_parameters_uses_pool_override_when_set() {
+        let general = General::default();
+        let pool = ConfigPool {
+            sync_server_parameters: Some(true),
+            ..Default::default()
+        };
+        assert!(pool.effective_sync_server_parameters(&general));
+    }
+
+    #[test]
+    fn effective_sync_server_parameters_falls_back_to_general_when_none() {
+        let mut general = General::default();
+        general.sync_server_parameters = true;
+        let pool = ConfigPool {
+            sync_server_parameters: None,
+            ..Default::default()
+        };
+        assert!(pool.effective_sync_server_parameters(&general));
+    }
+
+    #[test]
+    fn effective_sync_server_parameters_false_general_false_pool_none() {
+        let general = General::default(); // sync_server_parameters defaults to false
+        let pool = ConfigPool {
+            sync_server_parameters: None,
+            ..Default::default()
+        };
+        assert!(!pool.effective_sync_server_parameters(&general));
+    }
+
+    #[test]
+    fn effective_sync_server_parameters_pool_override_wins_over_general() {
+        let mut general = General::default();
+        general.sync_server_parameters = true;
+        let pool = ConfigPool {
+            sync_server_parameters: Some(false),
+            ..Default::default()
+        };
+        // Pool override (false) wins over general (true)
+        assert!(!pool.effective_sync_server_parameters(&general));
+    }
+
+    fn compute_general_startup_hash(general: &General) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        general.startup_parameters.hash(&mut hasher);
+        general.sync_server_parameters.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn compute_pool_fingerprint(pool: &ConfigPool, general: &General) -> u64 {
+        use std::hash::Hasher;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hasher.write_u64(pool.hash_value());
+        hasher.write_u64(compute_general_startup_hash(general));
+        hasher.finish()
+    }
+
+    #[test]
+    fn reload_sync_server_parameters_false_to_true_changes_general_startup_hash() {
+        let mut general_before = General::default();
+        general_before.sync_server_parameters = false;
+        let mut general_after = General::default();
+        general_after.sync_server_parameters = true;
+        assert_ne!(
+            compute_general_startup_hash(&general_before),
+            compute_general_startup_hash(&general_after),
+            "Changing general.sync_server_parameters must change the general_startup_hash"
+        );
+    }
+
+    #[test]
+    fn reload_sync_server_parameters_true_to_false_changes_general_startup_hash() {
+        let mut general_before = General::default();
+        general_before.sync_server_parameters = true;
+        let mut general_after = General::default();
+        general_after.sync_server_parameters = false;
+        assert_ne!(
+            compute_general_startup_hash(&general_before),
+            compute_general_startup_hash(&general_after),
+            "Changing general.sync_server_parameters must change the general_startup_hash"
+        );
+    }
+
+    #[test]
+    fn reload_general_sync_server_parameters_changes_static_pool_fingerprint() {
+        let pool = ConfigPool::default();
+        let mut general_before = General::default();
+        general_before.sync_server_parameters = false;
+        let mut general_after = General::default();
+        general_after.sync_server_parameters = true;
+        assert_ne!(
+            compute_pool_fingerprint(&pool, &general_before),
+            compute_pool_fingerprint(&pool, &general_after),
+            "Changing general.sync_server_parameters must invalidate static pool fingerprint"
+        );
+    }
+
+    #[test]
+    fn reload_general_sync_server_parameters_changes_auth_query_parent_fingerprint() {
+        let pool = ConfigPool::default();
+        let mut general_before = General::default();
+        general_before.sync_server_parameters = false;
+        let mut general_after = General::default();
+        general_after.sync_server_parameters = true;
+        // parent_fingerprint = pool_config.hash_value() ^ general_startup_hash
+        let fp_before = pool.hash_value() ^ compute_general_startup_hash(&general_before);
+        let fp_after = pool.hash_value() ^ compute_general_startup_hash(&general_after);
+        assert_ne!(
+            fp_before, fp_after,
+            "Changing general.sync_server_parameters must invalidate auth_query parent_fingerprint"
+        );
+    }
+
+    #[test]
+    fn reload_pool_sync_server_parameters_none_to_true_changes_fingerprint() {
+        let mut general = General::default();
+        general.sync_server_parameters = false;
+        let pool_before = ConfigPool {
+            sync_server_parameters: None,
+            ..Default::default()
+        };
+        let pool_after = ConfigPool {
+            sync_server_parameters: Some(true),
+            ..Default::default()
+        };
+        assert_ne!(
+            compute_pool_fingerprint(&pool_before, &general),
+            compute_pool_fingerprint(&pool_after, &general),
+            "Setting pool.sync_server_parameters must change fingerprint"
+        );
+    }
+
+    #[test]
+    fn reload_no_change_preserves_fingerprint() {
+        let general = General::default();
+        let pool = ConfigPool::default();
+        assert_eq!(
+            compute_pool_fingerprint(&pool, &general),
+            compute_pool_fingerprint(&pool, &general),
+            "Same config must produce identical fingerprint"
+        );
+    }
+
+    #[test]
+    fn reload_unchanged_sync_server_parameters_preserves_fingerprint() {
+        let mut general = General::default();
+        general.sync_server_parameters = true;
+        let pool = ConfigPool {
+            sync_server_parameters: Some(true),
+            ..Default::default()
+        };
+        // Pool-level override is set; general value is different but
+        // pool override wins, so effective value is the same.
+        let mut general2 = General::default();
+        general2.sync_server_parameters = false;
+        let pool2 = ConfigPool {
+            sync_server_parameters: Some(true),
+            ..Default::default()
+        };
+        // general changed, but pool override is the same → fingerprint
+        // still changes because general_startup_hash is part of it.
+        // This is expected: the fingerprint detects ANY general change,
+        // even if the effective value is unchanged. This is a safe
+        // over-rebuild rather than under-rebuild.
+        assert_ne!(
+            compute_pool_fingerprint(&pool, &general),
+            compute_pool_fingerprint(&pool2, &general2),
+        );
     }
 }

--- a/tests/bdd/features/sync-server-parameters.feature
+++ b/tests/bdd/features/sync-server-parameters.feature
@@ -197,6 +197,87 @@ Feature: Pool-level sync_server_parameters override
       """
     Then the command should fail
 
+  Scenario: Extended protocol prepared statements resolve correct schema with different search_path
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = false
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL_BASE="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable"
+      cd tests/go && go test -v -run Test_ExtendedProtocolPreparedStatementDifferentSchemas ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_ExtendedProtocolPreparedStatementDifferentSchemas"
+
+  Scenario: Prepared INSERT targets bucket_0 before RELOAD, stays in bucket_0 after RELOAD
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Overwrite config: remove sync_server_parameters (defaults to false).
+    When we overwrite pg_doorman config file with:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Go test: prepare INSERT → RELOAD → execute → verify bucket_0 → new connection → verify public.
+    When I run shell command:
+      """
+      export DATABASE_URL_BASE="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable"
+      export DOORMAN_PORT="${DOORMAN_PORT}"
+      cd tests/go && go test -v -run Test_PreparedInsertTargetsCorrectSchemaAfterReload ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_PreparedInsertTargetsCorrectSchemaAfterReload"
+
   Scenario: Different clients send different search_path to the same pool
     Given pg_doorman started with config:
       """

--- a/tests/bdd/features/sync-server-parameters.feature
+++ b/tests/bdd/features/sync-server-parameters.feature
@@ -278,6 +278,57 @@ Feature: Pool-level sync_server_parameters override
     Then the command should succeed
     And the command output should contain "PASS: Test_PreparedInsertTargetsCorrectSchemaAfterReload"
 
+  Scenario: Pool-level sync_server_parameters RELOAD removes search_path from in-flight backend
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Overwrite config: remove pool-level sync_server_parameters (defaults to false).
+    When we overwrite pg_doorman config file with:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Go test: prepare INSERT → RELOAD → execute → verify bucket_0 → new connection → verify public.
+    When I run shell command:
+      """
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      export DOORMAN_PORT="${DOORMAN_PORT}"
+      cd tests/go && go test -v -run Test_PreparedInsertTargetsCorrectSchemaAfterPoolLevelReload ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_PreparedInsertTargetsCorrectSchemaAfterPoolLevelReload"
+
   Scenario: Different clients send different search_path to the same pool
     Given pg_doorman started with config:
       """
@@ -334,3 +385,54 @@ Feature: Pool-level sync_server_parameters override
       cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should fail
+
+  Scenario: Enabling general.sync_server_parameters via RELOAD activates parameter syncing
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Overwrite config: add sync_server_parameters = true in [general].
+    When we overwrite pg_doorman config file with:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = true
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    # Go test: INSERT before RELOAD → public; RELOAD enables sync; INSERT after → bucket_0.
+    When I run shell command:
+      """
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      export DOORMAN_PORT="${DOORMAN_PORT}"
+      cd tests/go && go test -v -run Test_SyncServerParametersActivatedAfterReload ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_SyncServerParametersActivatedAfterReload"

--- a/tests/bdd/features/sync-server-parameters.feature
+++ b/tests/bdd/features/sync-server-parameters.feature
@@ -271,7 +271,7 @@ Feature: Pool-level sync_server_parameters override
     # Go test: prepare INSERT → RELOAD → execute → verify bucket_0 → new connection → verify public.
     When I run shell command:
       """
-      export DATABASE_URL_BASE="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable"
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
       export DOORMAN_PORT="${DOORMAN_PORT}"
       cd tests/go && go test -v -run Test_PreparedInsertTargetsCorrectSchemaAfterReload ./sync-parameters
       """

--- a/tests/bdd/features/sync-server-parameters.feature
+++ b/tests/bdd/features/sync-server-parameters.feature
@@ -40,11 +40,11 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should succeed
-    And the command output should contain "PASS: Test_SyncServerParameters"
+    And the command output should contain "PASS: Test_SyncServerParametersWithSearchPath"
 
   Scenario: Pool with sync_server_parameters=false ignores client search_path
     Given pg_doorman started with config:
@@ -70,8 +70,8 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should fail
 
@@ -98,11 +98,11 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should succeed
-    And the command output should contain "PASS: Test_SyncServerParameters"
+    And the command output should contain "PASS: Test_SyncServerParametersWithSearchPath"
 
   Scenario: sync_server_parameters is empty in general and declared for one database
     Given pg_doorman started with config:
@@ -127,11 +127,11 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should succeed
-    And the command output should contain "PASS: Test_SyncServerParameters"
+    And the command output should contain "PASS: Test_SyncServerParametersWithSearchPath"
 
   Scenario: sync_server_parameters is empty in general and declared for two databases
     Given pg_doorman started with config:
@@ -177,25 +177,55 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should succeed
-    And the command output should contain "PASS: Test_SyncServerParameters"
+    And the command output should contain "PASS: Test_SyncServerParametersWithSearchPath"
 
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/another_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/another_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should fail
 
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/other_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/other_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should fail
+
+  Scenario: Different clients send different search_path to the same pool
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = false
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL_BASE="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable"
+      cd tests/go && go test -v -run Test_DifferentSearchPathsInSamePool ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_DifferentSearchPathsInSamePool"
 
   Scenario: sync_server_parameters is not declared
     Given pg_doorman started with config:
@@ -219,7 +249,7 @@ Feature: Pool-level sync_server_parameters override
       """
     When I run shell command:
       """
-      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
-      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      export DATABASE_URL_WITH_SEARCH_PATH="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParametersWithSearchPath ./sync-parameters
       """
     Then the command should fail

--- a/tests/bdd/features/sync-server-parameters.feature
+++ b/tests/bdd/features/sync-server-parameters.feature
@@ -1,0 +1,225 @@
+@go @sync-server-parameters
+Feature: Pool-level sync_server_parameters override
+  Test that pool-level sync_server_parameters override applies
+  client-sent session parameters on checkout.
+
+  Background:
+    Given PostgreSQL started with pg_hba.conf:
+      """
+      local   all             all                                     trust
+      host    all             all             127.0.0.1/32            trust
+      host    all             all             ::1/128                 trust
+      """
+    And fixtures from "tests/fixture.sql" applied
+    And pg_doorman hba file contains:
+      """
+      host all all 127.0.0.1/32 md5
+      """
+
+  Scenario: Pool with sync_server_parameters=true applies client search_path
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = false
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_SyncServerParameters"
+
+  Scenario: Pool with sync_server_parameters=false ignores client search_path
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = false
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = false
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should fail
+
+  Scenario: General sync_server_parameters=true applies client search_path
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+      sync_server_parameters = true
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_SyncServerParameters"
+
+  Scenario: sync_server_parameters is empty in general and declared for one database
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_SyncServerParameters"
+
+  Scenario: sync_server_parameters is empty in general and declared for two databases
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = true
+
+      [pools.other_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+      sync_server_parameters = false
+
+      [pools.another_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+
+      [[pools.another_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+
+      [[pools.other_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should succeed
+    And the command output should contain "PASS: Test_SyncServerParameters"
+
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/another_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should fail
+
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/other_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should fail
+
+  Scenario: sync_server_parameters is not declared
+    Given pg_doorman started with config:
+      """
+      [general]
+      host = "127.0.0.1"
+      port = ${DOORMAN_PORT}
+      admin_username = "admin"
+      admin_password = "admin"
+      pg_hba = {path = "${DOORMAN_HBA_FILE}"}
+
+      [pools.example_db]
+      server_host = "127.0.0.1"
+      server_port = ${PG_PORT}
+      pool_mode = "transaction"
+
+      [[pools.example_db.users]]
+      username = "example_user_1"
+      password = "md58a67a0c805a5ee0384ea28e0dea557b6"
+      pool_size = 10
+      """
+    When I run shell command:
+      """
+      export DATABASE_URL="postgresql://example_user_1:test@127.0.0.1:${DOORMAN_PORT}/example_db?sslmode=disable&search_path=bucket_0"
+      cd tests/go && go test -v -run Test_SyncServerParameters ./sync-parameters
+      """
+    Then the command should fail

--- a/tests/go/sync-parameters/extended_protocol_test.go
+++ b/tests/go/sync-parameters/extended_protocol_test.go
@@ -120,10 +120,8 @@ func Test_PreparedInsertTargetsCorrectSchemaAfterReload(t *testing.T) {
 	require.NoError(t, err)
 	adminDB.Close()
 
-	// Execute the prepared INSERT.
-	// The statement was compiled BEFORE RELOAD with search_path = bucket_0,
-	// so it targets bucket_0.items regardless of sync_server_parameters being off now
-	_, err = conn.Exec(ctx, "INSERT INTO items (id, val) VALUES ($1, $2)", 1, "test")
+	// Execute the prepared statement.
+	_, err = conn.Exec(ctx, "insert_item", 1, "test")
 	require.NoError(t, err)
 
 	// Verify: row in bucket_0.items, public.items is empty.
@@ -137,6 +135,79 @@ func Test_PreparedInsertTargetsCorrectSchemaAfterReload(t *testing.T) {
 	assert.Equal(t, 0, count, "public.items should be empty")
 
 	// New connection after RELOAD: sync_server_parameters is off,
+	// search_path is NOT synced, so INSERT goes to default (public).
+	afterReloadConn, err := pgx.Connect(ctx, dsnWithSearchPath)
+	require.NoError(t, err)
+	defer afterReloadConn.Close(ctx)
+
+	_, err = afterReloadConn.Exec(ctx, "INSERT INTO items (id, val) VALUES ($1, $2)", 2, "test2")
+	require.NoError(t, err)
+
+	err = afterReloadConn.QueryRow(ctx, "SELECT count(*) FROM public.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "new row should be in public.items")
+
+	err = afterReloadConn.QueryRow(ctx, "SELECT count(*) FROM bucket_0.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "bucket_0.items should still have 1 row")
+}
+
+// Test_PreparedInsertTargetsCorrectSchemaAfterPoolLevelReload verifies that
+// when sync_server_parameters is enabled at the pool level, a PREPARE binds
+// to the client's search_path. After RELOAD removes the pool-level override
+// (effective value becomes false), the in-flight backend still carries the
+// old search_path, so the named prepared statement resolves to the same
+// bucket_0 target. A new connection after RELOAD gets the default search_path
+// and INSERT goes to public.
+func Test_PreparedInsertTargetsCorrectSchemaAfterPoolLevelReload(t *testing.T) {
+	dsnWithSearchPath := os.Getenv("DATABASE_URL_WITH_SEARCH_PATH")
+	adminPort := os.Getenv("DOORMAN_PORT")
+	ctx := context.Background()
+
+	setupBucketTables(t, dsnWithSearchPath)
+
+	conn, err := pgx.Connect(ctx, dsnWithSearchPath)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Prepare INSERT via extended protocol.
+	// Pool-level sync_server_parameters = true, search_path = bucket_0 is
+	// synced, so the statement binds to schema bucket_0.
+	PreparedStatement, err := conn.Prepare(ctx, "insert_item", "INSERT INTO items (id, val) VALUES ($1, $2)")
+	require.NoError(t, err)
+	assert.Equal(t, "insert_item", PreparedStatement.Name)
+
+	// RELOAD: config now has pool-level sync_server_parameters removed
+	// (defaults to false). The pool is rebuilt, but the in-flight backend
+	// connection still carries search_path = bucket_0.
+	adminAddr := fmt.Sprintf("127.0.0.1:%s", adminPort)
+	adminDB, err := sql.Open("postgres", fmt.Sprintf("postgresql://admin:admin@%s/pgbouncer?sslmode=disable", adminAddr))
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	_, err = adminDB.Exec("RELOAD")
+	require.NoError(t, err)
+	adminDB.Close()
+
+	// Execute the prepared INSERT by name.
+	// The in-flight backend retains search_path = bucket_0 from checkout,
+	// so even though pool-level sync_server_parameters is now off, the
+	// backend's search_path has not changed and the re-plan resolves to
+	// the same bucket_0 target.
+	_, err = conn.Exec(ctx, "insert_item", 1, "test")
+	require.NoError(t, err)
+
+	// Verify: row in bucket_0.items, public.items is empty.
+	var count int
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM bucket_0.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "row should be in bucket_0.items (in-flight backend retains search_path)")
+
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM public.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "public.items should be empty")
+
+	// New connection after RELOAD: pool-level sync_server_parameters is off,
 	// search_path is NOT synced, so INSERT goes to default (public).
 	afterReloadConn, err := pgx.Connect(ctx, dsnWithSearchPath)
 	require.NoError(t, err)

--- a/tests/go/sync-parameters/extended_protocol_test.go
+++ b/tests/go/sync-parameters/extended_protocol_test.go
@@ -55,10 +55,6 @@ func setupBucketTables(t *testing.T, dsn string) {
 
 func Test_ExtendedProtocolPreparedStatementDifferentSchemas(t *testing.T) {
 	doormanDSN := os.Getenv("DATABASE_URL_BASE")
-	if doormanDSN == "" {
-		t.Skip("DATABASE_URL_BASE not set")
-	}
-
 	setupTestSchemas(t, doormanDSN)
 
 	ctx := context.Background()
@@ -97,17 +93,12 @@ func Test_ExtendedProtocolPreparedStatementDifferentSchemas(t *testing.T) {
 }
 
 func Test_PreparedInsertTargetsCorrectSchemaAfterReload(t *testing.T) {
-	doormanDSN := os.Getenv("DATABASE_URL_BASE")
+	dsnWithSearchPath := os.Getenv("DATABASE_URL_WITH_SEARCH_PATH")
 	adminPort := os.Getenv("DOORMAN_PORT")
-	if doormanDSN == "" || adminPort == "" {
-		t.Skip("DATABASE_URL_BASE or DOORMAN_PORT not set")
-	}
-
 	ctx := context.Background()
 
-	setupBucketTables(t, doormanDSN)
+	setupBucketTables(t, dsnWithSearchPath)
 
-	dsnWithSearchPath := doormanDSN + "&search_path=bucket_0"
 	conn, err := pgx.Connect(ctx, dsnWithSearchPath)
 	require.NoError(t, err)
 	defer conn.Close(ctx)

--- a/tests/go/sync-parameters/extended_protocol_test.go
+++ b/tests/go/sync-parameters/extended_protocol_test.go
@@ -1,0 +1,164 @@
+package doorman
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestSchemas(t *testing.T, dsn string) {
+	t.Helper()
+	ctx := context.Background()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	for _, s := range []string{"schema_a", "schema_b"} {
+		_, _ = conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+s+" CASCADE")
+		_, err = conn.Exec(ctx, "CREATE SCHEMA "+s)
+		require.NoError(t, err)
+		_, err = conn.Exec(ctx, "CREATE TABLE "+s+".users (id int, name text)")
+		require.NoError(t, err)
+	}
+	_, err = conn.Exec(ctx, "INSERT INTO schema_a.users VALUES (1, 'alice')")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "INSERT INTO schema_b.users VALUES (2, 'bob')")
+	require.NoError(t, err)
+}
+
+func setupBucketTables(t *testing.T, dsn string) {
+	t.Helper()
+	ctx := context.Background()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	_, _ = conn.Exec(ctx, "DROP TABLE IF EXISTS public.items")
+	_, _ = conn.Exec(ctx, "DROP TABLE IF EXISTS bucket_0.items")
+	_, _ = conn.Exec(ctx, "DROP SCHEMA IF EXISTS bucket_0 CASCADE")
+	_, err = conn.Exec(ctx, "CREATE SCHEMA bucket_0")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "CREATE TABLE public.items (id int, val text)")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "CREATE TABLE bucket_0.items (id int, val text)")
+	require.NoError(t, err)
+}
+
+func Test_ExtendedProtocolPreparedStatementDifferentSchemas(t *testing.T) {
+	doormanDSN := os.Getenv("DATABASE_URL_BASE")
+	if doormanDSN == "" {
+		t.Skip("DATABASE_URL_BASE not set")
+	}
+
+	setupTestSchemas(t, doormanDSN)
+
+	ctx := context.Background()
+
+	type testCase struct {
+		searchPath   string
+		expectedID   int
+		expectedName string
+	}
+
+	cases := []testCase{
+		{"schema_a", 1, "alice"},
+		{"schema_b", 2, "bob"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.searchPath, func(t *testing.T) {
+			dsn := doormanDSN + "&search_path=" + tc.searchPath
+			conn, err := pgx.Connect(ctx, dsn)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			rows, err := conn.Query(ctx, "SELECT id, name FROM users")
+			require.NoError(t, err)
+			defer rows.Close()
+
+			require.True(t, rows.Next())
+			var id int
+			var name string
+			require.NoError(t, rows.Scan(&id, &name))
+			assert.Equal(t, tc.expectedID, id)
+			assert.Equal(t, tc.expectedName, name)
+			assert.False(t, rows.Next())
+		})
+	}
+}
+
+func Test_PreparedInsertTargetsCorrectSchemaAfterReload(t *testing.T) {
+	doormanDSN := os.Getenv("DATABASE_URL_BASE")
+	adminPort := os.Getenv("DOORMAN_PORT")
+	if doormanDSN == "" || adminPort == "" {
+		t.Skip("DATABASE_URL_BASE or DOORMAN_PORT not set")
+	}
+
+	ctx := context.Background()
+
+	setupBucketTables(t, doormanDSN)
+
+	dsnWithSearchPath := doormanDSN + "&search_path=bucket_0"
+	conn, err := pgx.Connect(ctx, dsnWithSearchPath)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Prepare INSERT via extended protocol.
+	// sync_server_parameters = true, search_path = bucket_0 is synced,
+	// so the statement uses schema bucket_0
+	PreparedStatement, err := conn.Prepare(ctx, "insert_item", "INSERT INTO items (id, val) VALUES ($1, $2)")
+	require.NoError(t, err)
+	assert.Equal(t, "insert_item", PreparedStatement.Name)
+
+	// Trigger RELOAD for cleaning sync_server_parameters
+	adminAddr := fmt.Sprintf("127.0.0.1:%s", adminPort)
+	adminDB, err := sql.Open("postgres", fmt.Sprintf("postgresql://admin:admin@%s/pgbouncer?sslmode=disable", adminAddr))
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	_, err = adminDB.Exec("RELOAD")
+	require.NoError(t, err)
+	adminDB.Close()
+
+	// Execute the prepared INSERT.
+	// The statement was compiled BEFORE RELOAD with search_path = bucket_0,
+	// so it targets bucket_0.items regardless of sync_server_parameters being off now
+	_, err = conn.Exec(ctx, "INSERT INTO items (id, val) VALUES ($1, $2)", 1, "test")
+	require.NoError(t, err)
+
+	// Verify: row in bucket_0.items, public.items is empty.
+	var count int
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM bucket_0.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "row should be in bucket_0.items")
+
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM public.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "public.items should be empty")
+
+	// New connection after RELOAD: sync_server_parameters is off,
+	// search_path is NOT synced, so INSERT goes to default (public).
+	afterReloadConn, err := pgx.Connect(ctx, dsnWithSearchPath)
+	require.NoError(t, err)
+	defer afterReloadConn.Close(ctx)
+
+	_, err = afterReloadConn.Exec(ctx, "INSERT INTO items (id, val) VALUES ($1, $2)", 2, "test2")
+	require.NoError(t, err)
+
+	err = afterReloadConn.QueryRow(ctx, "SELECT count(*) FROM public.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "new row should be in public.items")
+
+	err = afterReloadConn.QueryRow(ctx, "SELECT count(*) FROM bucket_0.items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "bucket_0.items should still have 1 row")
+}

--- a/tests/go/sync-parameters/sync_parameters_test.go
+++ b/tests/go/sync-parameters/sync_parameters_test.go
@@ -2,6 +2,7 @@ package doorman
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,11 +10,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_SyncServerParameters(t *testing.T) {
-	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+func Test_SyncServerParametersWithSearchPath(t *testing.T) {
+	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL_WITH_SEARCH_PATH"))
 	assert.NoError(t, err)
 	defer db.Close()
 	var searchPath string
 	assert.NoError(t, db.QueryRow(`SHOW search_path`).Scan(&searchPath))
 	assert.Equal(t, "bucket_0", searchPath)
+}
+
+func Test_DifferentSearchPathsInSamePool(t *testing.T) {
+	baseDSN := os.Getenv("DATABASE_URL_BASE")
+
+	cases := []struct {
+		name       string
+		searchPath string
+	}{
+		{"bucket_0", "bucket_0"},
+		{"bucket_100555", "bucket_100555"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn := fmt.Sprintf("%s&search_path=%s", baseDSN, tc.searchPath)
+			db, err := sql.Open("postgres", dsn)
+			assert.NoError(t, err)
+			defer db.Close()
+
+			var got string
+			assert.NoError(t, db.QueryRow(`SHOW search_path`).Scan(&got))
+			assert.Equal(t, tc.searchPath, got)
+		})
+	}
 }

--- a/tests/go/sync-parameters/sync_parameters_test.go
+++ b/tests/go/sync-parameters/sync_parameters_test.go
@@ -1,0 +1,19 @@
+package doorman
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SyncServerParameters(t *testing.T) {
+	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+	assert.NoError(t, err)
+	defer db.Close()
+	var searchPath string
+	assert.NoError(t, db.QueryRow(`SHOW search_path`).Scan(&searchPath))
+	assert.Equal(t, "bucket_0", searchPath)
+}

--- a/tests/go/sync-parameters/sync_parameters_test.go
+++ b/tests/go/sync-parameters/sync_parameters_test.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_SyncServerParametersWithSearchPath(t *testing.T) {
@@ -42,4 +43,62 @@ func Test_DifferentSearchPathsInSamePool(t *testing.T) {
 			assert.Equal(t, tc.searchPath, got)
 		})
 	}
+}
+
+// Test_SyncServerParametersActivatedAfterReload verifies that enabling
+// general.sync_server_parameters via RELOAD activates parameter syncing.
+// Before RELOAD: search_path from DSN is ignored (INSERT goes to public).
+// After RELOAD:  search_path from DSN is synced (INSERT goes to bucket_0).
+func Test_SyncServerParametersActivatedAfterReload(t *testing.T) {
+	dsnWithSearchPath := os.Getenv("DATABASE_URL_WITH_SEARCH_PATH")
+	adminPort := os.Getenv("DOORMAN_PORT")
+
+	setupBucketTables(t, dsnWithSearchPath)
+
+	// ---- Phase 1: sync_server_parameters is OFF (not in config) ----
+	db, err := sql.Open("postgres", dsnWithSearchPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var searchPath string
+	require.NoError(t, db.QueryRow("SHOW search_path").Scan(&searchPath))
+	assert.Equal(t, `"$user", public`, searchPath, "sync_server_parameters is off, search_path stays default")
+
+	_, err = db.Exec("INSERT INTO items (id, val) VALUES ($1, $2)", 1, "before_reload")
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM public.items").Scan(&count))
+	assert.Equal(t, 1, count, "row should be in public.items (search_path not synced)")
+
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM bucket_0.items").Scan(&count))
+	assert.Equal(t, 0, count, "bucket_0.items should be empty")
+	db.Close()
+
+	// ---- Phase 2: RELOAD enables general.sync_server_parameters ----
+	adminAddr := fmt.Sprintf("127.0.0.1:%s", adminPort)
+	adminDB, err := sql.Open("postgres", fmt.Sprintf("postgresql://admin:admin@%s/pgbouncer?sslmode=disable", adminAddr))
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	_, err = adminDB.Exec("RELOAD")
+	require.NoError(t, err)
+	adminDB.Close()
+
+	// ---- Phase 3: new connection, search_path is now synced ----
+	db2, err := sql.Open("postgres", dsnWithSearchPath)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	require.NoError(t, db2.QueryRow("SHOW search_path").Scan(&searchPath))
+	assert.Equal(t, "bucket_0", searchPath, "sync_server_parameters is on, search_path is synced")
+
+	_, err = db2.Exec("INSERT INTO items (id, val) VALUES ($1, $2)", 2, "after_reload")
+	require.NoError(t, err)
+
+	require.NoError(t, db2.QueryRow("SELECT count(*) FROM bucket_0.items").Scan(&count))
+	assert.Equal(t, 1, count, "new row should be in bucket_0.items (search_path synced)")
+
+	require.NoError(t, db2.QueryRow("SELECT count(*) FROM public.items").Scan(&count))
+	assert.Equal(t, 1, count, "public.items should still have 1 row from phase 1")
 }


### PR DESCRIPTION
# Summary

Add pool-level sync_server_parameters override

# Problem
sync_server_parameters was a global-only setting in [general]. When enabled, client-sent session parameters (e.g. search_path, work_mem) are applied via SET queries on checkout. When disabled, they are silently ignored. 

# Solution
Added sync_server_parameters: Option<bool> to the [pools.<name>] config section. When set, it overrides the global [general] value for that specific pool. When omitted, falls back to the global setting — preserving backward compatibility.

# Backward compatibility
Fully compatible. Existing configs without sync_server_parameters on pool level continue to work exactly as before.

# Config example
```
[general]
sync_server_parameters = false  # global default

[pools.some_db]
sync_server_parameters = true   # override for this pool
```